### PR TITLE
Bug Hunt: valid IPv6 domain literals in email addresses fail validation

### DIFF
--- a/test/string.js
+++ b/test/string.js
@@ -434,6 +434,7 @@ describe('string', function () {
             var schema = Joi.string().email();
             Validate(schema, [
                 ['van@walmartlabs.com', true],
+                ['van@[IPv6:2a00:1450:4001:c02::1b]', true],
                 ['@iaminvalid.com', false]
             ]);
             done();


### PR DESCRIPTION
Validating e-mail addresses is a compromise between all the various RFCs and real world, so I do not mind if you disregard this as not a bug.

[RFC5321](http://tools.ietf.org/html/rfc5321#section-4.1.3) defines domain literals that can be used instead of hostnames in the e-mail address. While you seem to pass IPv4 addresses in the form of `user@[127.0.0.1]`, joi does not recognize IPv6 format which is a bit different, namely `user@[IPv6:zzz]` where `zzz` is a valid IPv6 address, using either full or compact syntax.

Output for validating such address:

```
{ [Error: value must be a valid email]
  details: 
   [ { message: 'value must be a valid email',
       path: 'value',
       type: 'string.email' } ],
  _object: 'van@[IPv6:2a00:1450:4001:c02::1b]',
  annotate: [Function] }
```
