### PR TITLE
Validate object constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Lead Maintainer: [Nicolas Morel](https://github.com/marsup)
         - [`object.rename(from, to, [options])`](#objectrenamefrom-to-options)
         - [`object.assert(ref, schema, [message])`](#objectassertref-schema-message)
         - [`object.unknown([allow])`](#objectunknownallow)
+        - [`object.type(constructor, [name])`](#objecttypeconstructorname)
     - [`string`](#string)
         - [`string.insensitive()`](#stringinsensitive)
         - [`string.min(limit, [encoding])`](#stringminlimit-encoding)
@@ -916,6 +917,16 @@ Overrides the handling of unknown keys for the scope of the current object only 
 
 ```javascript
 var schema = Joi.object({ a: Joi.any() }).unknown();
+```
+
+#### `object.type(constructor, [name])`
+
+Requires the object to be an instance of a given constructor where:
+- `constructor` - the constructor function that the object must be an instance of.
+- `name` - an alternate name to use in validation errors. This is useful when the constructor function does not have a name.
+
+```javascript
+var schema = Joi.object().type(RegExp);
 ```
 
 ### `string`

--- a/lib/language.js
+++ b/lib/language.js
@@ -63,7 +63,8 @@ exports.errors = {
         rename: {
             multiple: 'cannot rename child {{from}} because multiple renames are disabled and another key was already renamed to {{to}}',
             override: 'cannot rename child {{from}} because override is disabled and target {{to}} exists'
-        }
+        },
+        type: 'must be an instance of {{type}}'
     },
     number: {
         base: 'must be a number',

--- a/lib/object.js
+++ b/lib/object.js
@@ -593,4 +593,20 @@ internals.Object.prototype.assert = function (ref, schema, message) {
 };
 
 
+internals.Object.prototype.type = function (constructor, name) {
+
+    Hoek.assert(typeof constructor === 'function', 'type must be a constructor function');
+    name = name || constructor.name;
+
+    return this._test('type', name, function (value, state, options) {
+
+        if (value instanceof constructor) {
+            return null;
+        }
+
+        return Errors.create('object.type', { type: name }, state, options);
+    });
+};
+
+
 module.exports = new internals.Object();

--- a/test/object.js
+++ b/test/object.js
@@ -203,6 +203,18 @@ describe('object', function () {
         ], done);
     });
 
+    it('should validate constructor when type is set', function (done) {
+
+        var schema = Joi.object().type(RegExp);
+        Helper.validate(schema, [
+            [{ item: 'something' }, false],
+            ['', false],
+            [new Date(), false],
+            [/abcd/, true],
+            [new RegExp(), true]
+        ], done);
+    });
+
     it('should traverse an object and validate all properties in the top level', function (done) {
 
         var schema = Joi.object({
@@ -982,6 +994,65 @@ describe('object', function () {
                 expect(err.message).to.equal('value validation failed because d.e failed to pass the assertion test');
                 done();
             });
+        });
+    });
+
+    describe('#type', function () {
+
+        it('uses constructor name for default type name', function (done) {
+
+            function Foo () {}
+
+            var schema = Joi.object().type(Foo);
+            schema.validate({}, function (err) {
+
+                expect(err).to.exist;
+                expect(err.message).to.equal('value must be an instance of Foo');
+                done();
+            });
+        });
+
+        it('uses custom type name if supplied', function (done) {
+
+            var Foo = function () {};
+
+            var schema = Joi.object().type(Foo, 'Bar');
+            schema.validate({}, function (err) {
+
+                expect(err).to.exist;
+                expect(err.message).to.equal('value must be an instance of Bar');
+                done();
+            });
+        });
+
+        it('overrides constructor name with custom name', function (done) {
+
+            function Foo () {}
+
+            var schema = Joi.object().type(Foo, 'Bar');
+            schema.validate({}, function (err) {
+
+                expect(err).to.exist;
+                expect(err.message).to.equal('value must be an instance of Bar');
+                done();
+            });
+        });
+
+        it('throws when constructor is not a function', function (done) {
+
+            expect(function () {
+
+                var schema = Joi.object().type('');
+            }).to.throw('type must be a constructor function');
+            done();
+        });
+
+        it('uses the constructor name in the schema description', function (done) {
+
+            var description = Joi.object().type(RegExp).describe();
+
+            expect(description.rules).to.deep.include({ name: 'type', arg: 'RegExp' });
+            done();
         });
     });
 });


### PR DESCRIPTION
Provides support for requiring an object to be an instance of a given constructor.

Closes #408.
