### PR TITLE
Allows using any.rename() and any.default() together

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -298,7 +298,6 @@ internals.Any.prototype.rename = function (to, renameOptions) {
         multiple: false,
         override: false
     };
-    var flags = this._flags;
 
     renameOptions = Utils.merge(defaults, renameOptions);
 
@@ -321,7 +320,7 @@ internals.Any.prototype.rename = function (to, renameOptions) {
             return Errors.create('any.rename.override', { value: to }, state, options);
         }
 
-        state.parent[to] = state.parent[state.key] || flags.default;
+        state.parent[to] = state.parent[state.key];
         state.renamed[to] = true;
 
         if (renameOptions.move) {
@@ -463,6 +462,13 @@ internals.Any.prototype._validate = function (value, state, options) {
 
     var finish = function () {
 
+        if (!errors.length &&
+            state.parent &&
+            ((options.modify && state.parent.hasOwnProperty(state.key)) || (value === undefined && self._flags.default !== undefined))) {
+
+            state.parent[state.key] = (value !== undefined ? value : self._flags.default);
+        }
+
         // Apply mutators as long as there are no errors
 
         for (var m = 0, ml = self._mutators.length; m < ml && !errors.length; ++m) {
@@ -470,13 +476,6 @@ internals.Any.prototype._validate = function (value, state, options) {
             if (err) {
                 errors.push(err);
             }
-        }
-
-        if (!errors.length &&
-            state.parent &&
-            ((options.modify && state.parent.hasOwnProperty(state.key)) || (value === undefined && self._flags.default !== undefined))) {
-
-            state.parent[state.key] = (value !== undefined ? value : self._flags.default);
         }
 
         // Return null or errors

--- a/test/any.js
+++ b/test/any.js
@@ -283,6 +283,18 @@ describe('Joi', function () {
                 done();
             });
 
+            it('sets the value after key is renamed. Old key should not exist', function (done) {
+
+                var schema = { foo: Joi.string().rename('foo2', { move: true }).default('test') };
+                var input = {};
+
+                expect(Joi.validate(input, schema)).to.not.exist;
+                expect(input.foo2).to.equal('test');
+                expect(input.foo).to.not.exist;
+
+                done();
+            });
+
             it('should not overide a value when value is given', function (done) {
 
                 var schema = { foo: Joi.string().default('bar') };


### PR DESCRIPTION
Example:

With this Joi object: `{ foo: Joi.string().rename('foo2').default('test') }`
And the input value: `{}`

The validation should output:

```
{
  foo : 'test',
  foo2: 'test'
}
```

But was outputting:

```
{
  foo: 'test',
  foo2: undefined
}
```
