### PR TITLE
fix expect throw syntax in tests.  change arguments to objects.

### DIFF
--- a/test/string.js
+++ b/test/string.js
@@ -38,8 +38,8 @@ describe('string', function () {
 
             expect(function () {
 
-                Joi.string().valid(1);
-            }).to.throw;
+                Joi.string().valid({});
+            }).to.throw();
             done();
         });
 
@@ -48,7 +48,7 @@ describe('string', function () {
             expect(function () {
 
                 Joi.string().valid('joi');
-            }).to.not.throw;
+            }).to.not.throw();
             done();
         });
 
@@ -95,8 +95,8 @@ describe('string', function () {
 
             expect(function () {
 
-                Joi.string().invalid(1);
-            }).to.throw;
+                Joi.string().invalid({});
+            }).to.throw();
             done();
         });
 
@@ -105,7 +105,7 @@ describe('string', function () {
             expect(function () {
 
                 Joi.string().invalid('joi');
-            }).to.not.throw;
+            }).to.not.throw();
             done();
         });
 


### PR DESCRIPTION
I was looking around for Bug Hunt candidates and noticed that a couple of the tests in `string.js` had syntax errors.

`expect(fn).to.throw;` will not fail if `fn()` doesn't throw, it has to be called like `expect(fn).to.throw();`

I also changed the arguments to Joi.string().valid() from a number to an object, because as far as I can tell a number shouldn't cause valid() to throw.
