### PR TITLE
Fixed error message returned for Number min/max 

### DIFF
--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -70,7 +70,7 @@ internals.NumberType.prototype._min = function (n) {
         var result = (isNaN(value) || value >= n);
         if (!result) {
             errors.addLocalized('number.min', key, {
-                value: value
+                value: n
             }, keyPath);
         }
 
@@ -95,7 +95,7 @@ internals.NumberType.prototype._max = function (n) {
         var result = (value <= n);
         if (!result) {
             errors.addLocalized('number.max', key, {
-                value: value
+                value: n
             }, keyPath);
         }
         return result;


### PR DESCRIPTION
This pull request fixes the upper/lower bound values in the error message during Number min/max validation. Issue #116 
