### PR TITLE
Added check for global flag in pattern.

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -323,6 +323,7 @@ internals.Object.prototype.max = function (limit) {
 internals.Object.prototype.pattern = function (regex, schema) {
 
     Hoek.assert(regex instanceof RegExp, 'Invalid regular expression');
+    Hoek.assert(!regex.global, 'Global flag cannot be used');
     Hoek.assert(schema !== undefined, 'Invalid rule');
 
     var obj = this.clone();

--- a/test/object.js
+++ b/test/object.js
@@ -688,6 +688,17 @@ describe('object', function () {
                 done();
             });
         });
+
+        it('throws an error when trying to use the global flag', function (done) {
+
+            expect(function() {
+
+                var schema = Joi.object({
+                    a: Joi.number()
+                }).pattern(/\d+/gi, Joi.boolean());
+            }).to.throw('Global flag cannot be used');
+            done();
+        });
     });
 
     describe('#with', function () {


### PR DESCRIPTION
If you had /g in your `pattern` option, the results of `pattern.regex.test(key)` [here](https://github.com/hapijs/joi/blob/master/lib/object.js#L168) will toggle back and forth between `true` and `false` creating very unpredictable validation results. 

Read up about this design decision http://stackoverflow.com/a/1520853/1011616

I'm not sure what to do about the versioning of this. If you're using a `pattern` function with "/g" then this is going to break your code.
