### PR TITLE
`description` is defined on `any`

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ var schema = {
 };
 ```
 
-#### `description(desc)`
+#### `any.description(desc)`
 
 Annotates the key where:
 - `desc` - the description string.


### PR DESCRIPTION
Fixes small omission to make the heading for `description()` match the headers for the methods around it.
