### PR TITLE
Helpful regexp message

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -8,6 +8,15 @@ var Language = require('./language');
 
 var internals = {};
 
+function stringify(value) {
+    if (typeof value === "object") {
+        if (Array.isArray(value)) {
+            return "[" + value.map(stringify).join(", ") + "]";
+        }
+        value = value.toString();
+    }
+    return JSON.stringify(value);
+}
 
 internals.Err = function (type, context, state, options) {
 
@@ -28,11 +37,11 @@ internals.Err.prototype.toString = function () {
 
     var format = Hoek.reach(localized, this.type) || Hoek.reach(Language.errors, this.type);
     var hasKey = /\{\{\!?key\}\}/.test(format);
-    format = (hasKey ? format : '{{!key}} ' + format);
+    format = (hasKey ? format : (Hoek.reach(localized, "key") || Hoek.reach(Language.errors, "key")) + format);
     var message = format.replace(/\{\{(\!?)([^}]+)\}\}/g, function ($0, isSecure, name) {
 
         var value = Hoek.reach(self.context, name);
-        var normalized = Array.isArray(value) ? value.join(', ') : value.toString();
+        var normalized = stringify(value);
         return (isSecure ? Hoek.escapeHtml(normalized) : normalized);
     });
 

--- a/lib/language.js
+++ b/lib/language.js
@@ -8,6 +8,7 @@ var internals = {};
 
 exports.errors = {
     root: 'value',
+    key: '{{key}} ',
     any: {
         unknown: 'is not allowed',
         invalid: 'contains an invalid value',
@@ -86,8 +87,8 @@ exports.errors = {
         alphanum: 'must only contain alpha-numeric characters',
         token: 'must only contain alpha-numeric and underscore characters',
         regex: {
-            base: 'fails to match the required pattern',
-            name: 'fails to match the {{name}} pattern'
+            base: 'with value {{value}} fails to match the required pattern: {{pattern}}',
+            name: 'with value {{value}} fails to match the {{name}} pattern'
         },
         email: 'must be a valid email',
         isoDate: 'must be a valid ISO 8601 date',

--- a/lib/string.js
+++ b/lib/string.js
@@ -38,7 +38,7 @@ internals.String.prototype._base = function (value, state, options) {
 
     return {
         value: value,
-        errors: (typeof value === 'string') ? null : Errors.create('string.base', null, state, options)
+        errors: (typeof value === 'string') ? null : Errors.create('string.base', { value: value }, state, options)
     };
 };
 
@@ -63,7 +63,7 @@ internals.String.prototype.min = function (limit, encoding) {
             return null;
         }
 
-        return Errors.create('string.min', { limit: limit }, state, options);
+        return Errors.create('string.min', { limit: limit, value: value }, state, options);
     });
 };
 
@@ -80,7 +80,7 @@ internals.String.prototype.max = function (limit, encoding) {
             return null;
         }
 
-        return Errors.create('string.max', { limit: limit }, state, options);
+        return Errors.create('string.max', { limit: limit, value: value }, state, options);
     });
 };
 
@@ -101,7 +101,7 @@ internals.String.prototype.creditCard = function () {
         }
 
         var check =  (sum % 10 === 0) && (sum > 0);
-        return check ? null : Errors.create('string.creditCard', null, state, options);
+        return check ? null : Errors.create('string.creditCard', { value: value }, state, options);
     });
 };
 
@@ -118,7 +118,7 @@ internals.String.prototype.length = function (limit, encoding) {
             return null;
         }
 
-        return Errors.create('string.length', { limit: limit }, state, options);
+        return Errors.create('string.length', { limit: limit, value: value }, state, options);
     });
 };
 
@@ -135,7 +135,7 @@ internals.String.prototype.regex = function (pattern, name) {
             return null;
         }
 
-        return Errors.create((name ? 'string.regex.name' : 'string.regex.base'), { name: name }, state, options);
+        return Errors.create((name ? 'string.regex.name' : 'string.regex.base'), { name: name, pattern: pattern, value: value }, state, options);
     });
 };
 
