### PR TITLE
Cast milisecond strings to a date object

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -45,6 +45,14 @@ internals.toDate = function (value) {
         }
     }
 
+    if (typeof value === 'string') {
+
+        var parsed = parseInt(value, 10);
+        if (!isNaN(parsed)) {
+            return new Date(parsed);
+        }
+    }
+
     return null;
 };
 

--- a/test/date.js
+++ b/test/date.js
@@ -59,6 +59,18 @@ describe('date', function () {
         });
     });
 
+    it('validates millisecond date as a string', function (done) {
+        var now = new Date();
+        var mili = now.getTime();
+
+        Joi.date().validate(mili.toString(), function (err, value) {
+
+            expect(err).to.not.exist;
+            expect(value).to.be.eql(now);
+            done();
+        });
+    });
+
     describe('#validate', function () {
 
         it('validates min', function (done) {


### PR DESCRIPTION
Some clients pass all values as strings, which leads to problems when trying to validate dates based on milliseconds, as they need to be cast to a number before `Joi.date()` accepts them as valid dates.

This PR adds the ability to automatically cast values like `"1401919200000"` to the correct `Date` object.
