### PR TITLE
match() -> test()

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -96,7 +96,7 @@ internals.String.prototype.regex = function (pattern) {
 
     return this._test('regex', pattern, function (value, state, options) {
 
-        if (value.match(pattern)) {
+        if (pattern.test(value)) {
             return null;
         }
 
@@ -109,7 +109,7 @@ internals.String.prototype.alphanum = function () {
 
     return this._test('alphanum', undefined, function (value, state, options) {
 
-        if (value.match(/^[a-zA-Z0-9]+$/)) {
+        if (/^[a-zA-Z0-9]+$/.test(value)) {
             return null;
         }
 
@@ -122,7 +122,7 @@ internals.String.prototype.token = function () {
 
     return this._test('token', undefined, function (value, state, options) {
 
-        if (value.match(/^\w+$/)) {
+        if (/^\w+$/.test(value)) {
             return null;
         }
 
@@ -137,7 +137,7 @@ internals.String.prototype.email = function () {
 
     return this._test('email', undefined, function (value, state, options) {
 
-        if (value.match(regex)) {
+        if (regex.test(value)) {
             return null;
         }
 
@@ -152,7 +152,7 @@ internals.String.prototype.isoDate = function () {
 
     return this._test('isoDate', undefined, function (value, state, options) {
 
-        if (value.match(regex)) {
+        if (regex.test(value)) {
             return null;
         }
 
@@ -168,7 +168,7 @@ internals.String.prototype.guid = function () {
 
     return this._test('guid', undefined, function (value, state, options) {
 
-        if (value.match(regex) || value.match(regex2)) {
+        if (regex.test(value) || regex2.test(value)) {
             return null;
         }
 


### PR DESCRIPTION
Replace `match()` with `test()` as result is used as a Boolean.  Closes #236
