### PR TITLE
update docs to use methods instead of objects for Joi.#{type}

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ Current version: **4.0.x**
 ```javascript
 var Joi = require('joi');
 
-var schema = Joi.object.keys({
-    username: Joi.string.alphanum().min(3).max(30).required(),
-    password: Joi.string.regex(/[a-zA-Z0-9]{3,30}/),
-    access_token: [Joi.string, Joi.number],
-    birthyear: Joi.number.integer().min(1900).max(2013),
-    email: Joi.string.email()
+var schema = Joi.object().keys({
+    username: Joi.string().alphanum().min(3).max(30).required(),
+    password: Joi.string().regex(/[a-zA-Z0-9]{3,30}/),
+    access_token: [Joi.string(), Joi.number()],
+    birthyear: Joi.number().integer().min(1900).max(2013),
+    email: Joi.string().email()
 }).with('username', 'birthyear').without('password', 'access_token');
 
 Joi.validate({ username: 'abc', birthyear: 1994 }, schema, function (err) { });  // err === null -> valid
@@ -120,7 +120,7 @@ Usage is a two steps process. First, a schema is constructed using the provided 
 
 ```javascript
 var schema = {
-    a: Joi.string
+    a: Joi.string()
 };
 ```
 
@@ -138,15 +138,15 @@ If the value is valid, `null` is returned, otherwise an `Error` object.
 The schema can be a plain JavaScript object where every key is assigned a **joi** type, or it can be a **joi** type directly:
 
 ```javascript
-var schema = Joi.string.min(10);
+var schema = Joi.string().min(10);
 ```
 
 If the schema is a **joi** type, the `schema.validate(value, callback)` can be called directly on the type. When passing a non-type schema object,
 the module converts it internally to an object() type equivalent to:
 
 ```javascript
