### PR TITLE
Add support for "converter" function to enable conversion of custom types.

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -87,6 +87,7 @@ module.exports = internals.Any = function () {
     this._tags = [];
     this._examples = [];
     this._meta = [];
+    this._convert = null
 
     this._inner = {};                           // Hash of arrays of immutable objects
 };
@@ -114,6 +115,7 @@ internals.Any.prototype.clone = function () {
     obj._tags = this._tags.slice();
     obj._examples = this._examples.slice();
     obj._meta = this._meta.slice();
+    obj._convert = this._convert;
 
     obj._inner = {};
     var inners = Object.keys(this._inner);

--- a/lib/any.js
+++ b/lib/any.js
@@ -87,7 +87,6 @@ module.exports = internals.Any = function () {
     this._tags = [];
     this._examples = [];
     this._meta = [];
-    this._convert = null
 
     this._inner = {};                           // Hash of arrays of immutable objects
 };
@@ -115,7 +114,6 @@ internals.Any.prototype.clone = function () {
     obj._tags = this._tags.slice();
     obj._examples = this._examples.slice();
     obj._meta = this._meta.slice();
-    obj._convert = this._convert;
 
     obj._inner = {};
     var inners = Object.keys(this._inner);

--- a/lib/array.js
+++ b/lib/array.js
@@ -15,6 +15,19 @@ internals.Array = function () {
 
     Any.call(this);
     this._type = 'array';
+    this._convert = function array(value) {
+        if (typeof value === 'string') {
+            try {
+                var converted = JSON.parse(value);
+                if (Array.isArray(converted)) {
+                    value = converted;
+                }
+            }
+            catch (e) { }
+        }
+        return value;
+    };
+
     this._inner.items = [];
     this._inner.inclusions = [];
     this._inner.exclusions = [];
@@ -31,16 +44,8 @@ internals.Array.prototype._base = function (value, state, options) {
         value: value
     };
 
-    if (typeof value === 'string' &&
-        options.convert) {
-
-        try {
-            var converted = JSON.parse(value);
-            if (Array.isArray(converted)) {
-                result.value = converted;
-            }
-        }
-        catch (e) { }
+    if (options.convert) {
+        result.value = this._convert(value);
     }
 
     var isArray = Array.isArray(result.value);

--- a/lib/array.js
+++ b/lib/array.js
@@ -78,6 +78,7 @@ internals.Array.prototype._base = function (value, state, options) {
 
 
 internals.Array.prototype._convert = function (value) {
+
     if (typeof value === 'string') {
         try {
             var converted = JSON.parse(value);
@@ -87,6 +88,7 @@ internals.Array.prototype._convert = function (value) {
         }
         catch (e) { }
     }
+    
     return value;
 };
 

--- a/lib/array.js
+++ b/lib/array.js
@@ -15,19 +15,6 @@ internals.Array = function () {
 
     Any.call(this);
     this._type = 'array';
-    this._convert = function array(value) {
-        if (typeof value === 'string') {
-            try {
-                var converted = JSON.parse(value);
-                if (Array.isArray(converted)) {
-                    value = converted;
-                }
-            }
-            catch (e) { }
-        }
-        return value;
-    };
-
     this._inner.items = [];
     this._inner.inclusions = [];
     this._inner.exclusions = [];
@@ -87,6 +74,20 @@ internals.Array.prototype._base = function (value, state, options) {
     }
 
     return result;
+};
+
+
+internals.Array.prototype._convert = function (value) {
+    if (typeof value === 'string') {
+        try {
+            var converted = JSON.parse(value);
+            if (Array.isArray(converted)) {
+                value = converted;
+            }
+        }
+        catch (e) { }
+    }
+    return value;
 };
 
 

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -35,12 +35,14 @@ internals.Binary.prototype._base = function (value, state, options) {
 
 
 internals.Binary.prototype._convert = function (value) {
+
     if (typeof value === 'string') {
         try {
             value = new Buffer(value, this._flags.encoding);
         }
         catch (e) { }
     }
+
     return value;
 };
 

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -14,16 +14,6 @@ internals.Binary = function () {
 
     Any.call(this);
     this._type = 'binary';
-    this._convert = function binary(value) {
-        if (typeof value === 'string') {
-            try {
-                var converted = new Buffer(value, this._flags.encoding);
-                value = converted;
-            }
-            catch (e) { }
-        }
-        return value;
-    };
 };
 
 Hoek.inherits(internals.Binary, Any);
@@ -41,6 +31,17 @@ internals.Binary.prototype._base = function (value, state, options) {
 
     result.errors = Buffer.isBuffer(result.value) ? null : Errors.create('binary.base', null, state, options);
     return result;
+};
+
+
+internals.Binary.prototype._convert = function (value) {
+    if (typeof value === 'string') {
+        try {
+            value = new Buffer(value, this._flags.encoding);
+        }
+        catch (e) { }
+    }
+    return value;
 };
 
 

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -14,6 +14,16 @@ internals.Binary = function () {
 
     Any.call(this);
     this._type = 'binary';
+    this._convert = function binary(value) {
+        if (typeof value === 'string') {
+            try {
+                var converted = new Buffer(value, this._flags.encoding);
+                value = converted;
+            }
+            catch (e) { }
+        }
+        return value;
+    };
 };
 
 Hoek.inherits(internals.Binary, Any);
@@ -25,14 +35,8 @@ internals.Binary.prototype._base = function (value, state, options) {
         value: value
     };
 
-    if (typeof value === 'string' &&
-        options.convert) {
-
-        try {
-            var converted = new Buffer(value, this._flags.encoding);
-            result.value = converted;
-        }
-        catch (e) { }
+    if (options.convert) {
+        result.value = this._convert(value);
     }
 
     result.errors = Buffer.isBuffer(result.value) ? null : Errors.create('binary.base', null, state, options);

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -14,6 +14,14 @@ internals.Boolean = function () {
 
     Any.call(this);
     this._type = 'boolean';
+    this._convert = function boolean(value) {
+        if (typeof value === 'string') {
+            var lower = value.toLowerCase();
+            value = (lower === 'true' || lower === 'yes' || lower === 'on' ? true
+                                                                           : (lower === 'false' || lower === 'no' || lower === 'off' ? false : value));
+        }
+        return value;
+    };
 };
 
 Hoek.inherits(internals.Boolean, Any);
@@ -25,12 +33,8 @@ internals.Boolean.prototype._base = function (value, state, options) {
         value: value
     };
 
-    if (typeof value === 'string' &&
-        options.convert) {
-
-        var lower = value.toLowerCase();
-        result.value = (lower === 'true' || lower === 'yes' || lower === 'on' ? true
-                                                                              : (lower === 'false' || lower === 'no' || lower === 'off' ? false : value));
+    if (options.convert) {
+        result.value = this._convert(value);
     }
 
     result.errors = (typeof result.value === 'boolean') ? null : Errors.create('boolean.base', null, state, options);

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -35,11 +35,13 @@ internals.Boolean.prototype._base = function (value, state, options) {
 
 
 internals.Boolean.prototype._convert = function (value) {
+
     if (typeof value === 'string') {
         var lower = value.toLowerCase();
         value = (lower === 'true' || lower === 'yes' || lower === 'on' ? true
                                                                        : (lower === 'false' || lower === 'no' || lower === 'off' ? false : value));
     }
+
     return value;
 };
 

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -14,14 +14,6 @@ internals.Boolean = function () {
 
     Any.call(this);
     this._type = 'boolean';
-    this._convert = function boolean(value) {
-        if (typeof value === 'string') {
-            var lower = value.toLowerCase();
-            value = (lower === 'true' || lower === 'yes' || lower === 'on' ? true
-                                                                           : (lower === 'false' || lower === 'no' || lower === 'off' ? false : value));
-        }
-        return value;
-    };
 };
 
 Hoek.inherits(internals.Boolean, Any);
@@ -39,6 +31,16 @@ internals.Boolean.prototype._base = function (value, state, options) {
 
     result.errors = (typeof result.value === 'boolean') ? null : Errors.create('boolean.base', null, state, options);
     return result;
+};
+
+
+internals.Boolean.prototype._convert = function (value) {
+    if (typeof value === 'string') {
+        var lower = value.toLowerCase();
+        value = (lower === 'true' || lower === 'yes' || lower === 'on' ? true
+                                                                       : (lower === 'false' || lower === 'no' || lower === 'off' ? false : value));
+    }
+    return value;
 };
 
 

--- a/lib/date.js
+++ b/lib/date.js
@@ -27,9 +27,6 @@ internals.Date = function () {
 
     Any.call(this);
     this._type = 'date';
-    this._convert = function date(value) {
-        return internals.toDate(value, this._flags.format);
-    };
 };
 
 Hoek.inherits(internals.Date, Any);
@@ -53,6 +50,11 @@ internals.Date.prototype._base = function (value, state, options) {
     }
 
     return result;
+};
+
+
+internals.Date.prototype._convert = function (value) {
+    return internals.toDate(value, this._flags.format);
 };
 
 

--- a/lib/date.js
+++ b/lib/date.js
@@ -27,6 +27,9 @@ internals.Date = function () {
 
     Any.call(this);
     this._type = 'date';
+    this._convert = function date(value) {
+        return internals.toDate(value, this._flags.format);
+    };
 };
 
 Hoek.inherits(internals.Date, Any);
@@ -35,8 +38,12 @@ Hoek.inherits(internals.Date, Any);
 internals.Date.prototype._base = function (value, state, options) {
 
     var result = {
-        value: (options.convert && internals.toDate(value, this._flags.format)) || value
+        value: value
     };
+
+    if (options.convert) {
+        result.value = this._convert(value);
+    }
 
     if (result.value instanceof Date && !isNaN(result.value.getTime())) {
         result.errors = null;

--- a/lib/date.js
+++ b/lib/date.js
@@ -54,6 +54,7 @@ internals.Date.prototype._base = function (value, state, options) {
 
 
 internals.Date.prototype._convert = function (value) {
+
     return internals.toDate(value, this._flags.format);
 };
 

--- a/lib/number.js
+++ b/lib/number.js
@@ -46,10 +46,12 @@ internals.Number.prototype._base = function (value, state, options) {
 
 
 internals.Number.prototype._convert = function (value) {
+
     if (typeof value === 'string') {
         var number = parseFloat(value);
         value = (isNaN(number) || !isFinite(value)) ? NaN : number;
     }
+
     return value;
 };
 

--- a/lib/number.js
+++ b/lib/number.js
@@ -16,13 +16,6 @@ internals.Number = function () {
     this._type = 'number';
     this._invalids.add(Infinity);
     this._invalids.add(-Infinity);
-    this._convert = function number(value) {
-        if (typeof value === 'string') {
-            var number = parseFloat(value);
-            value = (isNaN(number) || !isFinite(value)) ? NaN : number;
-        }
-        return value;
-    };
 };
 
 Hoek.inherits(internals.Number, Any);
@@ -49,6 +42,15 @@ internals.Number.prototype._base = function (value, state, options) {
 
     result.errors = isNumber ? null : Errors.create('number.base', null, state, options);
     return result;
+};
+
+
+internals.Number.prototype._convert = function (value) {
+    if (typeof value === 'string') {
+        var number = parseFloat(value);
+        value = (isNaN(number) || !isFinite(value)) ? NaN : number;
+    }
+    return value;
 };
 
 

--- a/lib/number.js
+++ b/lib/number.js
@@ -16,6 +16,13 @@ internals.Number = function () {
     this._type = 'number';
     this._invalids.add(Infinity);
     this._invalids.add(-Infinity);
+    this._convert = function number(value) {
+        if (typeof value === 'string') {
+            var number = parseFloat(value);
+            value = (isNaN(number) || !isFinite(value)) ? NaN : number;
+        }
+        return value;
+    };
 };
 
 Hoek.inherits(internals.Number, Any);
@@ -28,11 +35,8 @@ internals.Number.prototype._base = function (value, state, options) {
         value: value
     };
 
-    if (typeof value === 'string' &&
-        options.convert) {
-
-        var number = parseFloat(value);
-        result.value = (isNaN(number) || !isFinite(value)) ? NaN : number;
+    if (options.convert) {
+        result.value = this._convert(value);
     }
 
     var isNumber = typeof result.value === 'number' && !isNaN(result.value);

--- a/lib/object.js
+++ b/lib/object.js
@@ -16,16 +16,6 @@ internals.Object = function () {
 
     Any.call(this);
     this._type = 'object';
-    this._convert = function object(value) {
-        if (typeof value === 'string') {
-            try {
-                value = JSON.parse(value);
-            }
-            catch (err) { }
-        }
-        return value;
-    };
-
     this._inner.children = null;
     this._inner.renames = [];
     this._inner.dependencies = [];
@@ -240,6 +230,17 @@ internals.Object.prototype._base = function (value, state, options) {
     }
 
     return finish();
+};
+
+
+internals.Object.prototype._convert = function (value) {
+    if (typeof value === 'string') {
+        try {
+            value = JSON.parse(value);
+        }
+        catch (err) { }
+    }
+    return value;
 };
 
 
@@ -704,7 +705,10 @@ internals.Object.prototype.type = function (constructor/*, name, converter*/) {
         return Errors.create('object.type', { type: name }, state, options);
     });
 
-    clone._convert = converter || clone._convert;
+    if (converter) {
+        // Override the converter _only for this instance_.
+        clone._convert = converter;
+    }
 
     return clone;
 };

--- a/lib/object.js
+++ b/lib/object.js
@@ -678,12 +678,24 @@ internals.Object.prototype.assert = function (ref, schema, message) {
 };
 
 
-internals.Object.prototype.type = function (constructor, name) {
+internals.Object.prototype.type = function (constructor/*, name, converter*/) {
 
     Hoek.assert(typeof constructor === 'function', 'type must be a constructor function');
-    name = name || constructor.name;
 
-    return this._test('type', name, function (value, state, options) {
+    var name = constructor.name;
+    var converter = null;
+
+    var next = arguments[1];
+    if (typeof next === 'string') {
+        name = next;
+        next = arguments[2];
+    }
+
+    if (typeof next === 'function') {
+        converter = next;
+    }
+
+    var clone = this._test('type', name, function (value, state, options) {
 
         if (value instanceof constructor) {
             return null;
@@ -691,6 +703,10 @@ internals.Object.prototype.type = function (constructor, name) {
 
         return Errors.create('object.type', { type: name }, state, options);
     });
+
+    clone._convert = converter || clone._convert;
+
+    return clone;
 };
 
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -234,12 +234,14 @@ internals.Object.prototype._base = function (value, state, options) {
 
 
 internals.Object.prototype._convert = function (value) {
+
     if (typeof value === 'string') {
         try {
             value = JSON.parse(value);
         }
         catch (err) { }
     }
+
     return value;
 };
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -16,6 +16,16 @@ internals.Object = function () {
 
     Any.call(this);
     this._type = 'object';
+    this._convert = function object(value) {
+        if (typeof value === 'string') {
+            try {
+                value = JSON.parse(value);
+            }
+            catch (err) { }
+        }
+        return value;
+    };
+
     this._inner.children = null;
     this._inner.renames = [];
     this._inner.dependencies = [];
@@ -37,13 +47,8 @@ internals.Object.prototype._base = function (value, state, options) {
         };
     };
 
-    if (typeof value === 'string' &&
-        options.convert) {
-
-        try {
-            value = JSON.parse(value);
-        }
-        catch (err) { }
+    if (options.convert) {
+        value = this._convert(value);
     }
 
     if (!value ||

--- a/lib/string.js
+++ b/lib/string.js
@@ -36,6 +36,7 @@ internals.String.prototype._base = function (value, state, options) {
 
 
 internals.String.prototype._convert = function (value) {
+
     if (typeof value === 'string') {
         if (this._flags.case) {
             value = (this._flags.case === 'upper' ? value.toLocaleUpperCase() : value.toLocaleLowerCase());
@@ -45,6 +46,7 @@ internals.String.prototype._convert = function (value) {
             value = value.trim();
         }
     }
+
     return value;
 };
 

--- a/lib/string.js
+++ b/lib/string.js
@@ -17,18 +17,6 @@ internals.String = function () {
     Any.call(this);
     this._type = 'string';
     this._invalids.add('');
-    this._convert = function string(value) {
-        if (typeof value === 'string') {
-            if (this._flags.case) {
-                value = (this._flags.case === 'upper' ? value.toLocaleUpperCase() : value.toLocaleLowerCase());
-            }
-
-            if (this._flags.trim) {
-                value = value.trim();
-            }
-        }
-        return value;
-    };
 };
 
 Hoek.inherits(internals.String, Any);
@@ -44,6 +32,20 @@ internals.String.prototype._base = function (value, state, options) {
         value: value,
         errors: (typeof value === 'string') ? null : Errors.create('string.base', { value: value }, state, options)
     };
+};
+
+
+internals.String.prototype._convert = function (value) {
+    if (typeof value === 'string') {
+        if (this._flags.case) {
+            value = (this._flags.case === 'upper' ? value.toLocaleUpperCase() : value.toLocaleLowerCase());
+        }
+
+        if (this._flags.trim) {
+            value = value.trim();
+        }
+    }
+    return value;
 };
 
 

--- a/lib/string.js
+++ b/lib/string.js
@@ -17,6 +17,18 @@ internals.String = function () {
     Any.call(this);
     this._type = 'string';
     this._invalids.add('');
+    this._convert = function string(value) {
+        if (typeof value === 'string') {
+            if (this._flags.case) {
+                value = (this._flags.case === 'upper' ? value.toLocaleUpperCase() : value.toLocaleLowerCase());
+            }
+
+            if (this._flags.trim) {
+                value = value.trim();
+            }
+        }
+        return value;
+    };
 };
 
 Hoek.inherits(internals.String, Any);
@@ -24,16 +36,8 @@ Hoek.inherits(internals.String, Any);
 
 internals.String.prototype._base = function (value, state, options) {
 
-    if (typeof value === 'string' &&
-        options.convert) {
-
-        if (this._flags.case) {
-            value = (this._flags.case === 'upper' ? value.toLocaleUpperCase() : value.toLocaleLowerCase());
-        }
-
-        if (this._flags.trim) {
-            value = value.trim();
-        }
+    if (options.convert) {
+        value = this._convert(value);
     }
 
     return {

--- a/test/binary.js
+++ b/test/binary.js
@@ -35,6 +35,28 @@ describe('binary', function () {
         });
     });
 
+    it('validates a buffer with conversion disabled', function (done) {
+
+        Joi.validate(new Buffer('test'), Joi.binary(), { convert: false }, function (err, value) {
+
+            expect(err).to.not.exist();
+            expect(value instanceof Buffer).to.equal(true);
+            expect(value.length).to.equal(4);
+            expect(value.toString('utf8')).to.equal('test');
+            done();
+        });
+    });
+
+    it('returns an error when string conversion is disabled', function (done) {
+
+        Joi.validate('test', Joi.binary(), { convert: false }, function (err, value) {
+
+            expect(err).to.exist();
+            expect(err.message).to.equal('"value" must be a buffer or a string');
+            done();
+        });
+    });
+
     it('validates allowed buffer content', function (done) {
 
         var hello = new Buffer('hello');

--- a/test/object.js
+++ b/test/object.js
@@ -1054,5 +1054,42 @@ describe('object', function () {
             expect(description.rules).to.deep.include({ name: 'type', arg: 'RegExp' });
             done();
         });
+
+        it('uses custom converter if supplied', function (done) {
+
+            function Foo (obj) {
+                this.foo = obj.foo;
+            }
+
+            var schema = Joi.object().type(Foo, function (value) {
+                return new Foo(value);
+            });
+
+            schema.validate({ foo: 'bar' }, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value instanceof Foo).to.equal(true);
+                expect(value.foo).to.equal('bar');
+                done();
+            });
+        });
+
+        it('overrides constructor name with custom name when converter present', function (done) {
+
+            function Foo (obj) {
+                this.foo = obj.foo;
+            }
+
+            var schema = Joi.object().type(Foo, 'Bar', function (value) {
+                return value;
+            });
+
+            schema.validate({ foo: 'bar' }, function (err) {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('"value" must be an instance of "Bar"');
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixes #574.

This feature allows users of the `type(constructor, [name])` API to specify a function that is responsible for converting the provided value to the desired type. The new signature is `type(constructor, [name], [converter]);`

##### Example
```javascript
function Foo(obj) {
    this.value = obj.value;
}

var schema = Joi.object(Foo, function convert(value) {
    return new Foo(value);
});

schema.validate({ value: 'foo'}, function (err, value) {
    console.log(value instanceof Foo); // true
});
```

##### Changes
- [x] Extract converter implementations to the `_convert` method on the prototypes of each respective type.
- [x] Add support for additional optional parameter `"converter"` to the `type` signature.
- [x] Override the default converter by adding an instance property of the same name ('_convert') to the _specific schema instance_ requiring customization, only when a converter is provided.
- [x] Add tests with 100% coverage.