### PR TITLE
Named string regex patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Lead Maintainer: [Eran Hammer](https://github.com/hueniverse)
         - [`string.min(limit, [encoding])`](#stringminlimit-encoding)
         - [`string.max(limit, [encoding])`](#stringmaxlimit-encoding)
         - [`string.length(limit, [encoding])`](#stringlengthlimit-encoding)
-        - [`string.regex(pattern)`](#stringregexpattern)
+        - [`string.regex(pattern, [name])`](#stringregexpattern)
         - [`string.alphanum()`](#stringalphanum)
         - [`string.token()`](#stringtoken)
         - [`string.email()`](#stringemail)
@@ -877,10 +877,11 @@ Specifies the exact string length required where:
 var schema = Joi.string().length(5);
 ```
 
-#### `string.regex(pattern)`
+#### `string.regex(pattern, [name])`
 
 Defines a regular expression rule where:
 - `pattern` - a regular expression object the string value must match against.
+- `name` - optional name for patterns (useful with multiple patterns). Defaults to 'required'.
 
 ```javascript
 var schema = Joi.string().regex(/^[abc]+$/);

--- a/lib/language.js
+++ b/lib/language.js
@@ -80,7 +80,7 @@ exports.errors = {
         length: 'length must be {{limit}} characters long',
         alphanum: 'must only contain alpha-numeric characters',
         token: 'must only contain alpha-numeric and underscore characters',
-        regex: 'fails to match the required pattern',
+        regex: 'fails to match the {{name}} pattern',
         email: 'must be a valid email',
         isoDate: 'must be a valid ISO 8601 date',
         guid: 'must be a valid GUID',

--- a/lib/string.js
+++ b/lib/string.js
@@ -102,9 +102,10 @@ internals.String.prototype.length = function (limit, encoding) {
 };
 
 
-internals.String.prototype.regex = function (pattern) {
+internals.String.prototype.regex = function (pattern, name) {
 
     Hoek.assert(pattern instanceof RegExp, 'pattern must be a RegExp');
+    name = name || 'required';
 
     pattern = new RegExp(pattern.source, pattern.ignoreCase ? 'i' : undefined);         // Future version should break this and forbid unsupported regex flags
 
@@ -114,7 +115,7 @@ internals.String.prototype.regex = function (pattern) {
             return null;
         }
 
-        return Errors.create('string.regex', null, state, options);
+        return Errors.create('string.regex', { name: name }, state, options);
     });
 };
 

--- a/test/string.js
+++ b/test/string.js
@@ -390,6 +390,29 @@ describe('string', function () {
         });
     });
 
+    describe('#regex', function () {
+
+        it('should not include a pattern name by default', function (done) {
+
+            var schema = Joi.string().regex(/[a-z]+/).regex(/[0-9]+/);
+            schema.validate('abcd', function (err, value) {
+
+                expect(err.message).to.contain('required pattern');
+                done();
+            });
+        });
+
+        it('should include a pattern name if specified', function (done) {
+
+            var schema = Joi.string().regex(/[a-z]+/, 'letters').regex(/[0-9]+/, 'numbers');
+            schema.validate('abcd', function (err, value) {
+
+                expect(err.message).to.contain('numbers pattern');
+                done();
+            });
+        });
+    });
+
     describe('#validate', function () {
 
         it('should, by default, allow undefined, deny empty string', function (done) {


### PR DESCRIPTION
Allows regexes to take a name when validating strings. This is useful for differentiating multiple regex patterns.

Closes #439.
