### PR TITLE
Bug Hunt: empty string key causes incorrect validation

### DIFF
--- a/test/object.js
+++ b/test/object.js
@@ -613,6 +613,15 @@ describe('object', function () {
             expect(error).to.equal(true);
             done();
         });
+
+        it('should validate correctly when key is an empty string', function (done) {
+
+            var schema = Joi.object().with('', 'b');
+            Validate(schema, [
+                [{ c: 'hi', d: 'there' }, true],
+            ]);
+            done();
+        });
     });
 
     describe('#without', function () {
@@ -636,6 +645,17 @@ describe('object', function () {
                 error = true;
             }
             expect(error).to.equal(true);
+
+
+            done();
+        });
+
+        it('should validate correctly when key is an empty string', function (done) {
+
+            var schema = Joi.object().without('', 'b');
+            Validate(schema, [
+                [{ a: 'hi', b: 'there' }, true]
+            ]);
             done();
         });
     });


### PR DESCRIPTION
Passing an empty string, which is a valid property name, to `Joi.object().with` or `Joi.object().without` causes incorrect validation results.
