### PR TITLE
Don't rename when there is nothing to rename.

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -94,12 +94,16 @@ internals.Object.prototype._base = function (value, state, options) {
             }
         }
 
-        target[item.to] = target[item.from];
-        renamed[item.to] = true;
+        if (target.hasOwnProperty(item.from)) {
 
-        if (!item.options.alias) {
-            delete target[item.from];
+            target[item.to] = target[item.from];
+
+            if (!item.options.alias) {
+                delete target[item.from];
+            }
         }
+
+        renamed[item.to] = true;
     }
 
     // Validate dependencies

--- a/test/object.js
+++ b/test/object.js
@@ -553,6 +553,23 @@ describe('object', function () {
                 done();
             });
         });
+
+        it('should not create new keys when they key in question does not exist', function (done) {
+
+            var schema = Joi.object().rename('b', '_b');
+
+            var input = {
+                a: 'something'
+            };
+
+            schema.validate(input, function (err, value) {
+
+                expect(err).to.not.exist;
+                expect(value).to.have.keys(['a']);
+                expect(value.a).to.equal('something');
+                done();
+            });
+        });
     });
 
     describe('#describe', function () {
@@ -878,4 +895,3 @@ describe('object', function () {
         });
     });
 });
-


### PR DESCRIPTION
When using `rename` on an optional key and such a key does not exist `rename` creates a new key with `undefined` as the value. 

This PR ensures that the there is something to rename and only then creates the new key.
