### PR TITLE
string().isoDate() validating yyyy-mm-dd

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -3,6 +3,7 @@
 var Net = require('net');
 var Hoek = require('hoek');
 var Isemail = require('isemail');
+var Isodate = require('isodate');
 var Any = require('./any');
 var Errors = require('./errors');
 
@@ -160,15 +161,16 @@ internals.String.prototype.email = function () {
 
 internals.String.prototype.isoDate = function () {
 
-    var regex = /^(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))$/;
-
     return this._test('isoDate', undefined, function (value, state, options) {
 
-        if (regex.test(value)) {
-            return null;
+        try {
+            Isodate(value);
+        }
+        catch(err) {
+            return Errors.create('string.isoDate', null, state, options);
         }
 
-        return Errors.create('string.isoDate', null, state, options);
+        return null;
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
   },
   "dependencies": {
     "hoek": "^2.2.x",
-    "topo": "1.x.x",
-    "isemail": "1.x.x"
+    "isemail": "1.x.x",
+    "isodate": "^0.1.x",
+    "topo": "1.x.x"
   },
   "devDependencies": {
     "lab": "4.x.x"

--- a/test/string.js
+++ b/test/string.js
@@ -1074,7 +1074,15 @@ describe('string', function () {
                 ['2013-06-07T14:21+07:00', true],
                 ['2013-06-07T14:21-07:00', true],
                 ['2013-06-07T14:21Z+7:00', false],
-                ['1-1-2013', false]
+                ['2013-01-01', true],
+                ['2013', true],
+                ['1-1-2013', false],
+                ['2013-1-1', false],
+                ['01-01', false],
+                ['20', false],
+                ['asdf', false],
+                ['', false],
+                [null, false]
             ], done);
         });
 


### PR DESCRIPTION
The regex introduced by #138 does not contemplate, e.g., the case of yyyy-mm-dd which is a valid format according to http://www.w3.org/TR/NOTE-datetime

The package https://www.npmjs.org/package/isostring does a fine job at validating this format.
