### PR TITLE
Recursively describes the includes of array schemas #312

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -44,6 +44,30 @@ internals.Array.prototype._base = function (value, state, options) {
 };
 
 
+internals.Array.prototype.describe = function () {
+
+    var description = Any.prototype.describe.call(this);
+    if (description.rules) {
+        var includes = [];
+        for (var i = 0, il = description.rules.length; i < il; ++i) {
+            var rule = description.rules[i];
+            if(rule.name === 'includes') {
+                for (var j = 0, jl = rule.arg.length; j < jl; ++j) {
+                    var type = rule.arg[j];
+                    includes.push(type.describe());
+                }
+            }
+        }
+
+        if(includes.length) {
+            description.includes = includes;
+        }
+    }
+
+    return description;
+};
+
+
 internals.Array.prototype.includes = function () {
 
     var inclusions = Hoek.flatten(Array.prototype.slice.call(arguments)).map(function (type) {

--- a/test/array.js
+++ b/test/array.js
@@ -336,5 +336,36 @@ describe('array', function () {
             ]);
             done();
         });
+
+        describe('#describe', function () {
+
+            it('returns an empty description when no rules are applied', function (done) {
+
+                var schema = Joi.array();
+                var desc = schema.describe();
+                expect(desc).to.deep.equal({
+                    type: 'array',
+                    valids: [undefined],
+                    invalids: [null]
+                });
+                done();
+            });
+
+            it('returns an includes array only if includes are specified', function (done) {
+
+                var schema = Joi.array().includes().max(5);
+                var desc = schema.describe();
+                expect(desc.includes).to.not.exist;
+                done();
+            });
+
+            it('returns a recursively defined array of includes when specified', function (done) {
+
+                var schema = Joi.array().includes(Joi.number(), Joi.string());
+                var desc = schema.describe();
+                expect(desc.includes).to.have.length(2);
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixes #312
- Walks the rules array to find includes
- Describes each included type
- Pushes the descriptions onto a new `.includes` property of the description.

There doesn't currently seem to be a good way to get at just the includes. I could either dig into this._test or the existing description rules. I chose the latter since it felt marginally cleaner. The alternative is to track includes in the Array type, but that was a bigger change and I wanted to presume as little as possible. It's simple enough to simplify this logic to use a this._includes if that's preferred.

Similarly, I'm not currently doing this for excludes, but if that seems like good behavior it's simple enough to add.

I have some (small) stake in this from #241, as I'd need to get into the include types of arrays as well for metadata in some cases. I thought I'd try to be helpful in the meantime.
