### PR TITLE
Made birthyear of example to be consistent with given schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The above schema defines the following constraints:
 * `access_token`
     * an optional, unconstrained string or number
 * `birthyear`
-    * an integer between 1850 and 2012
+    * an integer between 1900 and 2013
 * `email`
     * a valid email address string
 


### PR DESCRIPTION
Simple doc inconsistency found when reading through. Figured I'd send it back to lend a small hand.
