### PR TITLE
Allow extra keys and strip extra keys options

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,8 +461,9 @@ To force Joi to not throw errors when it encounters an unknown key, use the `all
 
     Joi.settings.allowExtraKeys = true;
 
-If you'd like Joi to remove the unknown keys from the object, use the `stripExtraKeys` option:
-
+If you'd like Joi to remove the unknown keys from the object, enable both the `stripExtraKeys` option and the `allowExtraKeys` option:
+    
+    Joi.settings.allowExtraKeys = true;
     Joi.settings.stripExtraKeys = true;
 
 ### Local

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ exports.validate = function (object, config) {
 
             var unprocessedValueType = typeof unprocessedObject[unprocessedKey];
             if ((!skipFunctions || unprocessedValueType !== 'function') && unprocessedValueType !== 'undefined') {
-                if (stripExtraKeys) {
+                if (stripExtraKeys && allowExtraKeys) {
                     delete object[unprocessedKey]
                 }
                 else if (!allowExtraKeys) {

--- a/test/index.js
+++ b/test/index.js
@@ -535,6 +535,7 @@ describe('#validate', function () {
     it('should pass validation with extra keys and remove them when stripExtraKeys is set', function (done) {
 
         Joi.settings.stripExtraKeys = true;
+        Joi.settings.allowExtraKeys = true;
 
         var obj = {
             a: 1,
@@ -547,6 +548,7 @@ describe('#validate', function () {
         expect(obj).to.deep.equal({a: 1, b: 'a'});
 
         Joi.settings.stripExtraKeys = false;
+        Joi.settings.allowExtraKeys = false;
 
         done();
     });
@@ -577,7 +579,8 @@ describe('#validate', function () {
         var localConfig = {
             a: Joi.types.Number().min(0).max(3),
             b: Joi.types.String().valid('a', 'b', 'c'),
-            stripExtraKeys: true
+            stripExtraKeys: true,
+            allowExtraKeys: true
         };
 
         var obj = {


### PR DESCRIPTION
Allowing extra keys prevents Joi from throwing errors when it encounters extra keys in the objects to validate. Stripping extra keys removes the unknown keys from the object to validate.
They can be set as a global and local option.
