### PR TITLE
Add possibility to translate empty value

### DIFF
--- a/languages/en-us.json
+++ b/languages/en-us.json
@@ -70,5 +70,8 @@
         "email": "The value of {{key}} must be a valid email",
         "isoDate": "the value of {{key}} must be a valid ISO 8601 date",
         "guid": "the value of {{key}} must be a valid GUID"
+    },
+    "valueType": {
+        "empty": "empty"
     }
 }

--- a/lib/any.js
+++ b/lib/any.js
@@ -383,6 +383,9 @@ internals.Any.prototype._validate = function (value, state, options) {
 
     var errors = [];
 
+    var resources = require(options.languagePath);
+    var empty = Utils.reach(resources, 'valueType.empty') || 'empty';
+
     var process = function () {
 
         // Check allowed and denied values using the original value
@@ -392,7 +395,7 @@ internals.Any.prototype._validate = function (value, state, options) {
         }
 
         if (self._invalids.has(value, self._flags.insensitive)) {
-            errors.push(internals.Any.error('any.invalid', { value: (value === '' ? 'empty' : self._invalids.key(value)) }, state));
+            errors.push(internals.Any.error('any.invalid', { value: (value === '' ? empty : self._invalids.key(value)) }, state));
             if (options.abortEarly) {
                 return errors;
             }
@@ -414,7 +417,7 @@ internals.Any.prototype._validate = function (value, state, options) {
                 }
 
                 if (self._invalids.has(value, self._flags.insensitive)) {
-                    errors.push(internals.Any.error('any.invalid', { value: (value === '' ? 'empty' : self._invalids.key(value)) }, state));
+                    errors.push(internals.Any.error('any.invalid', { value: (value === '' ? empty : self._invalids.key(value)) }, state));
                     if (options.abortEarly) {
                         return errors;
                     }


### PR DESCRIPTION
- Add "valueType" category with "empty" value in languages/en-us.json
- Edit _validate method in lib/any.js in order to replace hard coded 'empty' by the value in translation file
