### PR TITLE
Remove usage of deprecated '__proto__' when creating objects

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -62,8 +62,7 @@ internals.Any.prototype.isImmutable = true;     // Prevents Hoek from deep cloni
 
 internals.Any.prototype.clone = function () {
 
-    var obj = {};
-    obj.__proto__ = Object.getPrototypeOf(this);
+    var obj = Object.create(Object.getPrototypeOf(this));
 
     obj.isJoi = true;
     obj._type = this._type;

--- a/lib/object.js
+++ b/lib/object.js
@@ -58,8 +58,7 @@ internals.Object.prototype._base = function (value, state, options) {
     // Ensure target is a local copy (parsed) or shallow copy
 
     if (target === value) {
-        target = {};
-        target.__proto__ = Object.getPrototypeOf(value);
+        target = Object.create(Object.getPrototypeOf(value));
         var valueKeys = Object.keys(value);
         for (var t = 0, tl = valueKeys.length; t < tl; ++t) {
             target[valueKeys[t]] = value[valueKeys[t]];


### PR DESCRIPTION
**proto** is deprecated and will cause errors in systems that do not support that property. Object.create will allow for this same functionality and is polyfill-able in legacy systems. All tests pass.
