### PR TITLE
Find full path to nested errors

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -18,6 +18,23 @@ internals.Err = function (type, context, state, options) {
 };
 
 
+internals.findPath = function findPath (context) {
+    // if this context doesn't have a reason, then we won't find a valid path
+    if (!context || !context.reason || !Array.isArray(context.reason)){
+        return false;
+    }
+
+    // recurse through the reasons to try to find a path
+    if (context.reason && Array.isArray(context.reason) && context.reason[0].context && context.reason[0].context.reason) {
+        return findPath(context.reason[0].context);
+    }
+    else {
+        return context.reason[0].path;
+    }
+};
+
+
+
 internals.Err.prototype.toString = function () {
 
     var self = this;
@@ -52,7 +69,7 @@ exports.process = function (errors, object) {
     var details = [];
     for (var i = 0, il = errors.length; i < il; ++i) {
         var item = errors[i];
-        details.push({ message: item.toString(), path: item.path || item.context.key, type: item.type });
+        details.push({ message: item.toString(), path: internals.findPath(item.context) || item.path || item.context.key, type: item.type });
     }
 
     return new internals.ValidationError(details, object);

--- a/test/array.js
+++ b/test/array.js
@@ -264,6 +264,20 @@ describe('Types', function () {
                 ]);
                 done();
             });
+
+            it('should return a full path to an error value on an array', function (done) {
+                var err = Joi.validate([[{hi: 1}], [{hi: 1}, {hi: 'a'}]], Joi.array().includes(Joi.array().includes(Joi.object({hi: Joi.number()}))));
+                expect(err).to.exist;
+                expect(err.details[0].path).to.equal('1.1.hi');
+                done();
+            });
+
+            it('should return a full path to an error value on an object', function (done) {
+                var err = Joi.validate({hi: [{hi: 1}, {hi: 'a'}]}, Joi.object({hi: Joi.array().includes(Joi.object({hi: Joi.number()}))}));
+                expect(err).to.exist;
+                expect(err.details[0].path).to.equal('hi.1.hi');
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
I'm not at all sure if this is the cleanest implementation, but it does do the job. I'd happy take a cleaner implementation that doesn't require recursion.

Fixes #202
