### PR TITLE
Fixed example in docs for validating boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Supports the same methods of the [`any()`](#any) type.
 var boolean = Joi.boolean();
 boolean.allow(null);
 
-var err = any.validate(true);
+var err = boolean.validate(true);
 ```
 
 ### `date()`


### PR DESCRIPTION
Fixed example in docs for validating boolean.  Was using undefined variable 'any' instead of 'boolean'.

Signed-off-by: Justin Noel github@calendee.com