@@ -148,7 +148,7 @@ internals.String.prototype.alphanum = function () {
             return null;
         }
 
-        return Errors.create('string.alphanum', null, state, options);
+        return Errors.create('string.alphanum', { value: value }, state, options);
     });
 };
 
@@ -161,7 +161,7 @@ internals.String.prototype.token = function () {
             return null;
         }
 
-        return Errors.create('string.token', null, state, options);
+        return Errors.create('string.token', { value: value }, state, options);
     });
 };
 
@@ -174,7 +174,7 @@ internals.String.prototype.email = function () {
             return null;
         }
 
-        return Errors.create('string.email', null, state, options);
+        return Errors.create('string.email', { value: value }, state, options);
     });
 };
 
@@ -187,7 +187,7 @@ internals.String.prototype.isoDate = function () {
             return null;
         }
 
-        return Errors.create('string.isoDate', null, state, options);
+        return Errors.create('string.isoDate', { value: value }, state, options);
     });
 };
 
@@ -203,7 +203,7 @@ internals.String.prototype.guid = function () {
             return null;
         }
 
-        return Errors.create('string.guid', null, state, options);
+        return Errors.create('string.guid', { value: value }, state, options);
     });
 };
 
@@ -220,7 +220,7 @@ internals.String.prototype.hostname = function () {
             return null;
         }
 
-        return Errors.create("string.hostname", null, state, options);
+        return Errors.create("string.hostname", { value: value }, state, options);
     });
 };
 
@@ -235,7 +235,7 @@ internals.String.prototype.lowercase = function () {
             return null;
         }
 
-        return Errors.create('string.lowercase', null, state, options);
+        return Errors.create('string.lowercase', { value: value }, state, options);
     });
 
     obj._flags.case = 'lower';
@@ -253,7 +253,7 @@ internals.String.prototype.uppercase = function (options) {
             return null;
         }
 
-        return Errors.create('string.uppercase', null, state, options);
+        return Errors.create('string.uppercase', { value: value }, state, options);
     });
 
     obj._flags.case = 'upper';
@@ -271,7 +271,7 @@ internals.String.prototype.trim = function () {
             return null;
         }
 
-        return Errors.create('string.trim', null, state, options);
+        return Errors.create('string.trim', { value: value }, state, options);
     });
 
     obj._flags.trim = true;

--- a/test/alternatives.js
+++ b/test/alternatives.js
@@ -28,7 +28,7 @@ describe('alternatives', function () {
         Joi.alternatives().validate('a', function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('value not matching any of the allowed alternatives');
+            expect(err.message).to.equal('"value" not matching any of the allowed alternatives');
             done();
         });
     });

--- a/test/any.js
+++ b/test/any.js
@@ -97,7 +97,7 @@ describe('any', function () {
             schema.validate(input, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.details[0].message).to.equal('Custom label must be a valid email');
+                expect(err.details[0].message).to.equal('"Custom label" must be a valid email');
                 done();
             });
         });
@@ -356,7 +356,7 @@ describe('any', function () {
             expect(function () {
 
                 var schema = Joi.valid(5, 6, 7).example(4);
-            }).to.throw('Bad example: value must be one of 5, 6, 7');
+            }).to.throw('Bad example: "value" must be one of "5, 6, 7"');
             done();
         });
     });

--- a/test/array.js
+++ b/test/array.js
@@ -38,7 +38,7 @@ describe('array', function () {
         Joi.array().validate('{ "something": false }', function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('value must be an array');
+            expect(err.message).to.equal('"value" must be an array');
             done();
         });
     });
@@ -114,7 +114,7 @@ describe('array', function () {
 
             schema.validate(input, function (err, value) {
 
-                expect(err.message).to.equal('test position 1 fails because foo is required');
+                expect(err.message).to.equal('"test" position 1 fails because ["\\\"foo\\\" is required"]');
                 done();
             });
         });
