### PR TITLE
Consistent usage of Array.isArray()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ exports.validate = function (object, config) {
             return error.path !== key;
         };
 
-        if (keyConfig instanceof Array) {
+        if (Array.isArray(keyConfig)) {
             for (var i = 0, il = keyConfig.length; i < il; ++i) {
                 converted = convertType(keyConfig[i], key, value);
 

--- a/lib/set.js
+++ b/lib/set.js
@@ -17,7 +17,7 @@ module.exports = internals.Set = function (initialValue) {
     if (initialValue !== null &&
         typeof initialValue !== 'undefined') {
 
-        Utils.assert(initialValue instanceof Array, 'Improper initial value provided');
+        Utils.assert(Array.isArray(initialValue), 'Improper initial value provided');
 
         for (var i = initialValue.length - 1; i >= 0; i--) {
             this.add(initialValue[i]);

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -43,7 +43,7 @@ internals.ArrayType.prototype.convert = function (value) {
 
         try {
             var converted = JSON.parse(value);
-            if (converted instanceof Array) {
+            if (Array.isArray(converted)) {
                 return converted;
             }
             else {
@@ -67,7 +67,7 @@ internals.ArrayType.prototype._base = function () {
 
     return function (value, obj, key, errors, keyPath) {
 
-        var result = value instanceof Array;
+        var result = Array.isArray(value);
         if (!result) {
             errors.add('the value of ' + key + ' must be an Array', keyPath);
         }

--- a/lib/types/base.js
+++ b/lib/types/base.js
@@ -322,7 +322,7 @@ internals.BaseType.prototype.description = function (desc) {
 
 internals.BaseType.prototype.notes = function (notes) {
 
-    Utils.assert(typeof notes === 'string' || notes instanceof Array, 'Validator notes must be a string or array');
+    Utils.assert(typeof notes === 'string' || Array.isArray(notes), 'Validator notes must be a string or array');
     this.notes = notes || '';
     return this;
 };
@@ -330,7 +330,7 @@ internals.BaseType.prototype.notes = function (notes) {
 
 internals.BaseType.prototype.tags = function (tags) {
 
-    Utils.assert(tags instanceof Array, 'Validator tags must be an array');
+    Utils.assert(Array.isArray(tags), 'Validator tags must be an array');
     this.tags = tags || [];
     return this;
 };


### PR DESCRIPTION
Parts of the code base where still using instanceof Array and parts where using Array.isArray(). Switched all the found cases to Array.isArray() which is faster for v8 and instanceof Array only checks to left hand inheritance chain to see if the object was made with the Array constructor, this could cause failure in edge cases and when used with the vm module.
