### PR TITLE
added 'synchronous' to validation callback description

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Validates a value using the given schema and options where:
   - `skipFunctions` - when `true`, ignores unknown keys with a function value. Defaults to `false`.
   - `stripUnknown` - when `true`, unknown keys are deleted (only when value is an object). Defaults to `false`.
   - `language` - overrides individual error messages. Defaults to no override (`{}`).
-- `callback` - the callback method using the signature `function(err, value)` where:
+- `callback` - the synchronous callback method using the signature `function(err, value)` where:
   - `err` - if validation failed, the error reason, otherwise `null`.
   - `value` - the validated value with any type conversions and other modifiers applied (the input is left unchanged). `value` can be
     incomplete if validation failed and `abortEarly` is `true`.


### PR DESCRIPTION
It was not apparent this is called synchronously, so a small text change to make it 100% clear.
