### PR TITLE
Add greater() and less() to number type. Closes #411

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Lead Maintainer: [Eran Hammer](https://github.com/hueniverse)
     - [`number`](#number)
         - [`number.min(limit)`](#numberminlimit)
         - [`number.max(limit)`](#numbermaxlimit)
+        - [`number.greater(limit)`](#numbergreaterlimit)
+        - [`number.less(limit)`](#numberlesslimit)
         - [`number.integer()`](#numberinteger)
         - [`number.precision(limit)`](#numberprecisionlimit)
     - [`object`](#object)
@@ -621,6 +623,22 @@ Specifies the maximum value where:
 
 ```javascript
 var schema = Joi.number().max(10);
+```
+
+#### `number.greater(limit)`
+
+Specifies that the value must be greater than `limit`.
+
+```javascript
+var schema = Joi.number().greater(5);
+```
+
+#### `number.less(limit)`
+
+Specifies that the value must be less than `limit`.
+
+```javascript
+var schema = Joi.number().less(10);
 ```
 
 #### `number.integer()`

--- a/lib/language.js
+++ b/lib/language.js
@@ -67,6 +67,8 @@ exports.errors = {
         base: 'must be a number',
         min: 'must be larger than or equal to {{limit}}',
         max: 'must be less than or equal to {{limit}}',
+        less: 'must be less than {{limit}}',
+        greater: 'must be greater than {{limit}}',
         float: 'must be a float or double',
         integer: 'must be an integer',
         negative: 'must be a negative number',

--- a/lib/number.js
+++ b/lib/number.js
@@ -68,6 +68,36 @@ internals.Number.prototype.max = function (limit) {
 };
 
 
+internals.Number.prototype.greater = function (limit) {
+
+    Hoek.assert(Hoek.isInteger(limit), 'limit must be an integer');
+
+    return this._test('greater', limit, function (value, state, options) {
+
+        if (value > limit) {
+            return null;
+        }
+
+        return Errors.create('number.greater', { limit: limit }, state, options);
+    });
+};
+
+
+internals.Number.prototype.less = function (limit) {
+
+    Hoek.assert(Hoek.isInteger(limit), 'limit must be an integer');
+
+    return this._test('less', limit, function (value, state, options) {
+
+        if (value < limit) {
+            return null;
+        }
+
+        return Errors.create('number.less', { limit: limit }, state, options);
+    });
+};
+
+
 internals.Number.prototype.integer = function () {
 
     return this._test('integer', undefined, function (value, state, options) {

--- a/test/number.js
+++ b/test/number.js
@@ -402,6 +402,68 @@ describe('number', function () {
                 [null, true]
             ], done);
         });
+
+        it('should handle combination of greater and less', function (done) {
+
+            var rule = Joi.number().greater(5).less(10);
+            Helper.validate(rule, [
+                [0, false],
+                [11, false],
+                [5, false],
+                [10, false],
+                [8, true],
+                [5.01, true],
+                [9.99, true],
+                [null, false]
+            ], done);
+        });
+
+        it('should handle combination of greater, less, and integer', function (done) {
+
+            var rule = Joi.number().integer().greater(5).less(10);
+            Helper.validate(rule, [
+                [0, false],
+                [11, false],
+                [5, false],
+                [10, false],
+                [6, true],
+                [9, true],
+                [5.01, false],
+                [9.99, false]
+            ], done);
+        });
+
+        it('should handle combination of greater, less, and null allowed', function (done) {
+
+            var rule = Joi.number().greater(5).less(10).allow(null);
+            Helper.validate(rule, [
+                [0, false],
+                [11, false],
+                [5, false],
+                [10, false],
+                [8, true],
+                [5.01, true],
+                [9.99, true],
+                [null, true]
+            ], done);
+        });
+
+        it('should handle combination of greater, less, invalid, and allow', function (done) {
+
+            var rule = Joi.number().greater(5).less(10).invalid(6).allow(-3);
+            Helper.validate(rule, [
+                [0, false],
+                [11, false],
+                [5, false],
+                [10, false],
+                [6, false],
+                [8, true],
+                [5.01, true],
+                [9.99, true],
+                [-3, true],
+                [null, false]
+            ], done);
+        });
     });
 
     it('should instantiate separate copies on invocation', function (done) {


### PR DESCRIPTION
Adds `Joi.number().greater()` and `Joi.number().less()` as discussed in #411.
