### PR TITLE
Removed unused sys import.

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -1,6 +1,5 @@
 // Load modules
 
-var Sys = require('sys');
 var Any = require('./any');
 var Cast = require('./cast');
 var Errors = require('./errors');


### PR DESCRIPTION
There was a stray `var Sys = require("sys");` that doesn't seem to be used at all. This line was wreaking havoc in a non-node environment.
