### PR TITLE
Restore local settings once validated

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ internals.joiConfig = {
 exports.validate = function (object, config) {
 
     var settings = Utils.clone(exports.settings);
+    var localSettings = {};
 
     if (!(config instanceof Types.Base)) {
         var names = Object.keys(config);
@@ -43,7 +44,7 @@ exports.validate = function (object, config) {
             var name = names[i];
 
             if (typeof config[name] === internals.joiConfig[name]) {
-                settings[name] = config[name];
+                localSettings[name] = settings[name] = config[name];
                 delete config[name];
             }
         }
@@ -130,6 +131,12 @@ exports.validate = function (object, config) {
     };
 
     processConfig();
+
+    var names = Object.keys(localSettings);
+    for (var i = 0, il = names.length; i < il; ++ i) {
+        var name = names[i];
+        config[name] = localSettings[name];
+    }
 
     return errors.toError();
 };

--- a/test/index.js
+++ b/test/index.js
@@ -583,6 +583,37 @@ describe('#validate', function () {
         done();
     });
 
+    it('should pass validation with extra keys set locally', function (done) {
+
+        expect(Joi.settings.stripExtraKeys).to.equal(false);
+
+        var localConfig = {
+            a: Joi.types.Number().min(0).max(3),
+            b: Joi.types.String().valid('a', 'b', 'c'),
+            allowExtraKeys: true
+        };
+
+        var obj = {
+            a: 1,
+            b: 'a',
+            d: 'c'
+        };
+        var err = Joi.validate(obj, localConfig);
+
+        expect(err).to.be.null;
+        expect(obj).to.deep.equal({a: 1, b: 'a', d: 'c'});
+        expect(Joi.settings.stripExtraKeys).to.equal(false);
+
+        err = Joi.validate(obj, localConfig);
+
+        expect(err).to.be.null;
+        expect(obj).to.deep.equal({a: 1, b: 'a', d: 'c'});
+        expect(Joi.settings.stripExtraKeys).to.equal(false);
+
+        done();
+    });
+
+
     it('should pass validation with extra keys and remove them when skipExtraKeys is set locally', function (done) {
 
         expect(Joi.settings.stripExtraKeys).to.equal(false);
@@ -600,6 +631,12 @@ describe('#validate', function () {
             d: 'c'
         };
         var err = Joi.validate(obj, localConfig);
+
+        expect(err).to.be.null;
+        expect(obj).to.deep.equal({a: 1, b: 'a'});
+        expect(Joi.settings.stripExtraKeys).to.equal(false);
+
+        err = Joi.validate(obj, localConfig);
 
         expect(err).to.be.null;
         expect(obj).to.deep.equal({a: 1, b: 'a'});


### PR DESCRIPTION
Hello,

Since validation removes local settings, Hapi couldn't validate objects using local settings more than one time.
The strategy here is to remember those settings and restore them at the end once the validation is done.

About the styling, I'm not sure whether you would rather put it in a function or hoist variables at the top, so feel free to comment if it needs modifications.

I duplicated a few lines in the tests to make sure there would be no regression, I don't know if it's worth their own tests.
