### PR TITLE
Enable to pass "now" in date.min and date.max

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,12 @@ Specifies the latest date allowed where:
 var schema = Joi.date().max('12-31-2020');
 ```
 
+Note: `'now'` can be passed in lieu of `date` so as to always compare relatively to the current date, allowing to explicitly ensure a date is either in the past or in the future.
+
+```javascript
+var schema = Joi.date().min('now');
+```
+
 ### `func`
 
 Generates a schema object that matches a function type.

--- a/lib/date.js
+++ b/lib/date.js
@@ -36,6 +36,10 @@ internals.toDate = function (value) {
         return value;
     }
 
+    if (value === 'now') {
+      return new Date();
+    }
+
     if (typeof value === 'string' ||
         Hoek.isInteger(value)) {
 

--- a/test/date.js
+++ b/test/date.js
@@ -73,6 +73,52 @@ describe('date', function () {
         });
     });
 
+    it('accepts "now" as the min date', function(done) {
+
+      var future = new Date(Date.now() + 1000000);
+
+      Joi.date().min('now').validate(future, function (err, value) {
+
+        expect(err).to.not.exist;
+        expect(value).to.be.eql(future);
+        done();
+      });
+    });
+
+    it('errors if .min("now") is used with a past date', function(done) {
+
+      var past = new Date(Date.now() - 1000000);
+
+      Joi.date().min('now').validate(past, function (err, value) {
+
+        expect(err).to.exist;
+        done();
+      });
+    });
+
+    it('accepts "now" as the max date', function(done) {
+
+      var past = new Date(Date.now() - 1000000);
+
+      Joi.date().max('now').validate(past, function (err, value) {
+
+        expect(err).to.not.exist;
+        expect(value).to.be.eql(past);
+        done();
+      });
+    });
+
+    it('errors if .max("now") is used with a future date', function(done) {
+
+      var future = new Date(Date.now() + 1000000);
+
+      Joi.date().max('now').validate(future, function (err, value) {
+
+        expect(err).to.exist;
+        done();
+      });
+    });
+
     describe('#validate', function () {
 
         it('validates min', function (done) {


### PR DESCRIPTION
It is not currently possible to validate a date relatively to the
current time. For example, the following schema will always validate
relatively to the time of the `schema` object allocation:

``` javascript
var schema = {
  date: Joi.date().min(new Date())
};
```

This patch addresses this issue by adding a new `'now'` placeholder.
It dynamically computes the current time on-the-fly at each comparison.
Allowing to always compare relatively to the current time.

``` javascript
var schema = {
  // Ensure the date field cannot represent a past date
  date: Joi.date().min('now')
};
```