@@ -323,7 +323,7 @@ describe('array', function () {
             schema.validate(input, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('arr position 2 fails because 2 must be an integer');
+                expect(err.message).to.equal('"arr" position 2 fails because ["2 must be an integer"]');
                 done();
             });
         });

--- a/test/binary.js
+++ b/test/binary.js
@@ -57,7 +57,7 @@ describe('binary', function () {
             Joi.binary().validate(5, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value must be a buffer or a string');
+                expect(err.message).to.equal('"value" must be a buffer or a string');
                 done();
             });
         });

--- a/test/date.js
+++ b/test/date.js
@@ -47,7 +47,7 @@ describe('date', function () {
         Joi.date().options({ convert: false }).validate('1-1-2013 UTC', function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('value must be a number of milliseconds or valid date string');
+            expect(err.message).to.equal('"value" must be a number of milliseconds or valid date string');
             done();
         });
     });

--- a/test/errors.js
+++ b/test/errors.js
@@ -74,7 +74,7 @@ describe('errors', function () {
 
             expect(err).to.exist;
             expect(err.name).to.equal('ValidationError');
-            expect(err.message).to.equal('value 11. required 7. xor 7. email 19. date 18. alphanum 16. min 14. max 15. notEmpty 3');
+            expect(err.message).to.equal('"value" 11. "required" 7. "xor" 7. "email" 19. "date" 18. "alphanum" 16. "min" 14. "max" 15. "notEmpty" 3');
             done();
         });
     });
@@ -83,7 +83,7 @@ describe('errors', function () {
 
         Joi.valid('sad').options({ language: { any: { allowOnly: 'my hero {{key}} is not {{valids}}' } } }).validate(5, function (err, value) {
 
-            expect(err.message).to.equal('my hero value is not sad');
+            expect(err.message).to.equal('my hero "value" is not "sad"');
             done();
         });
     });
@@ -96,11 +96,11 @@ describe('errors', function () {
 
         Joi.validate({ 'a()': 'x' }, schema, function (err, value) {
 
-            expect(err.message).to.equal('a&#x28;&#x29; must be a number');
+            expect(err.message).to.equal('"a()" must be a number');
 
             Joi.validate({ 'b()': 'x' }, schema, function (err, value) {
 
-                expect(err.message).to.equal('b&#x28;&#x29; is not allowed');
+                expect(err.message).to.equal('"b()" is not allowed');
                 done();
             });
         });
@@ -185,16 +185,25 @@ describe('errors', function () {
 
         Joi.string().options({ language: { root: 'blah' } }).validate(4, function (err, value) {
 
-            expect(err.message).to.equal('blah must be a string');
+            expect(err.message).to.equal('"blah" must be a string');
             done();
         });
     });
 
     it('overrides label key language', function (done) {
 
+        Joi.string().options({ language: { key: '{{!key}} ' } }).validate(4, function (err, value) {
+
+            expect(err.message).to.equal("&quot;value&quot; must be a string");
+            done();
+        });
+    });
+
+    it('allows html escaping', function (done) {
+
         Joi.string().options({ language: { root: 'blah', label: 'bleh' } }).validate(4, function (err, value) {
 
-            expect(err.message).to.equal('bleh must be a string');
+            expect(err.message).to.equal('"bleh" must be a string');
             done();
         });
     });
@@ -227,7 +236,7 @@ describe('errors', function () {
             Joi.validate(object, schema, { abortEarly: false }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.annotate()).to.equal('{\n  \"y\": {\n    \"b\" \u001b[31m[1]\u001b[0m: {\n      \"c\": 10\n    },\n    \u001b[41m\"u\"\u001b[0m\u001b[31m [2]: -- missing --\u001b[0m\n  },\n  \"a\" \u001b[31m[3]\u001b[0m: \"m\"\n}\n\u001b[31m\n[1] a must be one of a, b, c, d\n[2] u is required\n[3] b must be a string\u001b[0m');
+                expect(err.annotate()).to.equal('{\n  \"y\": {\n    \"b\" \u001b[31m[1]\u001b[0m: {\n      \"c\": 10\n    },\n    \u001b[41m\"u\"\u001b[0m\u001b[31m [2]: -- missing --\u001b[0m\n  },\n  "a" \u001b[31m[3]\u001b[0m: \"m\"\n}\n\u001b[31m\n[1] "a" must be one of "a, b, c, d"\n[2] "u" is required\n[3] "b" must be a string\u001b[0m');
                 done();
             });
         });
