### PR TITLE
Fixes #130: String().max() fails when key is optional

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -92,11 +92,10 @@ internals.StringType.prototype._max = function (n) {
 
     Utils.assert((!isNaN(n) && ((n | 0) == parseFloat(n))), 'In Types.String.max(n), the n must be an integer');
     Utils.assert(n >= 0, 'In Types.String.max(n), the n must be a non-negative integer');
-    this.__valids.remove(undefined);
 
     return function (value, obj, key, errors, keyPath) {
 
-        var result = value !== null && typeof value !== 'undefined' && (value.length <= n);
+        var result = value !== null && (value.length <= n);
         if (!result) {
             errors.addLocalized('string.max', key, {
                 value: n

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -148,14 +148,6 @@ describe('Joi.types.String', function () {
             ], done);
         });
 
-        it('should invalid undefined if max set', function (done) {
-
-            var t = S().max(3);
-            verifyBehavior(t, [
-                [undefined, false]
-            ], done);
-        });
-
         it('should invalidate invalid values', function (done) {
 
             var t = S().valid('a', 'b', 'c');
@@ -219,6 +211,14 @@ describe('Joi.types.String', function () {
                 ['test', false],
                 ['0', true],
                 [null, false]
+            ], done);
+        });
+
+        it('should return true with max and not required when value is undefined', function (done) {
+
+            var t = S().max(3);
+            verifyBehavior(t, [
+                [undefined, true]
             ], done);
         });
 
@@ -388,6 +388,17 @@ describe('Joi.types.String', function () {
                 ['1234', false],
                 ['', true],
                 [null, false]
+            ], done);
+        });
+
+        it('should handle combination of nullOk and max', function (done) {
+            var rule = S().nullOk().max(3);
+            verifyBehavior(rule, [
+                ['x', true],
+                ['123', true],
+                ['1234', false],
+                ['', false],
+                [null, true]
             ], done);
         });
 


### PR DESCRIPTION
- Fix #130
- Add test for combination of nullOk() and max()
