### PR TITLE
Bug Hunt: unable to rename keys that are empty strings

### DIFF
--- a/test/object.js
+++ b/test/object.js
@@ -537,6 +537,17 @@ describe('object', function () {
                 done();
             });
         });
+
+        it('should be able to rename keys that are empty strings', function (done) {
+
+            var schema = Joi.object().rename('', 'notEmpty');
+            var input = {
+                '': 'something'
+            };
+
+            Validate(schema, [input, true]);
+            done();
+        });
     });
 
     describe('#describe', function () {


### PR DESCRIPTION
Should be able to rename object properties to/from an empty string but `Joi.object().rename` throws an error.
