### PR TITLE
add uppercase, lowercase, and trim for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Current version: **4.2.x**
         - [`string.guid()`](#stringguid)
         - [`string.isoDate()`](#stringisodate)
         - [`string.hostname()`](#stringhostname)
+        - [`string.lowercase([options])`](#stringlowercase)
+        - [`string.uppercase([options])`](#stringuppercase)
+        - [`string.trim([options])`](#stringtrim)
     - [`alternatives`](#alternatives)
         - [`alternatives.try(schemas)`](#alternativestryschemas)
         - [`alternatives.when(ref, options)`](#alternativeswhenref-options)
@@ -853,6 +856,39 @@ Requires the string value to be a valid hostname as per [RFC1123](http://tools.i
 
 ```javascript
 var schema = Joi.string().hostname();
+```
+
+#### `string.lowercase([options])`
+
+Requires the string value to be all lowercase.
+
+- `options` - optional object with settings:
+    - `force` - `true` changes the string to uppercase before validation. Default is `false`.
+
+```javascript
+var schema = Joi.string().lowercase();
+```
+
+#### `string.uppercase([options])`
+
+Requires the string value to be all uppercase.
+
+- `options` - optional object with settings:
+    - `force` - `true` changes the string to uppercase before validation. Default is `false`.
+
+```javascript
+var schema = Joi.string().uppercase();
+```
+
+#### `string.trim([options])`
+
+Requires the string value to not have leading or trailing whitespace.
+
+- `options` - optional object with settings:
+    - `force` - `true` removes leading and trailing whitespace before validation. Default is `false`.
+
+```javascript
+var schema = Joi.string().trim();
 ```
 
 ### `alternatives`

--- a/lib/any.js
+++ b/lib/any.js
@@ -43,6 +43,9 @@ module.exports = internals.Any = function () {
     this._renames = [];
     this._dependencies = [];
     this._refs = [];
+
+    this._forceCase = null;
+    this._forceTrim = null;
 };
 
 
@@ -69,6 +72,9 @@ internals.Any.prototype.clone = function () {
     obj._renames = this._renames.slice();
     obj._dependencies = this._dependencies.slice();
     obj._refs = this._refs.slice();
+
+    obj._forceCase = this._forceCase;
+    obj._forceTrim = this._forceTrim;
 
     return obj;
 };

--- a/lib/language.js
+++ b/lib/language.js
@@ -82,6 +82,9 @@ exports.errors = {
         email: 'must be a valid email',
         isoDate: 'must be a valid ISO 8601 date',
         guid: 'must be a valid GUID',
-        hostname: 'must be a valid hostname'
+        hostname: 'must be a valid hostname',
+        lowercase: 'must only contain lowercase characters',
+        uppercase: 'must only contain uppercase characters',
+        trim: 'must not have leading or trailing whitespace'
     }
 };

--- a/lib/string.js
+++ b/lib/string.js
@@ -23,6 +23,19 @@ Hoek.inherits(internals.String, Any);
 
 internals.String.prototype._base = function (value, state, options) {
 
+    if (typeof value === 'string') {
+        if (this._forceCase === 'upper') {
+            value = value.toLocaleUpperCase();
+        }
+        else if (this._forceCase === 'lower') {
+            value = value.toLocaleLowerCase();
+        }
+
+        if (this._forceTrim) {
+            value = value.trim();
+        }
+    }
+
     return {
         value: value,
         errors: (value && typeof value === 'string') ? null : Errors.create('string.base', null, state, options)
@@ -187,6 +200,66 @@ internals.String.prototype.hostname = function () {
 
         return Errors.create("string.hostname", null, state, options);
     });
+};
+
+
+internals.String.prototype.lowercase = function (options) {
+
+    Hoek.assert(!(options && options.force) || !this._forceCase, 'cannot force both lowercase and uppercase');
+
+    var obj = this._test('lowercase', undefined, function (value, state, options) {
+
+        if (value === value.toLocaleLowerCase()) {
+            return null;
+        }
+
+        return Errors.create('string.lowercase', null, state, options);
+    });
+
+    if (options && options.force) {
+        obj._forceCase = 'lower';
+    }
+
+    return obj;
+};
+
+
+internals.String.prototype.uppercase = function (options) {
+
+    Hoek.assert(!(options && options.force) || !this._forceCase, 'cannot force both lowercase and uppercase');
+
+    var obj = this._test('uppercase', undefined, function (value, state, options) {
+
+        if (value === value.toLocaleUpperCase()) {
+            return null;
+        }
+
+        return Errors.create('string.uppercase', null, state, options);
+    });
+
+    if (options && options.force) {
+        obj._forceCase = 'upper';
+    }
+
+    return obj;
+};
+
+internals.String.prototype.trim = function (options) {
+
+    var obj = this._test('trim', undefined, function (value, state, options) {
+
+        if (value === value.trim()) {
+            return null;
+        }
+
+        return Errors.create('string.trim', null, state, options);
+    });
+
+    if (options && options.force) {
+        obj._forceTrim = true;
+    }
+
+    return obj;
 };
 
 

--- a/test/string.js
+++ b/test/string.js
@@ -236,6 +236,199 @@ describe('string', function () {
         });
     });
 
+    describe('#lowercase', function () {
+
+        it('should throw when there is a force case conflict', function (done) {
+
+            expect(function () {
+
+                Joi.string().uppercase({ force: true }).lowercase({ force: true });
+            }).to.throw('cannot force both lowercase and uppercase');
+            done();
+        });
+
+        it('should only allow strings that are entirely lowercase', function (done) {
+
+            var schema = Joi.string().lowercase();
+            Validate(schema, [
+                ['this is all lowercase', true],
+                ['5', true],
+                ['lower\tcase', true],
+                ['Uppercase', false],
+                ['MixEd cAsE', false],
+                [1, false]
+            ], done);
+        });
+
+        it('should not change the result value by default', function (done) {
+
+            var schema = Joi.string().lowercase();
+            schema.validate('stay lowercase', function (err, value) {
+
+                expect(err).to.not.exist;
+                expect(value).to.equal('stay lowercase');
+                done();
+            });
+        });
+
+        it('should, when set to force, attempt to coerce string to lowercase before validation', function (done) {
+
+            var schema = Joi.string().lowercase({ force: true });
+            schema.validate('UPPER TO LOWER', function (err, value) {
+
+                expect(err).to.not.exist;
+                expect(value).to.equal('upper to lower');
+                done();
+            });
+        });
+
+        it('should work in combination with a forced trim', function (done) {
+
+            var schema = Joi.string().lowercase({ force: true }).trim({ force: true });
+            Validate(schema, [
+                [' abc', true],
+                [' ABC', true],
+                ['ABC', true],
+                [1, false]
+            ], done);
+        });
+    });
+
+    describe('#uppercase', function () {
+
+        it('should throw when there is a force case conflict', function (done) {
+
+            expect(function () {
+
+                Joi.string().lowercase({ force: true }).uppercase({ force: true });
+            }).to.throw('cannot force both lowercase and uppercase');
+            done();
+        });
+
+        it('should only allow strings that are entirely uppercase', function (done) {
+
+            var schema = Joi.string().uppercase();
+            Validate(schema, [
+                ['THIS IS ALL UPPERCASE', true],
+                ['5', true],
+                ['UPPER\nCASE', true],
+                ['lOWERCASE', false],
+                ['MixEd cAsE', false],
+                [1, false]
+            ], done);
+        });
+
+        it('should not change the result value by default', function (done) {
+
+            var schema = Joi.string().uppercase();
+            schema.validate('STAY UPPERCASE', function (err, value) {
+
+                expect(err).to.not.exist;
+                expect(value).to.equal('STAY UPPERCASE');
+                done();
+            });
+        });
+
+        it('should, when set to force, attempt to coerce string to uppercase before validation', function (done) {
+
+            var schema = Joi.string().uppercase({ force: true });
+            schema.validate('lower to upper', function (err, value) {
+
+                expect(err).to.not.exist;
+                expect(value).to.equal('LOWER TO UPPER');
+                done();
+            });
+        });
+
+        it('should work in combination with a forced trim', function (done) {
+
+            var schema = Joi.string().uppercase({ force: true }).trim({ force: true });
+            Validate(schema, [
+                [' abc', true],
+                [' ABC', true],
+                ['ABC', true],
+                [1, false]
+            ], done);
+        });
+    });
+
+    describe('#trim', function () {
+
+        it('should only allow strings that have no leading or trailing whitespace', function (done) {
+
+            var schema = Joi.string().trim();
+            Validate(schema, [
+                [' something', false],
+                ['something ', false],
+                ['something\n', false],
+                ['some thing', true],
+                ['something', true]
+            ], done);
+        });
+
+        it('should not change the result value by default', function (done) {
+
+            var schema = Joi.string().trim();
+            schema.validate('something', function (err, value) {
+
+                expect(err).to.not.exist;
+                expect(value).to.equal('something');
+                done();
+            });
+        });
+
+        it('should, when set to force, remove leading and trailing whitespace before validation', function (done) {
+
+            var schema = Joi.string().trim({ force: true });
+            schema.validate(' trim this ', function (err, value) {
+
+                expect(err).to.not.exist;
+                expect(value).to.equal('trim this');
+                done();
+            });
+        });
+
+        it('should work in combination with min', function (done) {
+
+            var schema = Joi.string().min(4).trim({ force: true });
+            Validate(schema, [
+                [' a ', false],
+                ['abc ', false],
+                ['abcd ', true]
+            ], done);
+        });
+
+        it('should work in combination with max', function (done) {
+
+            var schema = Joi.string().max(4).trim({ force: true });
+            Validate(schema, [
+                [' abcde ', false],
+                ['abc ', true],
+                ['abcd ', true]
+            ], done);
+        });
+
+        it('should work in combination with length', function (done) {
+
+            var schema = Joi.string().length(4).trim({ force: true });
+            Validate(schema, [
+                [' ab ', false],
+                ['abc ', false],
+                ['abcd ', true]
+            ], done);
+        });
+
+        it('should work in combination with a forced case change', function (done) {
+
+            var schema = Joi.string().trim({ force: true }).lowercase({ force: true });
+            Validate(schema, [
+                [' abc', true],
+                [' ABC', true],
+                ['ABC', true]
+            ], done);
+        });
+    });
+
     describe('#validate', function () {
 
         it('should, by default, allow undefined, deny empty string', function (done) {


### PR DESCRIPTION
closes #220
-added uppercase validator for strings with an option to force string to uppercase
-added lowercase validator for strings with an option to force string to lowercase
-added trim validator for strings with an option to remove leading and trailing whitespace
-updated readme documentation
