### PR TITLE
Bug Hunt: double-quoted local-parts of email addresses cause validation failure

### DIFF
--- a/test/string.js
+++ b/test/string.js
@@ -434,6 +434,7 @@ describe('string', function () {
             var schema = Joi.string().email();
             Validate(schema, [
                 ['van@walmartlabs.com', true],
+                ['"van"@walmartlabs.com', true],
                 ['@iaminvalid.com', false]
             ]);
             done();


### PR DESCRIPTION
According to [RFC2822 Section 3.4.1](http://tools.ietf.org/html/rfc2822#section-3.4.1), email addresses can use double-quoted local-parts. Joi erronously calls this an error case.

This, of course, depends on your definition of a valid email address. If you want to be strictly RFC-compliant, then this is an error. If you want to be more realistic, I don't think this is a huge deal. In fact, [RFC 5321](http://tools.ietf.org/html/rfc5321) says that "all quoted forms MUST be treated as equivalent, and the sending system SHOULD transmit the form that uses the minimum quoting possible.". So, while technically valid, hosts are discouraged from using it. It's up to you whether or not this qualifies for the [Bug Hunt](https://github.com/spumko/joi/issues/281).

It also fails on `üñîçøðé@üñîçøðé.com`, if that's a more acceptable failure case.

Test output using `joi@4.0.0`:

``` bash
$ npm test

> joi@4.0.0 test /home/sean/demo/joi
> make test-cov



  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  ..................................................
  .........................{ [Error: value must be a valid email]
  details: 
   [ { message: 'value must be a valid email',
       path: 'value',
       type: 'string.email' } ],
  _object: '"van"@walmartlabs.com',
  annotate: [Function] }
x........................
  ............................................

 1 of 394 tests failed:

  326) string #validate should validate email:

      actual expected

      truefalse

      at /home/sean/demo/joi/test/helper.js:35:37


 No global variable leaks detected.

 Coverage: 100.00%
make: *** [test-cov] Error 1
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
