### PR TITLE
apply default behavior fix to other types, not just string

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -16,11 +16,6 @@ ArrayType.prototype.__name = 'Array';
 
 ArrayType.prototype.convert = function(value) {
 
-    if (!BaseType.prototype.exists(value)) {
-
-        return value;
-    }
-
     if (typeof value === 'string') {
 
         // No need to try/catch, `Invalid JSON Body` exception already handled elsehwere
@@ -39,14 +34,11 @@ ArrayType.prototype.convert = function(value) {
             // console.log(e, value)
         }
     }
-    else if (value instanceof Array) {
-
-        return value;
-    }
     else {
 
         // Defensive programming
-        throw "Invalid data type passed to Types.Array (" + value + ", " + typeof value + " is not supported)";
+        // throw "Invalid data type passed to Types.Array (" + value + ", " + typeof value + " is not supported)";
+        return value;
     }
 }
 

--- a/lib/types/boolean.js
+++ b/lib/types/boolean.js
@@ -12,7 +12,7 @@ BooleanType.prototype.__name = "Boolean";
 
 BooleanType.prototype.convert = function(value) {
 
-    if (typeof value !== "undefined" && value !== null) {
+    if (typeof value == "string") {
 
         switch (value.toLowerCase()) {
 
@@ -28,7 +28,7 @@ BooleanType.prototype.convert = function(value) {
     }
     else {
 
-        return false;
+        return value;
     }
 }
 

--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -15,7 +15,14 @@ NumberType.prototype.__name = "Number";
 
 NumberType.prototype.convert = function(value) {
 
-    return Number(value);
+    if (typeof value == "string") {
+
+        return Number(value);
+    }
+    else {
+
+        return value;
+    }
 }
 
 NumberType.prototype._empty = function(){


### PR DESCRIPTION
fix eran's {     "error": "Bad request",     "message": "Invalid parameter: position = NaN",     "code": 400 }

hopefully...
