### PR TITLE
allow passing a method to .default(), for #363

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -314,7 +314,17 @@ internals.Any.prototype.applyFunctionToChildren = function (children, fn, args, 
 };
 
 
-internals.Any.prototype.default = function (value) {
+internals.Any.prototype.default = function (value, description) {
+
+    if (typeof value === 'function' &&
+        !Ref.isRef(value)) {
+
+        if (!value.description) {
+            value.description = description;
+        }
+
+        Hoek.assert(typeof value.description === 'string' && value.description.length > 0, 'description must be provided when default value is a function');
+    }
 
     var obj = this.clone();
     obj._flags.default = value;
@@ -400,6 +410,24 @@ internals.Any.prototype.unit = function (name) {
 };
 
 
+internals._try = function (fn, arg) {
+
+    var err;
+    var result;
+
+    try {
+        result = fn.call(null, arg);
+    } catch (e) {
+        err = e;
+    }
+
+    return {
+        value: result,
+        error: err
+    };
+};
+
+
 internals.Any.prototype._validate = function (value, state, options, reference) {
 
     var self = this;
@@ -416,10 +444,35 @@ internals.Any.prototype._validate = function (value, state, options, reference) 
     var errors = [];
     var finish = function () {
 
+        var finalValue;
+
+        if (value !== undefined) {
+            finalValue = options.raw ? originalValue : value;
+        }
+        else if (Ref.isRef(self._flags.default)) {
+            finalValue = self._flags.default(state.parent, options);
+        }
+        else if (typeof self._flags.default === 'function') {
+            var arg;
+
+            if (state.parent !== null &&
+                self._flags.default.length > 0) {
+
+                arg = Hoek.clone(state.parent);
+            }
+
+            var defaultValue = internals._try(self._flags.default, arg);
+            finalValue = defaultValue.value;
+            if (defaultValue.error) {
+                errors.push(Errors.create('any.default', defaultValue.error, state, options));
+            }
+        }
+        else {
+            finalValue = self._flags.default;
+        }
+
         return {
-            value: (value !== undefined) ?
-                (options.raw ? originalValue : value) :
-                (Ref.isRef(self._flags.default) ? self._flags.default(state.parent, options) : self._flags.default),
+            value: finalValue,
             errors: errors.length ? errors : null
         };
     };

--- a/lib/language.js
+++ b/lib/language.js
@@ -17,7 +17,8 @@ exports.errors = {
         invalid: 'contains an invalid value',
         empty: 'is not allowed to be empty',
         required: 'is required',
-        allowOnly: 'must be one of {{valids}}'
+        allowOnly: 'must be one of {{valids}}',
+        default: 'threw an error when running default method'
     },
     alternatives: {
         base: 'not matching any of the allowed alternatives'

--- a/test/any.js
+++ b/test/any.js
@@ -214,6 +214,149 @@ describe('any', function () {
             });
         });
 
+        it('throws when value is a method and no description is provided', function (done) {
+
+            expect(function () {
+
+                var schema = Joi.object({ foo: Joi.string().default(function () { return 'test'; }) });
+            }).to.throw();
+
+            done();
+        });
+
+        it('allows passing description as a property of a default method', function (done) {
+
+            var defaultFn = function () {
+                
+                return 'test';
+            };
+            defaultFn.description = 'test';
+
+            expect(function () {
+
+                var schema = Joi.object({ foo: Joi.string().default(defaultFn) });
+            }).to.not.throw();
+
+            done();
+        });
+
+        it('sets the value when passing a method', function (done) {
+
+            var schema = Joi.object({ foo: Joi.string().default(function () { return 'test'; }, 'testing') });
+            var input = {};
+
+            schema.validate(input, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value.foo).to.equal('test');
+                done();
+            });
+        });
+
+        it('executes the default method each time validate is called', function (done) {
+
+            var count = 0;
+            var schema = Joi.object({ foo: Joi.number().default(function () { return ++count; }, 'incrementer') });
+            var input = {};
+
+            schema.validate(input, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value.foo).to.equal(1);
+            });
+
+            schema.validate(input, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value.foo).to.equal(2);
+            });
+
+            done();
+        });
+
+        it('passes a clone of the context if the default method accepts an argument', function (done) {
+
+            var schema = Joi.object({
+                foo: Joi.string().default(function (context) { return context.bar + 'ing'; }, 'testing'),
+                bar: Joi.string()
+            });
+            var input = { bar: 'test' };
+
+            schema.validate(input, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value.foo).to.equal('testing');
+                done();
+            });
+        });
+
+        it('does not modify the original object when modifying the clone in a default method', function (done) {
+
+            var defaultFn = function (context) {
+
+                context.bar = 'broken';
+                return 'test';
+            };
+            defaultFn.description = 'testing';
+
+            var schema = Joi.object({
+                foo: Joi.string().default(defaultFn),
+                bar: Joi.string()
+            });
+            var input = { bar: 'test' };
+
+            schema.validate(input, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value.bar).to.equal('test');
+                expect(value.foo).to.equal('test');
+                done();
+            });
+        });
+
+        it('passes undefined as the context if the default method has no parent', function (done) {
+
+            var c;
+            var methodCalled = false;
+            var schema = Joi.string().default(function (context) {
+
+                methodCalled = true;
+                c = context;
+                return 'test';
+            }, 'testing');
+
+            schema.validate(undefined, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(methodCalled).to.equal(true);
+                expect(c).to.equal(undefined);
+                expect(value).to.equal('test');
+                done();
+            });
+        });
+
+        it('catches errors in default methods', function (done) {
+
+            var defaultFn = function () {
+
+                throw new Error('boom');
+            };
+            defaultFn.description = 'broken method';
+
+            var schema = Joi.string().default(defaultFn);
+
+            schema.validate(undefined, function (err, value) {
+
+                expect(err).to.exist();
+                expect(err.details).to.have.length(1);
+                expect(err.details[0].message).to.contain('threw an error when running default method');
+                expect(err.details[0].type).to.equal('any.default');
+                expect(err.details[0].context).to.be.an.instanceof(Error);
+                expect(err.details[0].context.message).to.equal('boom');
+                done();
+            });
+        });
+
         it('should not overide a value when value is given', function (done) {
 
             var schema = Joi.object({ foo: Joi.string().default('bar') });

--- a/test/index.js
+++ b/test/index.js
@@ -1385,6 +1385,17 @@ describe('Joi', function () {
 
     describe('#describe', function () {
 
+        var defaultFn = function () {
+
+            return 'test';
+        };
+        defaultFn.description = 'testing';
+
+        var defaultDescribedFn = function () {
+
+            return 'test';
+        };
+
         var schema = Joi.object({
             sub: {
                 email: Joi.string().email(),
@@ -1398,7 +1409,9 @@ describe('Joi', function () {
             required: Joi.string().required(),
             xor: Joi.string(),
             renamed: Joi.string().valid('456'),
-            notEmpty: Joi.string().required().description('a').notes('b').tags('c')
+            notEmpty: Joi.string().required().description('a').notes('b').tags('c'),
+            defaultFn: Joi.string().default(defaultFn, 'not here'),
+            defaultDescribedFn: Joi.string().default(defaultDescribedFn, 'described test')
         }).rename('renamed', 'required').without('required', 'xor').without('xor', 'required');
 
         var result = {
@@ -1474,6 +1487,20 @@ describe('Joi', function () {
                     notes: ['b'],
                     tags: ['c'],
                     invalids: ['']
+                },
+                defaultFn: {
+                    type: 'string',
+                    flags: {
+                        default: defaultFn
+                    },
+                    invalids: ['']
+                },
+                defaultDescribedFn: {
+                    type: 'string',
+                    flags: {
+                        default: defaultDescribedFn
+                    },
+                    invalids: ['']
                 }
             },
             dependencies: [
@@ -1494,6 +1521,8 @@ describe('Joi', function () {
 
             var description = schema.describe();
             expect(description).to.deep.equal(result);
+            expect(description.children.defaultFn.flags.default.description).to.equal('testing');
+            expect(description.children.defaultDescribedFn.flags.default.description).to.equal('described test');
             done();
         });
 


### PR DESCRIPTION
This covers the use cases of `Date.now`, UUID generation, and other similar methods.