### PR TITLE
Default Assert Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Current version: **4.6.x**
         - [`object.with(key, peers)`](#objectwithkey-peers)
         - [`object.without(key, peers)`](#objectwithoutkey-peers)
         - [`object.rename(from, to, [options])`](#objectrenamefrom-to-options)
-        - [`object.assert(ref, schema, message)`](#objectassertref-schema-message)
+        - [`object.assert(ref, schema, [message])`](#objectassertref-schema-message)
         - [`object.unknown([allow])`](#objectunknownallow)
     - [`string`](#string)
         - [`string.insensitive()`](#stringinsensitive)
@@ -772,13 +772,13 @@ var object = Joi.object().keys({
 object.validate({ b: 5 }, function (err, value) { });
 ```
 
-#### `object.assert(ref, schema, message)`
+#### `object.assert(ref, schema, [message])`
 
 Verifies an assertion where:
 - `ref` - the key name or [reference](#refkey-options).
 - `schema` - the validation rules required to satisfy the assertion. If the `schema` includes references, they are resolved against
   the object value, not the value of the `ref` target.
-- `message` - human-readable message used when the assertion fails.
+- `message` - optional human-readable message used when the assertion fails. Defaults to 'failed to pass the assertion test'.
 
 ```javascript
 var schema = Joi.object().keys({

--- a/lib/object.js
+++ b/lib/object.js
@@ -530,6 +530,7 @@ internals.Object.prototype.assert = function (ref, schema, message) {
 
     ref = Cast.ref(ref);
     Hoek.assert(ref.isContext || ref.depth > 1, 'Cannot use assertions for root level references - use direct key rules instead');
+    message = message || 'pass the assertion test';
 
     var cast = Cast.schema(schema);
 

--- a/test/object.js
+++ b/test/object.js
@@ -905,5 +905,29 @@ describe('object', function () {
             }).to.not.throw();
             done();
         });
+
+        it('provides a default message for failed assertions', function (done) {
+
+            var schema = Joi.object({
+                a: {
+                    b: Joi.string(),
+                    c: Joi.number()
+                },
+                d: {
+                    e: Joi.any()
+                }
+            }).assert('d.e', Joi.boolean());
+
+            schema.validate({
+                d: {
+                    e:[]
+                }
+            }, function (err) {
+
+                expect(err).to.exist;
+                expect(err.message).to.equal('value validation failed because d.e failed to pass the assertion test');
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
Added a default assertion message and made the message argument into `object.assert` optional.

Fixes #374 
