### PR TITLE
Bug Hunt: empty object() + pattern() + unknown(false) fails to error

### DIFF
--- a/test/object.js
+++ b/test/object.js
@@ -659,6 +659,18 @@ describe('object', function () {
                 done();
             });
         });
+
+        it('should throw an error when using a pattern on empty schema with unknown(false) and pattern doesn\'t match', function (done) {
+
+            var schema = Joi.object().pattern(/\d/, Joi.number()).unknown(false);
+
+            Joi.validate({ a: 5 }, schema, { abortEarly: false }, function (err, value) {
+
+                expect(err).to.exist;
+                expect(err.message).to.equal('a is not allowed');
+                done();
+            });
+        });
     });
 
     describe('#with', function () {


### PR DESCRIPTION
I wanted to validate an object that is used as a 'map' with keys of a specific format. So I used this pattern but it doesn't error:

``` js
Joi.object().pattern(/\d/, Joi.number()).unknown(false)
```

Note I'm not sure about the expected error message but the test a never reaches that as we get an `AssertionError: expected null to exists` from the line above.