@@ -245,7 +254,7 @@ describe('errors', function () {
             Joi.validate({ x: true }, schema, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.annotate()).to.equal('{\n  \"x\" \u001b[31m[1, 2, 3]\u001b[0m: true\n}\n\u001b[31m\n[1] x must be a string\n[2] x must be a number\n[3] x must be a number of milliseconds or valid date string\u001b[0m');
+                expect(err.annotate()).to.equal('{\n  \"x\" \u001b[31m[1, 2, 3]\u001b[0m: true\n}\n\u001b[31m\n[1] "x" must be a string\n[2] "x" must be a number\n[3] "x" must be a number of milliseconds or valid date string\u001b[0m');
                 done();
             });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -70,7 +70,7 @@ describe('Joi', function () {
         Joi.string().validate(null, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.annotate()).to.equal('{\n  \u001b[41m\"value\"\u001b[0m\u001b[31m [1]: -- missing --\u001b[0m\n}\n\u001b[31m\n[1] value must be a string\u001b[0m');
+            expect(err.annotate()).to.equal('{\n  \u001b[41m\"value\"\u001b[0m\u001b[31m [1]: -- missing --\u001b[0m\n}\n\u001b[31m\n[1] "value" must be a string\u001b[0m');
             done();
         });
     });
@@ -171,7 +171,7 @@ describe('Joi', function () {
 
         Joi.validate({ txt: 'a' }, schema, { abortEarly: false }, function (err, value) {
 
-            expect(err.message).to.equal('txt missing required peer upc');
+            expect(err.message).to.equal('"txt" missing required peer "upc"');
 
             Helper.validate(schema, [
                 [{ upc: 'test' }, true],
@@ -193,7 +193,7 @@ describe('Joi', function () {
 
         Joi.validate({ txt: 'a', upc: 'b' }, schema, { abortEarly: false }, function (err, value) {
 
-            expect(err.message).to.equal('txt conflict with forbidden peer upc');
+            expect(err.message).to.equal('"txt" conflict with forbidden peer "upc"');
 
             Helper.validate(schema, [
                 [{ upc: 'test' }, true],
@@ -215,7 +215,7 @@ describe('Joi', function () {
 
         Joi.validate({}, schema, { abortEarly: false }, function (err, value) {
 
-            expect(err.message).to.equal('value must contain at least one of txt, upc');
+            expect(err.message).to.equal('"value" must contain at least one of ["txt", "upc"]');
 
             Helper.validate(schema, [
                 [{ upc: null }, false],
@@ -293,7 +293,7 @@ describe('Joi', function () {
 
         Joi.validate({}, schema, { abortEarly: false }, function (err, value) {
 
-            expect(err.message).to.equal('value must contain at least one of txt, upc, code');
+            expect(err.message).to.equal('"value" must contain at least one of ["txt", "upc", "code"]');
 
             Helper.validate(schema, [
                 [{ upc: null }, true],
@@ -330,7 +330,7 @@ describe('Joi', function () {
 
         Joi.validate({ txt: 'x' }, schema, { abortEarly: false }, function (err, value) {
 
-            expect(err.message).to.equal('value contains txt without its required peers upc, code');
+            expect(err.message).to.equal('"value" contains ["txt"] without its required peers ["upc", "code"]');
 
             Helper.validate(schema, [
                 [{}, true],
@@ -369,7 +369,7 @@ describe('Joi', function () {
 
         Joi.validate({ txt: 'x', upc: 'y', code: 123 }, schema, { abortEarly: false }, function (err, value) {
 
-            expect(err.message).to.equal('value txt must not exist simultaneously with upc, code');
+            expect(err.message).to.equal('"value" ["txt"] must not exist simultaneously with ["upc", "code"]');
 
             Helper.validate(schema, [
                 [{}, true],
@@ -406,7 +406,7 @@ describe('Joi', function () {
         schema.validate({ auth: { mode: 'none' } }, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('mode must be one of required, optional, try, null. auth must be a string. auth must be a boolean');
+            expect(err.message).to.equal('"mode" must be one of "required, optional, try, null". "auth" must be a string. "auth" must be a boolean');
 
             Helper.validate(schema, [
                 [{ auth: { mode: 'try' } }, true],
@@ -436,7 +436,7 @@ describe('Joi', function () {
         schema.validate({ auth: { mode: 'none' } }, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('mode must be one of required, optional, try, null. auth must be a string. auth must be a boolean');
+            expect(err.message).to.equal('"mode" must be one of "required, optional, try, null". "auth" must be a string. "auth" must be a boolean');
 
             Helper.validate(schema, [
                 [{ auth: { mode: 'try' } }, true],
@@ -584,11 +584,11 @@ describe('Joi', function () {
 
                 Joi.object().validate(true, function (err, value) {
 
-                    expect(err.message).to.contain('value must be an object');
+                    expect(err.message).to.contain('"value" must be an object');
 
                     Joi.string().validate(true, function (err, value) {
 
-                        expect(err.message).to.contain('value must be a string');
+                        expect(err.message).to.contain('"value" must be a string');
 
                         Joi.string().email().validate('test@test.com', function (err, value) {
 
@@ -635,17 +635,17 @@ describe('Joi', function () {
         Joi.object({}).validate({ foo: 'bar' }, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('foo is not allowed');
+            expect(err.message).to.equal('"foo" is not allowed');
 
             Joi.compile({}).validate({ foo: 'bar' }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('foo is not allowed');
+                expect(err.message).to.equal('"foo" is not allowed');
 
                 Joi.compile({ other: Joi.number() }).validate({ foo: 'bar' }, function (err, value) {
 
                     expect(err).to.exist;
-                    expect(err.message).to.equal('foo is not allowed');
+                    expect(err.message).to.equal('"foo" is not allowed');
 
                     done();
                 });
@@ -664,12 +664,12 @@ describe('Joi', function () {
         Joi.compile(config).validate({ auth: { unknown: true } }, function (err, value) {
 
             expect(err).to.not.be.null;
-            expect(err.message).to.contain('unknown is not allowed');
+            expect(err.message).to.contain('"unknown" is not allowed');
 
             Joi.compile(config).validate({ something: false }, function (err, value) {
 
                 expect(err).to.not.be.null;
-                expect(err.message).to.contain('something is not allowed');
+                expect(err.message).to.contain('"something" is not allowed');
 
                 done();
             });
@@ -691,7 +691,7 @@ describe('Joi', function () {
         Joi.compile(config).validate({}, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.contain('module is required');
+            expect(err.message).to.contain('"module" is required');
 
             Joi.compile(config).validate({ module: 'test' }, function (err, value) {
 
@@ -700,8 +700,8 @@ describe('Joi', function () {
                 Joi.compile(config).validate({ module: {} }, function (err, value) {
 
                     expect(err).to.not.be.null;
-                    expect(err.message).to.contain('compile is required');
-                    expect(err.message).to.contain('module must be a string');
+                    expect(err.message).to.contain('"compile" is required');
+                    expect(err.message).to.contain('"module" must be a string');
 
                     Joi.compile(config).validate({ module: { compile: function () { } } }, function (err, value) {
 
@@ -747,7 +747,7 @@ describe('Joi', function () {
         Joi.compile(config).validate({}, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.contain('module is required');
+            expect(err.message).to.contain('"module" is required');
             done();
         });
     });
@@ -1191,7 +1191,7 @@ describe('Joi', function () {
         Joi.validate(input, schema, { skipFunctions: false }, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.contain('func is not allowed');
+            expect(err.message).to.contain('"func" is not allowed');
             done();
         });
     });
@@ -1443,7 +1443,7 @@ describe('Joi', function () {
             expect(function () {
 
                 Joi.assert('x', Joi.number());
-            }).to.throw('"x"\n\u001b[31m\n[1] value must be a number\u001b[0m');
+            }).to.throw('"x"\n\u001b[31m\n[1] "value" must be a number\u001b[0m');
             done();
         });
 
@@ -1461,7 +1461,7 @@ describe('Joi', function () {
             expect(function () {
 
                 Joi.assert('x', Joi.number(), 'the reason is');
-            }).to.throw('the reason is "x"\n\u001b[31m\n[1] value must be a number\u001b[0m');
+            }).to.throw('the reason is "x"\n\u001b[31m\n[1] "value" must be a number\u001b[0m');
             done();
         });
     });

--- a/test/object.js
+++ b/test/object.js
@@ -443,7 +443,7 @@ describe('object', function () {
 
             Joi.compile(schema).validate({ test1: 'a', test2: 'b' }, function (err, value) {
 
-                expect(err.message).to.equal('value cannot rename child test2 because multiple renames are disabled and another key was already renamed to test');
+                expect(err.message).to.equal('"value" cannot rename child "test2" because multiple renames are disabled and another key was already renamed to "test"');
                 done();
             });
         });
@@ -453,7 +453,7 @@ describe('object', function () {
             Joi.object().rename('a', 'b').rename('c', 'b').rename('d', 'b').options({ abortEarly: false }).validate({ a: 1, c: 1, d: 1 }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value cannot rename child c because multiple renames are disabled and another key was already renamed to b. value cannot rename child d because multiple renames are disabled and another key was already renamed to b');
+                expect(err.message).to.equal('"value" cannot rename child "c" because multiple renames are disabled and another key was already renamed to "b". "value" cannot rename child "d" because multiple renames are disabled and another key was already renamed to "b"');
                 done();
             });
         });
@@ -484,7 +484,7 @@ describe('object', function () {
 
             schema.validate({ test: 'b', test1: 'a' }, function (err, value) {
 
-                expect(err.message).to.equal('value cannot rename child test because override is disabled and target test1 exists');
+                expect(err.message).to.equal('"value" cannot rename child "test" because override is disabled and target "test1" exists');
                 done();
             });
         });
@@ -702,7 +702,7 @@ describe('object', function () {
             Joi.validate({ bb: 'y', 5: 'x' }, schema, { abortEarly: false }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('5 must be a boolean. bb must be one of x');
+                expect(err.message).to.equal('"5" must be a boolean. "bb" must be one of "x"');
 
                 Helper.validate(schema, [
                     [{ a: 5 }, true],
@@ -727,7 +727,7 @@ describe('object', function () {
             Joi.validate({ x: { bb: 'y', 5: 'x' } }, schema, { abortEarly: false }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('5 must be a boolean. bb must be one of x');
+                expect(err.message).to.equal('"5" must be a boolean. "bb" must be one of "x"');
                 done();
             });
         });
@@ -739,7 +739,7 @@ describe('object', function () {
             Joi.validate({ a: 5 }, schema, { abortEarly: false }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('a is not allowed');
+                expect(err.message).to.equal('"a" is not allowed');
                 done();
             });
         });
@@ -884,7 +884,7 @@ describe('object', function () {
             }).validate({ a: { b: { c: 1 } } }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value must contain at least one of x, y');
+                expect(err.message).to.equal('"value" must contain at least one of ["x", "y"]');
                 done();
             });
         });
@@ -907,7 +907,7 @@ describe('object', function () {
             schema.validate({ a: { b: 'x', c: 5 }, d: { e: 6 } }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value validation failed because d.e failed to equal to a.c');
+                expect(err.message).to.equal('"value" validation failed because "d.e" failed to "equal to a.c"');
 
                 Helper.validate(schema, [
                     [{ a: { b: 'x', c: 5 }, d: { e: 5 } }, true]
@@ -930,7 +930,7 @@ describe('object', function () {
             schema.validate({ a: { b: 'x', c: 5 }, d: { e: 6 } }, function (err, value) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value validation failed because d.e failed to equal to a.c');
+                expect(err.message).to.equal('"value" validation failed because "d.e" failed to "equal to a.c"');
 
                 Helper.validate(schema, [
                     [{ a: { b: 'x', c: 5 }, d: { e: 5 } }, true]
@@ -991,7 +991,7 @@ describe('object', function () {
             }, function (err) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value validation failed because d.e failed to pass the assertion test');
+                expect(err.message).to.equal('"value" validation failed because "d.e" failed to "pass the assertion test"');
                 done();
             });
         });
@@ -1007,7 +1007,7 @@ describe('object', function () {
             schema.validate({}, function (err) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value must be an instance of Foo');
+                expect(err.message).to.equal('"value" must be an instance of "Foo"');
                 done();
             });
         });
@@ -1020,7 +1020,7 @@ describe('object', function () {
             schema.validate({}, function (err) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value must be an instance of Bar');
+                expect(err.message).to.equal('"value" must be an instance of "Bar"');
                 done();
             });
         });
@@ -1033,7 +1033,7 @@ describe('object', function () {
             schema.validate({}, function (err) {
 
                 expect(err).to.exist;
-                expect(err.message).to.equal('value must be an instance of Bar');
+                expect(err.message).to.equal('"value" must be an instance of "Bar"');
                 done();
             });
         });

--- a/test/ref.js
+++ b/test/ref.js
@@ -33,7 +33,7 @@ describe('ref', function () {
         schema.validate({ a: 5, b: 6 }, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('a must be one of ref:b');
+            expect(err.message).to.equal('"a" must be one of "ref:b"');
 
             Helper.validate(schema, [
                 [{ a: 5 }, false],
@@ -54,7 +54,7 @@ describe('ref', function () {
         schema.validate({ a: 5, '': 6 }, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('a must be one of ref:');
+            expect(err.message).to.equal('"a" must be one of "ref:"');
 
             Helper.validate(schema, [
                 [{ a: 5 }, false],
@@ -77,7 +77,7 @@ describe('ref', function () {
         schema.validate({ a: 5, b: { c: 6 } }, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('a must be one of ref:b.c');
+            expect(err.message).to.equal('"a" must be one of "ref:b.c"');
 
             Helper.validate(schema, [
                 [{ a: 5 }, false],
@@ -294,7 +294,7 @@ describe('ref', function () {
         Joi.validate({ a: 5, b: 6 }, schema, { context: { x: 22 } }, function (err, value) {
 
             expect(err).to.exist;
-            expect(err.message).to.equal('a must be one of context:x');
+            expect(err.message).to.equal('"a" must be one of "context:x"');
 
             Helper.validateOptions(schema, [
                 [{ a: 5 }, false],

--- a/test/string.js
+++ b/test/string.js
@@ -194,7 +194,7 @@ describe('string', function () {
             var t = Joi.string().creditCard();
             t.validate('4111111111111112', function (err, value) {
 
-                expect(err.message).to.equal('value must be a credit card');
+                expect(err.message).to.equal('"value" must be a credit card');
 
                 Helper.validate(t, [
                     ['378734493671000', true],  // american express
@@ -445,7 +445,7 @@ describe('string', function () {
             var schema = Joi.string().regex(/[a-z]+/, 'letters').regex(/[0-9]+/, 'numbers');
             schema.validate('abcd', function (err, value) {
 
-                expect(err.message).to.contain('numbers pattern');
+                expect(err.message).to.contain('"numbers" pattern');
                 done();
             });
         });


### PR DESCRIPTION
A user of mine complained that the joi output is not verbose enough. It didn't show the value that didn't match the regular expression. I added a few properties and added a new locale support. Right now I only added the value to the string object. While I added this I also added a new approach to encoding. Please treat this as an experimental pull request and a suggestion to discuss if the current way how the differentiation between language code and user messages work.