### PR TITLE
added xregex validator which must exactly match the input term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config.json
 coverage.*
 lib-cov
 complexity.md
+*.sublime-*

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ var Joi = require('joi');
 var schema = {
     username: Joi.types.String().alphanum().min(3).max(30).with('birthyear').required(),
     password: Joi.types.String().regex(/[a-zA-Z0-9]{3,30}/).without('access_token'),
+    twitter: Joi.type.String().xregex([a-zA-Z0-9_]{3,15})
     access_token: Joi.types.String(),
     birthyear: Joi.types.Number().min(1850).max(2012),
     email: Joi.types.String().email()
@@ -56,6 +57,9 @@ defines these constraints:
     * an optional string
     * must satisfy the custom regex
     * cannot appear together with 'access_token'
+* 'twitter'
+    * an optional string
+    * must exactly match the regex
 * 'access_token'
     * an optional, unconstrained string
 * 'birthyear'
@@ -69,7 +73,7 @@ The above constraints point out some non-obvious features:
 * relationships are defined in an additive fashion
     * "X.join(Y), Y.join(Z)" is the same as requiring all three to be present: "X AND Y AND Z"
     * Likewise "X.xor(Y), Y.xor(Z)" => requires that only one of three be present: "X XOR Y XOR Z"
-* .regex may or may not override other string-related constraints (.alphanum, .min, .max)
+* .regex/.xregex may or may not override other string-related constraints (.alphanum, .min, .max)
     ** constraints are evaluated in order
 * order of chained functions matter
     ** ".min(0).max(100).min(1)" sets the min to 1, overwriting the result of the first min call
@@ -256,6 +260,14 @@ If pattern is not specified, it returns an Error.
 
 If pattern is not a valid RegExp object, it returns an error.
 
+##### String.xregex(pattern)
+
+Specifies that this input exactly matches the given RegExp pattern.
+
+If pattern is not specified, it returns an Error.
+
+If pattern is not a valid RegExp object, it returns an error.
+
 ##### String.email()
 
 Specifies that this input is a valid email string.
@@ -401,6 +413,7 @@ Yet, in another case, a prior constraint may overrule a subsequent constraint:
 ```javascript
 Types.String().max(5).max(10) # This input cannot be larger than 5 characters
 Types.String().max(3).regex(/.{0,5}/) # This input cannot be larger than 3 characters
+Types.String().max(3).xregex(/[a-z]{0,5}/) # This input cannot be larger than 3 characters
 ```
 
 This should apply to all other constraints that do not override.

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -134,6 +134,29 @@ internals.StringType.prototype.regex = function (pattern) {
 };
 
 
+internals.StringType.prototype._xregex = function (n) {
+ 
+    Utils.assert(n instanceof RegExp, 'In Types.String.xregex(n), the n must be a RegExp');
+ 
+    return function (value, obj, key, errors, keyPath) {
+        var result = n.exec(value);
+ 
+        if (!result || result.index || result[0] !== result.input) {
+            errors.add('the value of ' + key + ' must exactly match the RegExp ' + n.toString(), keyPath);
+            return false;
+        }
+        return true;
+    };
+};
+
+
+internals.StringType.prototype.xregex = function (pattern) {
+ 
+    this.add('xregex', this._xregex(pattern), arguments);
+    return this;
+};
+
+
 internals.StringType.prototype._date = function () {
 
     return function (value, obj, key, errors, keyPath) {

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -222,6 +222,17 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should validate xregex', function (done) {
+
+            var t = S().xregex(/[a-z]{3,5}/);
+            verifyBehavior(t, [
+                ['van', true],
+                ['doors', true],
+                ['thedoors', false],
+                ['123ab', false],
+            ], done);
+        });
+
         it('should validate alphanum when alphanum allows spaces', function (done) {
 
             var t = S().alphanum(true);
@@ -437,9 +448,41 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of min, max, and xregex', function (done) {
+
+            var rule = S().min(2).max(3).xregex(/[a-z]+/);
+            verifyBehavior(rule, [
+                ['x', false],
+                ['123', false],
+                ['1234', false],
+                ['12', false],
+                ['ab', true],
+                ['abc', true],
+                ['abcd', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of min, max, regex, and emptyOk', function (done) {
 
             var rule = S().min(2).max(3).regex(/^a/).emptyOk();
+            verifyBehavior(rule, [
+                ['x', false],
+                ['123', false],
+                ['1234', false],
+                ['12', false],
+                ['ab', true],
+                ['abc', true],
+                ['abcd', false],
+                ['', true],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of min, max, xregex, and emptyOk', function (done) {
+
+            var rule = S().min(2).max(3).xregex(/[a-z]*/).emptyOk();
             verifyBehavior(rule, [
                 ['x', false],
                 ['123', false],
@@ -463,6 +506,23 @@ describe('Joi.types.String', function () {
                 ['12', false],
                 ['ab', true],
                 ['abc', true],
+                ['abcd', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of min, max, xregex, and required', function (done) {
+
+            var rule = S().min(2).max(3).xregex(/[a-c]*/).required();
+            verifyBehavior(rule, [
+                ['x', false],
+                ['123', false],
+                ['1234', false],
+                ['12', false],
+                ['ab', true],
+                ['abc', true],
+                ['abd', false],
                 ['abcd', false],
                 ['', false],
                 [null, false]
@@ -538,6 +598,25 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of min, max, alphanum, and xregex', function (done) {
+
+            var rule = S().min(2).max(3).alphanum().xregex(/[a-c0-9]*/);
+            verifyBehavior(rule, [
+                ['x', false],
+                ['123', true],
+                ['1234', false],
+                ['12', true],
+                ['ab', true],
+                ['abc', true],
+                ['a2c', true],
+                ['a2d', false],
+                ['abcd', false],
+                ['*ab', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of min, max, alphanum, required, and regex', function (done) {
 
             var rule = S().min(2).max(3).alphanum().required().regex(/^a/);
@@ -556,6 +635,25 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of min, max, alphanum, required, and xregex', function (done) {
+
+            var rule = S().min(2).max(3).alphanum().required().xregex(/[a-c0-9]*/);
+            verifyBehavior(rule, [
+                ['x', false],
+                ['123', true],
+                ['1234', false],
+                ['12', true],
+                ['ab', true],
+                ['abc', true],
+                ['a2c', true],
+                ['a2d', false],
+                ['abcd', false],
+                ['*ab', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of min, max, alphanum, emptyOk, and regex', function (done) {
 
             var rule = S().min(2).max(3).alphanum().emptyOk().regex(/^a/);
@@ -567,6 +665,26 @@ describe('Joi.types.String', function () {
                 ['ab', true],
                 ['abc', true],
                 ['a2c', true],
+                ['abcd', false],
+                ['*ab', false],
+                ['', true],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of min, max, alphanum, emptyOk, and xregex', function (done) {
+
+            var rule = S().min(2).max(3).alphanum().emptyOk().xregex(/[a-c0-9]*/);
+            verifyBehavior(rule, [
+                ['x', false],
+                ['2034', false], 
+                ['123', true],
+                ['1234', false],
+                ['12', true],
+                ['ab', true],
+                ['abc', true],
+                ['a2c', true],
+                ['a2d', false],
                 ['abcd', false],
                 ['*ab', false],
                 ['', true],
@@ -601,6 +719,20 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of date and xregex', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/);
+            verifyBehavior(rule, [
+                ['x', false],
+                ['2034', true], 
+                ['1990', false],
+                ['5-6-2034', true],
+                ['1-6-2034', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of date, regex, and min', function (done) {
 
             var rule = S().date().regex(/^1/).min(4);
@@ -614,6 +746,21 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of date, xregex, and min', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(4);
+            verifyBehavior(rule, [
+                ['x', false],
+                ['2034', true], 
+                ['1990', false],
+                ['5-6-2034', true],
+                ['1-6-2034', false],
+                ['1-2', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of date, regex, and max', function (done) {
 
             var rule = S().date().regex(/^1/).max(4);
@@ -621,6 +768,21 @@ describe('Joi.types.String', function () {
                 ['x', false],
                 ['1-2-1990', false],
                 ['1-2', true],
+                ['2-2-1990', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of date, xregex, and max', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).max(4);
+            verifyBehavior(rule, [
+                ['x', false],
+                ['2034', true], 
+                ['1990', false],
+                ['6-5-2034', false],
+                ['3-2', true],
                 ['2-2-1990', false],
                 ['', false],
                 [null, false]
@@ -640,6 +802,21 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of date, xregex, min, and max', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(3).max(4);
+            verifyBehavior(rule, [
+                ['x', false],
+                ['2034', true], 
+                ['1990', false],
+                ['6-5-2034', false],
+                ['3-2', true],
+                ['2-2-1990', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of date, regex, min, max, and allow', function (done) {
 
             var rule = S().date().regex(/^1/).min(3).max(4).allow('x');
@@ -647,6 +824,22 @@ describe('Joi.types.String', function () {
                 ['x', true],
                 ['1-2-1990', false],
                 ['1-2', true],
+                ['2-2-1990', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of date, xregex, min, max, and allow', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(3).max(4).allow('x');
+            verifyBehavior(rule, [
+                ['x', true],
+                ['2034', true], 
+                ['1990', false],
+                ['6-5-2034', false],
+                ['3-2', true],
+                ['1-2', false],
                 ['2-2-1990', false],
                 ['', false],
                 [null, false]
@@ -666,6 +859,23 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of date, xregex, min, max, allow, and deny', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(3).max(4).allow('x').deny('5-6');
+            verifyBehavior(rule, [
+                ['x', true],
+                ['2034', true], 
+                ['1990', false],
+                ['6-5-2034', false],
+                ['1-2', false],
+                ['5-6', false],
+                ['3-6', true],
+                ['2-2-1990', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of date, regex, min, max, allow, deny, and emptyOk', function (done) {
 
             var rule = S().date().regex(/^1/).min(3).max(4).allow('x').deny('1-2').emptyOk();
@@ -673,6 +883,23 @@ describe('Joi.types.String', function () {
                 ['x', true],
                 ['1-2-1990', false],
                 ['1-2', false],
+                ['2-2-1990', false],
+                ['', true],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of date, xregex, min, max, allow, deny, and emptyOk', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(3).max(4).allow('x').deny('5-6').emptyOk();
+            verifyBehavior(rule, [
+                ['x', true],
+                ['2034', true], 
+                ['1990', false], 
+                ['6-5-2034', false],
+                ['1-2', false],
+                ['5-6', false],
+                ['3-6', true],
                 ['2-2-1990', false],
                 ['', true],
                 [null, false]
@@ -692,6 +919,21 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of date, xregex, min, max, and emptyOk', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(3).max(4).emptyOk();
+            verifyBehavior(rule, [
+                ['2034', true],
+                ['1990', false], 
+                ['6-5-2034', false],
+                ['1-2', false],
+                ['3-6', true],
+                ['2-2-1990', false],
+                ['', true],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of date, regex, min, max, and nullOk', function (done) {
 
             var rule = S().date().regex(/^1/).min(3).max(4).nullOk();
@@ -699,6 +941,21 @@ describe('Joi.types.String', function () {
                 ['x', false],
                 ['1-2-1990', false],
                 ['1-2', true],
+                ['2-2-1990', false],
+                ['', false],
+                [null, true]
+            ], done);
+        });
+
+        it('should handle combination of date, xregex, min, max, and nullOk', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(3).max(4).nullOk();
+            verifyBehavior(rule, [
+                ['2034', true],
+                ['1990', false], 
+                ['6-5-2034', false],
+                ['1-2', false],
+                ['3-6', true],
                 ['2-2-1990', false],
                 ['', false],
                 [null, true]
@@ -718,6 +975,21 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of date, xregex, min, max, nullOk, emptyOk', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(3).max(4).nullOk().emptyOk();
+            verifyBehavior(rule, [
+                ['2034', true],
+                ['1990', false], 
+                ['6-5-2034', false],
+                ['1-2', false],
+                ['3-6', true],
+                ['2-2-1990', false],
+                ['', true],
+                [null, true]
+            ], done);
+        });
+
         it('should handle combination of date, regex, min, max, and required', function (done) {
 
             var rule = S().date().regex(/^1/).min(3).max(4).required();
@@ -725,6 +997,21 @@ describe('Joi.types.String', function () {
                 ['x', false],
                 ['1-2-1990', false],
                 ['1-2', true],
+                ['2-2-1990', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of date, xregex, min, max, and required', function (done) {
+
+            var rule = S().date().xregex(/[2-6-0]*/).min(3).max(4).required();
+            verifyBehavior(rule, [
+                ['2034', true],
+                ['1990', false],
+                ['6-5-2034', false],
+                ['1-2', false],
+                ['3-6', true],
                 ['2-2-1990', false],
                 ['', false],
                 [null, false]
@@ -833,12 +1120,44 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of email, min, max, allow, deny, and xregex', function (done) {
+
+            var rule = S().email().min(8).max(10).allow('x@x.com').deny('123@x.com').xregex(/[xc-o1-5\@\.]*/);
+            verifyBehavior(rule, [
+                ['x@x.com', true],
+                ['123@x.com', false],
+                ['cde@x.com', true],
+                ['abc@x.com', false],
+                ['126@x.com', false],
+                ['1234@x.com', true],
+                ['12345@x.com', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of email, min, max, allow, deny, regex, and emptyOk', function (done) {
 
             var rule = S().email().min(8).max(10).allow('x@x.com').deny('123@x.com').regex(/^1/).emptyOk();
             verifyBehavior(rule, [
                 ['x@x.com', true],
                 ['123@x.com', false],
+                ['1234@x.com', true],
+                ['12345@x.com', false],
+                ['', true],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of email, min, max, allow, deny, xregex, and emptyOk', function (done) {
+
+            var rule = S().email().min(8).max(10).allow('x@x.com').deny('123@x.com').xregex(/[xc-o1-5\@\.]*/).emptyOk();
+            verifyBehavior(rule, [
+                ['x@x.com', true],
+                ['123@x.com', false],
+                ['cde@x.com', true],
+                ['abc@x.com', false],
+                ['126@x.com', false],
                 ['1234@x.com', true],
                 ['12345@x.com', false],
                 ['', true],
@@ -872,12 +1191,44 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
+        it('should handle combination of email, min, max, and xregex', function (done) {
+
+            var rule = S().email().min(8).max(10).xregex(/[xc-o1-5\@\.]*/);
+            verifyBehavior(rule, [
+                ['x@x.com', false],
+                ['123@x.com', true],
+                ['cde@x.com', true],
+                ['abc@x.com', false],
+                ['126@x.com', false],
+                ['1234@x.com', true],
+                ['12345@x.com', false],
+                ['', false],
+                [null, false]
+            ], done);
+        });
+
         it('should handle combination of email, min, max, regex, and emptyOk', function (done) {
 
             var rule = S().email().min(8).max(10).regex(/^1234/).emptyOk();
             verifyBehavior(rule, [
                 ['x@x.com', false],
                 ['123@x.com', false],
+                ['1234@x.com', true],
+                ['12345@x.com', false],
+                ['', true],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of email, min, max, xregex, and emptyOk', function (done) {
+
+            var rule = S().email().min(8).max(10).xregex(/[xc-o1-5\@\.]*/).emptyOk();
+            verifyBehavior(rule, [
+                ['x@x.com', false],
+                ['123@x.com', true],
+                ['cde@x.com', true],
+                ['abc@x.com', false],
+                ['126@x.com', false],
                 ['1234@x.com', true],
                 ['12345@x.com', false],
                 ['', true],
@@ -895,6 +1246,23 @@ describe('Joi.types.String', function () {
                 ['12345@x.com', false],
                 ['', false],
                 [null, false]
+            ], done);
+        });
+
+        it('should handle combination of email, min, max, xregex, and required', function (done) {
+
+            var rule = S().email().min(8).max(10).xregex(/[xc-o1-5\@\.]*/).required();
+            verifyBehavior(rule, [
+                ['x@x.com', false],
+                ['123@x.com', true],
+                ['cde@x.com', true],
+                ['abc@x.com', false],
+                ['126@x.com', false],
+                ['1234@x.com', true],
+                ['12345@x.com', false],
+                ['', false],
+                [null, false]
+
             ], done);
         });
     });


### PR DESCRIPTION
...not like the existing regex-validator, which have only to match the input term

long story short, please take a look at the examples:
term = "abcdef1234"
r = /[a-z]{3,5}/

regex-validator will match
xregex-valdator won't match

to get this work with existing validator, I have to chain: regex(r).max(5), **but**

term = "abc12"
r = /[a-z]{3,5}/

regex-validator will match (regex(r).max(5))
xregex-valdator won't match

term = "twitter_name!/()"
r = /[a-zA-Z0-9_]{3,15}/

regex-validator will match
xregex-valdator won't match
## 

I didn't find the right (practicable) solution for this, so I added xregex-validator ;-)
