### PR TITLE
strings are joy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,20 +86,15 @@ exports.validate = function (object, config) {
         var T = Types[keyConfig.type];
         var converter = T && T().convert || null;
         if (!self.settings.skipConversions && typeof converter === 'function') {
-            try {
-                value = converter(value);
-                if (self.settings.saveConversions) {
-                    object[key] = value;
-                }
+            value = converter(value);
+            if (self.settings.saveConversions) {
+                object[key] = value;
+            }
 
-                return { value: value };
-            }
-            catch (err) {
-                return;
-            }
+            return { value: value };
         }
 
-        return { value: value };                                                            // If no convert function then just return the value
+        return { value: value };  // If no convert function then just return the value
     };
 
     processConfig();

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -41,7 +41,6 @@ internals.ArrayType.prototype.convert = function (value) {
             return value;
         }
 
-        // No need to try/catch, `Invalid JSON Body` exception already handled elsehwere
         try {
             var converted = JSON.parse(value);
             if (converted instanceof Array) {
@@ -53,8 +52,7 @@ internals.ArrayType.prototype.convert = function (value) {
         }
         catch (e) {
             //JSON.parse failed, means that given string is a string
-            //which cannot be converted into JSON format. Just return it as an array.
-            return [value];
+            return value;
         }
     }
     else {

--- a/lib/types/object.js
+++ b/lib/types/object.js
@@ -33,8 +33,12 @@ internals.ObjectType.prototype.__name = 'Object';
 
 
 internals.ObjectType.prototype.convert = function (value) {
-
-    return (typeof value === 'object' || typeof value === 'undefined') ? value : JSON.parse(value);
+    try {
+        return (typeof value === 'object' || typeof value === 'undefined') ? value : JSON.parse(value);
+    }
+    catch(err) {
+        return value;
+    }
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -334,6 +334,65 @@ describe('#validate', function () {
         done();
     });
 
+    it('should fail validation when parameter is required to be an object but is given as string', function (done) {
+
+        var obj = {
+            a: "a string"
+        };
+        var err = Joi.validate(obj, { a: Joi.types.Object({ b: Joi.types.String().required() }) });
+        expect(err).to.exist;
+        done();
+    });
+
+    it('should pass validation when parameter is required to be an object and is given correctly as a json string', function (done) {
+
+        var obj = {
+            a: '{"b":"string"}'
+        };
+        var err = Joi.validate(obj, { a: Joi.types.Object({ b: Joi.types.String().required() }) });
+        expect(err).to.be.null;
+        done();
+    });
+
+    it('should fail validation when parameter is required to be an object but is given as a json string that is incorrect (number instead of string)', function (done) {
+
+        var obj = {
+            a: '{"b":2}'
+        };
+        var err = Joi.validate(obj, { a: Joi.types.Object({ b: Joi.types.String().required() }) });
+        expect(err).to.exist;
+        done();
+    });
+
+    it('should fail validation when parameter is required to be an Array but is given as string', function (done) {
+
+        var obj = {
+            a: "an array"
+        };
+        var err = Joi.validate(obj, { a: Joi.types.Array() });
+        expect(err).to.exist;
+        done();
+    });
+
+    it('should pass validation when parameter is required to be an Array and is given correctly as a json string', function (done) {
+
+        var obj = {
+            a: '[1,2]'
+        };
+        var err = Joi.validate(obj, { a: Joi.types.Array() });
+        expect(err).to.be.null;
+        done();
+    });
+
+    it('should fail validation when parameter is required to be an Array but is given as a json that is incorrect (object instead of array)', function (done) {
+
+        var obj = {
+            a: '{"b":2}'
+        };
+        var err = Joi.validate(obj, { a: Joi.types.Object({ b: Joi.types.String().required() }) });
+        expect(err).to.exist;
+        done();
+    });
 
     it('should fail validation when config is an array and fails', function (done) {
 

--- a/test/types/array.js
+++ b/test/types/array.js
@@ -69,8 +69,7 @@ describe('Types', function () {
             it('should convert a non-array string', function(done) {
 
                 var result = A().convert('asdf');
-                expect(result.length).to.equal(1);
-                expect(result[0]).to.equal('asdf');
+                expect(result).to.equal('asdf');
                 done();
             });
         });

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -40,6 +40,13 @@ describe('Types', function () {
             done();
         });
 
+        it('should convert a non-json string as a string', function (done) {
+
+            var result = O().convert('a string');
+            expect(result).to.be.equal('a string');
+            done();
+        });
+
         it('should validate an object', function (done) {
 
             var t = O().required();


### PR DESCRIPTION
In joi strings are real joy - they could be just a string, or an object/array in disguise. 

I tried to fix a problem where you give a string instead of an object and you expect it to fail. What I saw in the code was an exception that was not handled correctly.

I believe the concept of converting a string/whatever to a type is similar to the '==' operator in javascript, it's a delicate matter, that might throw us to some pits, but it's kinda cool :) 

Think about an array; in the previous code a string will be converted to an array. why?
If we want to add that behaviour, we would want something like that:

```
'a' == ['a']; // true
'a' == 'a';  // also true
```

Then we should consider not using a type converter, but rather an ambiguous comparison 
That is why I added tests which seem redundant now, but if a different mechanism will be used for comparison between types, the tests will still be there, guarding.
