### PR TITLE
Retain object reference when no rules specified

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -55,6 +55,17 @@ internals.Object.prototype._base = function (value, state, options) {
         return finish();
     }
 
+    // Skip if there are no other rules to test
+
+    if (!this._inner.renames.length &&
+        !this._inner.dependencies.length &&
+        !this._inner.children &&                    // null allows any keys
+        !this._inner.patterns.length) {
+
+        target = value;
+        return finish();
+    }
+
     // Ensure target is a local copy (parsed) or shallow copy
 
     if (target === value) {

--- a/test/object.js
+++ b/test/object.js
@@ -43,7 +43,7 @@ describe('object', function () {
         });
     });
 
-    it('should validate an object', function (done) {
+    it('validates an object', function (done) {
 
         var schema = Joi.object().required();
         Helper.validate(schema, [
@@ -51,6 +51,20 @@ describe('object', function () {
             [{ hi: true }, true],
             ['', false]
         ], done);
+    });
+
+    it('return object reference when no rules specified', function (done) {
+
+        var schema = Joi.object({
+            a: Joi.object()
+        });
+
+        var item = { x: 5 };
+        schema.validate({ a: item }, function (err, value) {
+
+            expect(value.a).to.equal(item);
+            done();
+        });
     });
 
     it('retains ignored values', function (done) {


### PR DESCRIPTION
We have a few places in hapi config where we validate an options object containing user-specified values like `app`. These are shallow copied even when there is no reason to (no other rules specified). This creates a simple shortcut when there is no reason to perform even a shallow copy. Without this, the type must be set to `joi.any()` which is not as good as `joi.object()`.
