### PR TITLE
code and tests for .withor

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -336,6 +336,11 @@ internals.Object.prototype.with = function (key, peers) {
     return this._dependency('with', key, peers);
 };
 
+internals.Object.prototype.withor = function (key, peers) {
+
+  return this._dependency('withor', key, peers);
+};
+
 
 internals.Object.prototype.without = function (key, peers) {
 
@@ -422,6 +427,31 @@ internals.with = function (value, peers, parent, state, options) {
     }
 
     return null;
+};
+
+internals.withor = function (value, peers, parent, state, options) {
+  if (value === undefined) {
+    return null;
+  }
+
+  var valid = false;
+
+  for (var i = 0, il = peers.length; i < il; ++i) {
+    var peer = peers[i];
+    if (parent.hasOwnProperty(peer) &&
+      parent[peer] !== undefined) {
+      if (valid) {
+        return Errors.create('object.withor', { peer: peer }, state, options);
+      }
+      valid = true;
+    }
+  }
+
+  if (!valid) {
+    return Errors.create('object.withor', { peer: peer }, state, options);
+  }
+
+  return null;
 };
 
 

--- a/test/object.js
+++ b/test/object.js
@@ -760,6 +760,93 @@ describe('object', function () {
         });
     });
 
+    describe('#withor', function () {
+
+      it('should throw an error when a parameter is not a string', function (done) {
+
+        try {
+          Joi.object().withor({});
+          var error = false;
+        }
+        catch (e) {
+          error = true;
+        }
+        expect(error).to.equal(true);
+
+        try {
+          Joi.object().withor(123);
+          error = false;
+        }
+        catch (e) {
+          error = true;
+        }
+        expect(error).to.equal(true);
+        done();
+      });
+
+      it('should validate correctly when key is an empty string', function (done) {
+
+        var schema = Joi.object().withor('', 'b');
+        Helper.validate(schema, [
+          [{ c: 'hi', d: 'there' }, true],
+        ]);
+        done();
+      });
+
+      it('should validate correctly when either of the parameters is present', function (done) {
+        var schema = Joi.object({
+          first: Joi.valid('value'),
+          second: Joi.string(),
+          third: Joi.number(),
+          fourth: Joi.string()
+        }).withor('first', ['second', 'third']);
+
+        Helper.validate(schema, [
+          [{ first: 'value', third: 12345 }, true]
+        ], done);
+      });
+
+      it('should validate correctly when additonal parameters are present outside of those specifed', function (done) {
+        var schema = Joi.object({
+          first: Joi.valid('value'),
+          second: Joi.string(),
+          third: Joi.number(),
+          fourth: Joi.string()
+        }).withor('first', ['second', 'third']);
+
+        Helper.validate(schema, [
+          [{ first: 'value', second: 'othervalue', fourth: 'something'}, true]
+        ], done);
+      });
+
+      it('should fail if with both of the parameters', function (done) {
+        var schema = Joi.object({
+          first: Joi.valid('value'),
+          second: Joi.string(),
+          third: Joi.number(),
+          fourth: Joi.string()
+        }).withor('first', ['second', 'third']);
+
+        Helper.validate(schema, [
+          [{ first: 'value', second: 'othervalue', third: 12345 }, false]
+        ], done);
+      });
+
+      it('should fail if neither of the parameters are present', function (done) {
+        var schema = Joi.object({
+          first: Joi.valid('value'),
+          second: Joi.string(),
+          third: Joi.number(),
+          fourth: Joi.string()
+        }).withor('first', ['second', 'third']);
+
+        Helper.validate(schema, [
+          [{ first: 'value' }, false]
+        ], done);
+      });
+
+    });
+
     describe('#xor', function () {
 
         it('should throw an error when a parameter is not a string', function (done) {


### PR DESCRIPTION
.withor is a convenience for when you need validation like this:

one of these combinations is acceptable:
{city, state} or {county, state} or {town, state} or {region, state}

.withor('state', ['city', 'county', 'town', 'region']) 