### PR TITLE
empty string is not a number

### DIFF
--- a/lib/number.js
+++ b/lib/number.js
@@ -28,8 +28,11 @@ Utils.inherits(internals.Number, Any);
 
 
 internals.Number.prototype._convert = function (value) {
+    if (typeof value === 'string') {
+        if (!value) {
+            return NaN;
+        }
 
-    if (typeof value === 'string' && value) {
         return Number(value);
     }
 

--- a/test/number.js
+++ b/test/number.js
@@ -65,7 +65,10 @@ describe('Joi.number', function () {
             var t = Joi.number();
             Validate(t, [
                 ['1', true],
-                ['100', true]
+                ['100', true],
+                ['1e3', true],
+                ['1 some text', false],
+                ['', false]
             ]);
             done();
         });
@@ -264,7 +267,7 @@ describe('Joi.number', function () {
         it('should display correctly for int type', function (done) {
 
             var t = Joi.number().integer();
-            var result = Joi.validate('', t);
+            var result = Joi.validate('1.1', t);
             expect(result.message).to.contain('integer');
             done();
         });


### PR DESCRIPTION
[I think] `""` shouldn't be allowed to be validated as a number.

there were 2 main things I had to overcome/understand
- In JavaScript, empty string is treated as false (`"" == false`), that's why an empty string wasn't treated at all by the code.
- I was thinking of using `parseFloat`, but I saw that `parseFloat("1 some text").is.equal(1)`. `Number` is much more safer in that sense, with one exception (that I'm aware of): `Number("").is.equal(0)`.