-var schema = Joi.object.keys({
-    a: Joi.string
+var schema = Joi.object().keys({
+    a: Joi.string()
 });
 ```
 
@@ -174,7 +174,7 @@ Validates a value using the given schema and options where:
 
 ```javascript
 var schema = {
-    a: Joi.number
+    a: Joi.number()
 };
 
 var value = {
@@ -197,14 +197,14 @@ var schema = Joi.compile(definition);
 
 // Same as:
 
-var schema = Joi.alternatives.try([
-    Joi.string.valid('key'),
-    Joi.number.valid(5),
-    Joi.object.keys({
-        a: Joi.boolean.valid(true),
-        b: Joi.alternatives.try([
-            Joi.string.regex(/^a/),
-            Joi.string.valid('boom')
+var schema = Joi.alternatives().try([
+    Joi.string().valid('key'),
+    Joi.number().valid(5),
+    Joi.object().keys({
+        a: Joi.boolean().valid(true),
+        b: Joi.alternatives().try([
+            Joi.string().regex(/^a/),
+            Joi.string().valid('boom')
         ])
     })
 ]);
@@ -215,7 +215,7 @@ var schema = Joi.alternatives.try([
 Generates a schema object that matches any data type.
 
 ```javascript
-var any = Joi.any;
+var any = Joi.any();
 any.valid('a');
 
 any.validate('a', function (err) { });
@@ -229,9 +229,9 @@ Whitelists a value where:
 
 ```javascript
 var schema = {
-    a: Joi.any.allow('a'),
-    b: Joi.any.allow('b', 'B'),
-    c: Joi.any.allow(['c', 'C'])
+    a: Joi.any().allow('a'),
+    b: Joi.any().allow('b', 'B'),
+    c: Joi.any().allow(['c', 'C'])
 };
 ```
 
@@ -243,9 +243,9 @@ Adds the provided values into the allowed whitelist and marks them as the only v
 
 ```javascript
 var schema = {
-    a: Joi.any.valid('a'),
-    b: Joi.any.valid('b', 'B'),
-    c: Joi.any.valid(['c', 'C'])
+    a: Joi.any().valid('a'),
+    b: Joi.any().valid('b', 'B'),
+    c: Joi.any().valid(['c', 'C'])
 };
 ```
 
@@ -257,9 +257,9 @@ Blacklists a value where:
 
 ```javascript
 var schema = {
-    a: Joi.any.invalid('a'),
-    b: Joi.any.invalid('b', 'B'),
-    c: Joi.any.invalid(['c', 'C'])
+    a: Joi.any().invalid('a'),
+    b: Joi.any().invalid('b', 'B'),
+    c: Joi.any().invalid(['c', 'C'])
 };
 ```
 
@@ -269,7 +269,7 @@ Marks a key as required which will not allow `undefined` as value. All keys are 
 
 ```javascript
 var schema = {
-    a: Joi.any.required()
+    a: Joi.any().required()
 };
 ```
 
@@ -279,7 +279,7 @@ Marks a key as optional which will allow `undefined` as values. Used to annotate
 
 ```javascript
 var schema = {
-    a: Joi.any.optional()
+    a: Joi.any().optional()
 };
 ```
 
@@ -289,7 +289,7 @@ Annotates the key where:
 - `desc` - the description string.
 
 ```javascript
-var schema = Joi.any.description('this key will match anything you give it');
+var schema = Joi.any().description('this key will match anything you give it');
 ```
 
 #### `any.notes(notes)`
@@ -298,7 +298,7 @@ Annotates the key where:
 - `notes` - the notes string or array of strings.
 
 ```javascript
-var schema = Joi.any.notes(['this is special', 'this is important']);
+var schema = Joi.any().notes(['this is special', 'this is important']);
 ```
 
 #### `any.tags(tags)`
@@ -307,7 +307,7 @@ Annotates the key where:
 - `tags` - the tag string or array of strings.
 
 ```javascript
-var schema = Joi.any.tags(['api', 'user']);
+var schema = Joi.any().tags(['api', 'user']);
 ```
 
 #### `any.example(value)`
@@ -318,7 +318,7 @@ Annotates the key where:
 If the example fails to pass validation, the function will throw.
 
 ```javascript
-var schema = Joi.string.min(4).example('abcd');
+var schema = Joi.string().min(4).example('abcd');
 ```
 
 #### `any.unit(name)`
@@ -327,7 +327,7 @@ Annotates the key where:
 - `name` - the unit name of the value.
 
 ```javascript
-var schema = Joi.number.unit('milliseconds');
+var schema = Joi.number().unit('milliseconds');
 ```
 
 #### `any.options(options)`
@@ -337,7 +337,7 @@ Overrides the global `validate()` options for the current key and any sub-key wh
 
 ```javascript
 var schema = {
-    a: Joi.any.options({ convert: false })
+    a: Joi.any().options({ convert: false })
 };
 ```
 
@@ -347,7 +347,7 @@ Sets the `options.convert` options to `false` which prevent type casting for the
 
 ```javascript
 var schema = {
-    a: Joi.any.strict()
+    a: Joi.any().strict()
 };
 ```
 
@@ -358,7 +358,7 @@ Sets a default value if the original value is undefined where:
 
 ```javascript
 var schema = {
-    username: Joi.string.default('new_user')
+    username: Joi.string().default('new_user')
 };
 var input = {};
 Joi.validate(input, schema, function (err) { });
@@ -371,8 +371,8 @@ Returns a new type that is the result of adding the rules of one type to another
 - `schema` - a **joi** type to merge into the current schema. Can only be of the same type as the context type or `any`.
 
 ```javascript
-var a = Joi.string.valid('a');
-var b = Joi.string.valid('b');
+var a = Joi.string().valid('a');
+var b = Joi.string().valid('b');
 var ab = a.concat(b);
 ```
 
@@ -400,7 +400,7 @@ Supports the same methods of the [`any()`](#any) type.
 
 ```javascript
 var array = Joi.array;
-array.includes(Joi.string.valid('a', 'b'));
+array.includes(Joi.string().valid('a', 'b'));
 
 array.validate(['a', 'b', 'a'], function (err) { });
 ```
@@ -412,7 +412,7 @@ List the types allowed for the array values where:
 
 ```javascript
 var schema = {
-    a: Joi.array.includes(Joi.string, Joi.number)
+    a: Joi.array().includes(Joi.string, Joi.number)
 };
 ```
 
@@ -423,7 +423,7 @@ List the types forbidden for the array values where:
 
 ```javascript
 var schema = {
-    a: Joi.array.excludes(Joi.object)
+    a: Joi.array().excludes(Joi.object)
 };
 ```
 
@@ -434,7 +434,7 @@ Specifies the minimum number of items in the array where:
 
 ```javascript
 var schema = {
-    a: Joi.array.min(2)
+    a: Joi.array().min(2)
 };
 ```
 
@@ -445,7 +445,7 @@ Specifies the maximum number of items in the array where:
 
 ```javascript
 var schema = {
-    a: Joi.array.max(10)
+    a: Joi.array().max(10)
 };
 ```
 
@@ -456,7 +456,7 @@ Specifies the exact number of items in the array where:
 
 ```javascript
 var schema = {
-    a: Joi.array.length(5)
+    a: Joi.array().length(5)
 };
 ```
 
@@ -467,7 +467,7 @@ Generates a schema object that matches a boolean data type (as well as the strin
 Supports the same methods of the [`any()`](#any) type.
 
 ```javascript
-var boolean = Joi.boolean;
+var boolean = Joi.boolean();
 boolean.allow(null);
 
 boolean.validate(true, function (err) { });
@@ -481,7 +481,7 @@ Supports the same methods of the [`any()`](#any) type.
 
 ```javascript
 var schema = {
-    a: Joi.binary
+    a: Joi.binary()
 };
 ```
 
@@ -491,7 +491,7 @@ Sets the string encoding format if a string input is converted to a buffer where
 - `encoding` - the encoding scheme.
 
 ```javascript
-var schema = Joi.binary.encoding('base64');
+var schema = Joi.binary().encoding('base64');
 ```
 
 #### `binary.min(limit)`
@@ -501,7 +501,7 @@ Specifies the minimum length of the buffer where:
 
 ```javascript
 var schema = {
-    a: Joi.binary.min(2)
+    a: Joi.binary().min(2)
 };
 ```
 
@@ -512,7 +512,7 @@ Specifies the maximum length of the buffer where:
 
 ```javascript
 var schema = {
-    a: Joi.binary.max(10)
+    a: Joi.binary().max(10)
 };
 ```
 
@@ -523,7 +523,7 @@ Specifies the exact length of the buffer:
 
 ```javascript
 var schema = {
-    a: Joi.binary.length(5)
+    a: Joi.binary().length(5)
 };
 ```
 
@@ -534,7 +534,7 @@ Generates a schema object that matches a date type (as well as a JavaScript date
 Supports the same methods of the [`any()`](#any) type.
 
 ```javascript
-var date = Joi.date;
+var date = Joi.date();
 date.min('12-20-2012');
 
 date.validate('12-21-2012', function (err) { });
@@ -547,7 +547,7 @@ Specifies the oldest date allowed where:
 
 ```javascript
 var schema = {
-    a: Joi.date.min('1-1-1974')
+    a: Joi.date().min('1-1-1974')
 };
 ```
 
@@ -558,7 +558,7 @@ Specifies the latest date allowed where:
 
 ```javascript
 var schema = {
-    a: Joi.date.max('12-31-2020')
+    a: Joi.date().max('12-31-2020')
 };
 ```
 
@@ -569,7 +569,7 @@ Generates a schema object that matches a function type.
 Supports the same methods of the [`any()`](#any) type.
 
 ```javascript
-var func = Joi.func;
+var func = Joi.func();
 func.allow(null);
 
 func.validate(function () {}, function (err) { });
@@ -582,7 +582,7 @@ Generates a schema object that matches a number data type (as well as strings th
 Supports the same methods of the [`any()`](#any) type.
 
 ```javascript
-var number = Joi.number;
+var number = Joi.number();
 number.min(1).max(10).integer();
 
 number.validate(5, function (err) { });
@@ -595,7 +595,7 @@ Specifies the minimum value where:
 
 ```javascript
 var schema = {
-    a: Joi.number.min(2)
+    a: Joi.number().min(2)
 };
 ```
 
@@ -606,7 +606,7 @@ Specifies the maximum value where:
 
 ```javascript
 var schema = {
-    a: Joi.number.max(10)
+    a: Joi.number().max(10)
 };
 ```
 
@@ -616,7 +616,7 @@ Requires the number to be an integer (no floating point).
 
 ```javascript
 var schema = {
-    a: Joi.number.integer()
+    a: Joi.number().integer()
 };
 ```
 
@@ -628,8 +628,8 @@ to allowing any child key.
 Supports the same methods of the [`any()`](#any) type.
 
 ```javascript
-var object = Joi.object.keys({
-    a: Joi.number.min(1).max(10).integer(),
+var object = Joi.object().keys({
+    a: Joi.number().min(1).max(10).integer(),
     b: 'some string'
 });
 
@@ -645,9 +645,9 @@ Sets the allowed object keys where:
   allows any child key.
 
 ```javascript
-var object = Joi.object.keys({
-    a: Joi.number
-    b: Joi.string
+var object = Joi.object().keys({
+    a: Joi.number()
+    b: Joi.string()
 });
 ```
 
@@ -658,7 +658,7 @@ Specifies the minimum number of keys in the object where:
 
 ```javascript
 var schema = {
-    a: Joi.object.min(2)
+    a: Joi.object().min(2)
 };
 ```
 
@@ -669,7 +669,7 @@ Specifies the maximum number of keys in the object where:
 
 ```javascript
 var schema = {
-    a: Joi.object.max(10)
+    a: Joi.object().max(10)
 };
 ```
 
@@ -680,7 +680,7 @@ Specifies the exact number of keys in the object where:
 
 ```javascript
 var schema = {
-    a: Joi.object.length(5)
+    a: Joi.object().length(5)
 };
 ```
 
@@ -692,9 +692,9 @@ well where:
   array of string values, or each peer provided as an argument.
 
 ```javascript
-var schema = Joi.object.keys({
-    a: Joi.any,
-    b: Joi.any
+var schema = Joi.object().keys({
+    a: Joi.any(),
+    b: Joi.any()
 }).or('a', 'b');
 ```
 
@@ -705,9 +705,9 @@ Defines a relationship between keys where one of the peers is required (and more
   array of string values, or each peer provided as an argument.
 
 ```javascript
-var schema = Joi.object.keys({
-    a: Joi.any,
-    b: Joi.any
+var schema = Joi.object().keys({
+    a: Joi.any(),
+    b: Joi.any()
 }).or('a', 'b');
 ```
 
@@ -718,9 +718,9 @@ Defines an exclusive relationship between a set of keys where one of them is req
   array of string values, or each peer provided as an argument.
 
 ```javascript
-var schema = Joi.object.keys({
-    a: Joi.any,
-    b: Joi.any
+var schema = Joi.object().keys({
+    a: Joi.any(),
+    b: Joi.any()
 }).xor('a', 'b');
 ```
 
@@ -734,9 +734,9 @@ Note that unlike [`object.and()`](#objectandpeers), `with()` creates a dependenc
 between the `peers` themselves.
 
 ```javascript
-var schema = Joi.object.keys({
-    a: Joi.any,
-    b: Joi.any
+var schema = Joi.object().keys({
+    a: Joi.any(),
+    b: Joi.any()
 }).with('a', 'b');
 ```
 
@@ -747,9 +747,9 @@ Forbids the presence of other keys whenever the specified is present where:
 - `peers` - the forbidden peer key names that must not appear together with `key`. `peers` can be a single string value or an array of string values.
 
 ```javascript
-var schema = Joi.object.keys({
-    a: Joi.any,
-    b: Joi.any
+var schema = Joi.object().keys({
+    a: Joi.any(),
+    b: Joi.any()
 }).without('a', ['b']);
 ```
 
@@ -766,8 +766,8 @@ Renames a key to another name (deletes the renamed key) where:
 Keys are renamed before any other validation rules are applied.
 
 ```javascript
-var object = Joi.object.keys({
-    a: Joi.number
+var object = Joi.object().keys({
+    a: Joi.number()
 }).rename('b', 'a');
 
 object.validate({ b: 5 }, function (err) { });
@@ -782,10 +782,10 @@ Verifies an assertion where:
 - `message` - human-readable message used when the assertion fails.
 
 ```javascript
-var schema = Joi.object.keys({
+var schema = Joi.object().keys({
     a: {
-        b: Joi.string,
-        c: Joi.number
+        b: Joi.string(),
+        c: Joi.number()
     },
     d: {
         e: Joi.any
@@ -800,7 +800,7 @@ Generates a schema object that matches a string data type. Note that empty strin
 Supports the same methods of the [`any()`](#any) type.
 
 ```javascript
-Joi.string.min(1).max(10);
+Joi.string().min(1).max(10);
 
 string.validate('12345', function (err) { });
 ```
@@ -810,7 +810,7 @@ string.validate('12345', function (err) { });
 Allows the value to match any whitelist of blacklist item in a case insensitive comparison.
 
 ```javascript
-var schema = Joi.string.valid('a').insensitive();
+var schema = Joi.string().valid('a').insensitive();
 ```
 
 #### `string.min(limit, [encoding])`
@@ -820,7 +820,7 @@ Specifies the minimum number string characters where:
 - `encoding` - is specified, the string length is calculated in bytes using the provided encoding.
 
 ```javascript
-var schema = Joi.string.min(2);
+var schema = Joi.string().min(2);
 ```
 
 #### `string.max(limit, [encoding])`
@@ -830,7 +830,7 @@ Specifies the maximum number of string characters where:
 - `encoding` - is specified, the string length is calculated in bytes using the provided encoding.
 
 ```javascript
-var schema = Joi.string.max(10);
+var schema = Joi.string().max(10);
 ```
 
 #### `string.length(limit, [encoding])`
@@ -840,7 +840,7 @@ Specifies the exact string length required where:
 - `encoding` - is specified, the string length is calculated in bytes using the provided encoding.
 
 ```javascript
-var schema = Joi.string.length(5);
+var schema = Joi.string().length(5);
 ```
 
 #### `string.regex(pattern)`
@@ -849,7 +849,7 @@ Defines a regular expression rule where:
 - `pattern` - a regular expression object the string value must match against.
 
 ```javascript
-var schema = Joi.string.regex(/^[abc]+$/);
+var schema = Joi.string().regex(/^[abc]+$/);
 ```
 
 #### `string.alphanum()`
@@ -857,7 +857,7 @@ var schema = Joi.string.regex(/^[abc]+$/);
 Requires the string value to only contain a-z, A-Z, and 0-9.
 
 ```javascript
-var schema = Joi.string.alphanum();
+var schema = Joi.string().alphanum();
 ```
 
 #### `string.token()`
@@ -865,7 +865,7 @@ var schema = Joi.string.alphanum();
 Requires the string value to only contain a-z, A-Z, 0-9, and underscore _.
 
 ```javascript
-var schema = Joi.string.token();
+var schema = Joi.string().token();
 ```
 
 #### `string.email()`
@@ -873,7 +873,7 @@ var schema = Joi.string.token();
 Requires the string value to be a valid email address.
 
 ```javascript
-var schema = Joi.string.email();
+var schema = Joi.string().email();
 ```
 
 #### `string.guid()`
@@ -881,7 +881,7 @@ var schema = Joi.string.email();
 Requires the string value to be a valid GUID.
 
 ```javascript
-var schema = Joi.string.guid();
+var schema = Joi.string().guid();
 ```
 
 #### `string.isoDate()`
@@ -889,7 +889,7 @@ var schema = Joi.string.guid();
 Requires the string value to be in valid ISO 8601 date format.
 
 ```javascript
-var schema = Joi.string.isoDate();
+var schema = Joi.string().isoDate();
 ```
 
 #### `string.hostname()`
@@ -911,7 +911,7 @@ Alternatives can be expressed using the shorter `[]` notation.
 
 ```javascript
 var alt = Joi.alternatives.try(Joi.number, Joi.string);
-// Same as [Joi.number, Joi.string]
+// Same as [Joi.number(), Joi.string()]
 ```
 
 #### `alternatives.try(schemas)
@@ -920,7 +920,7 @@ Adds an alternative schema type for attempting to match against the validated va
 - `schema` - an array of alternative **joi** types. Also supports providing each type as a separate argument.
 
 ```javascript
-var alt = Joi.alternatives.try(Joi.number, Joi.string);
+var alt = Joi.alternatives.try(Joi.number(), Joi.string());
 alt.validate('a', function (err) { });
 ```
 
@@ -954,10 +954,10 @@ Note that references can only be used where explicitly supported such as in `val
 (parents) references are needed, use [`object.assert()`](#objectassertref-schema-message).
 
 ```javascript
-var schema = Joi.object.keys({
+var schema = Joi.object().keys({
     a: Joi.ref('b.c'),
     b: {
-        c: Joi.any
+        c: Joi.any()
     }
 });
 


### PR DESCRIPTION
It looks like the README wasn't updated to use `Joi.string()` instead of `Joi.string` (etc.). I updated all of the references I saw.

This caused me some confusion when trying to use the first example.
