### PR TITLE
Remove Makefile, add npm scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-test:
-	@node node_modules/lab/bin/lab
-test-cov:
-	@node node_modules/lab/bin/lab -t 100
-test-cov-html:
-	@node node_modules/lab/bin/lab -r html -o coverage.html
-
-.PHONY: test test-cov test-cov-html

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "lab": "3.x.x"
   },
   "scripts": {
-    "test": "make test-cov"
+    "test": "node node_modules/lab/bin/lab",
+    "test-cov": "node node_modules/lab/bin/lab -t 100",
+    "test-cov-html": "node node_modules/lab/bin/lab -r html -o coverage.html"
   },
   "licenses": [
     {


### PR DESCRIPTION
Couldn't find a reason/issue explaining why the Makefile stuff wasn't just in package.json.

Instead of `make test-cov` it would now be run with `npm run test-cov`.

Runs fine on my mac, but for some reason test-cov reports 0% on my windows 8 vm in git bash:

``` bash
$ npm run test-cov

> joi@3.0.0 test-cov c:\Users\lkptrzk\git\joi
> node node_modules/lab/bin/lab -t 100



  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ............................................

 294 tests complete (330 ms)

 No global variable leaks detected.

 Coverage: 0.00%

 Code coverage below threshold: 0.00 < 100


npm ERR! joi@3.0.0 test-cov: `node node_modules/lab/bin/lab -t 100`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the joi@3.0.0 test-cov script.
npm ERR! This is most likely a problem with the joi package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node node_modules/lab/bin/lab -t 100
npm ERR! You can get their info via:
npm ERR!     npm owner ls joi
npm ERR! There is likely additional logging output above.
npm ERR! System Windows_NT 6.2.9200
npm ERR! command "c:\\Program Files\\nodejs\\node.exe" "c:\\Program Files\\nodej
s\\node_modules\\npm\\bin\\npm-cli.js" "run" "test-cov"
npm ERR! cwd c:\Users\lkptrzk\git\joi
npm ERR! node -v v0.10.24
npm ERR! npm -v 1.3.21
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     c:\Users\lkptrzk\git\joi\npm-debug.log
npm ERR! not ok code 0
```

But at least `npm test` runs okay! `make` isn't in git bash on windows by default and installing anything in any pseudo bash environment in windows is hell.

Figured I'd submit a PR even if it's not wanted so the reason's documented somewhere.
