### PR TITLE
Bug Hunt: object.and is supposed to be all-or-nothing

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -352,6 +352,7 @@ describe('Joi', function () {
             expect(err.message).to.equal('value contains txt without its required peers upc, code');
 
             Validate(schema, [
+                [{}, true],
                 [{ upc: null }, false],
                 [{ upc: 'test' }, false],
                 [{ txt: null }, false],


### PR DESCRIPTION
If all of the keys are missing, the `and` rule should pass.  This avoids having to do `.with('a', 'b').with('b', 'a')`.
