### PR TITLE
Add info to README about validate callback being optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Joi.validate(value, schema, function (err, value) { });
 
 // or
 var result = Joi.validate(value, schema);
-// assert.deepEqual(result, {"error":null,"value":{"a":123}});
+// result.error -> null
+// result.value -> { "a" : 123 }
 ```
 
 ### `compile(schema)`


### PR DESCRIPTION
I much prefer not passing callbacks unless a function is doing IO, and think it would be nice to advertise in the README that the callback parameter to Joi.validate is optional.
This behavior is discussed in [issue 97](https://github.com/spumko/joi/issues/97).
