### PR TITLE
Clarify documentation of any.allowed()

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Whitelists a value where:
 - `value` - the allowed value which can be of any type and will be matched against the validated value before applying any other rules.
   `value` can be an array of values, or multiple values can be passed as individual arguments. `value` supports [references](#refkey-options).
 
+Note that this whitelist of allowed values is in *addition* to any other permitted values.  To create an exclusive whitelist of values, see [`any.valid(value)`](#anyvalidvalue).
+
 ```javascript
 var schema = {
     a: Joi.any().allow('a'),


### PR DESCRIPTION
Adding a clarifying statement that values whitelisted by `.allowed()` are not exclusively valid.

It was my own fault for not being familiar enough with the API, but this bit me as a result of assuming that "whitelisted" in the description implied that any not-whitelisted values would be considered invalid. I'm just submitting this to help anyone else who reads this in the same way.