### PR TITLE
Add ability to specify `isnt` with alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,12 +488,13 @@ Converts the type into an [`alternatives`](#alternatives) type where the conditi
 - `ref` - the key name or [reference](#refkey-options).
 - `options` - an object with:
     - `is` - the required condition **joi** type.
+    - `isnt` - the condition **joi** type required to not be met
     - `then` - the alternative schema type if the condition is true. Required if `otherwise` is missing.
     - `otherwise` - the alternative schema type if the condition is false. Required if `then` is missing.
 
 ```javascript
 var schema = {
-    a: Joi.any().valid('x').when('b', { is: 5, then: Joi.valid('y'), otherwise: Joi.valid('z') }),
+    a: Joi.any().valid('x').when('b', { is: Joi.number(), isnt: 5, then: Joi.valid('y'), otherwise: Joi.valid('z') }),
     b: Joi.any()
 };
 ```

--- a/lib/alternatives.js
+++ b/lib/alternatives.js
@@ -31,7 +31,21 @@ internals.Alternatives.prototype._base = function (value, state, options) {
         var item = this._inner.matches[i];
         var schema = item.schema;
         if (!schema) {
-            var failed = item.is._validate(item.ref(state.parent, options), null, options, state.parent).errors;
+            var failed,
+                refToValidate = item.ref(state.parent, options);
+
+            if (item.is !== undefined) {
+                failed = item.is._validate(refToValidate, null, options, state.parent).errors;
+            }
+
+            if (item.isnt !== undefined) {
+                var errs = item.isnt._validate(refToValidate, null, options, state.parent).errors;
+                if (!errs) {
+                    var isntError = Errors.create('alternative.isnt', { value: refToValidate }, state, options);
+                    failed = failed ? failed.push(isntError) : [isntError];
+                }
+            }
+
             schema = failed ? item.otherwise : item.then;
             if (!schema) {
                 continue;
@@ -75,20 +89,28 @@ internals.Alternatives.prototype.when = function (ref, options) {
     Hoek.assert(Ref.isRef(ref) || typeof ref === 'string', 'Invalid reference:', ref);
     Hoek.assert(options, 'Missing options');
     Hoek.assert(typeof options === 'object', 'Invalid options');
-    Hoek.assert(options.hasOwnProperty('is'), 'Missing "is" directive');
+    Hoek.assert(options.hasOwnProperty('is') || options.hasOwnProperty('isnt'), 'Missing "is" or "isnt" directive');
     Hoek.assert(options.then !== undefined || options.otherwise !== undefined, 'options must have at least one of "then" or "otherwise"');
 
     var obj = this.clone();
 
     var item = {
         ref: Cast.ref(ref),
-        is: Cast.schema(options.is),
+        is: options.hasOwnProperty('is') ? Cast.schema(options.is) : undefined,
+        isnt: options.hasOwnProperty('isnt') ? Cast.schema(options.isnt) : undefined,
         then: options.then !== undefined ? Cast.schema(options.then) : undefined,
         otherwise: options.otherwise !== undefined ? Cast.schema(options.otherwise) : undefined
     };
 
     Ref.push(obj._refs, item.ref);
-    obj._refs = obj._refs.concat(item.is._refs);
+
+    if (item.is) {
+        obj._refs = obj._refs.concat(item.is._refs);
+    }
+
+    if (item.isnt) {
+        obj._refs = obj._refs.concat(item.isnt._refs);
+    }
 
     if (item.then && item.then._refs) {
         obj._refs = obj._refs.concat(item.then._refs);
@@ -121,9 +143,16 @@ internals.Alternatives.prototype.describe = function () {
             // when()
 
             var when = {
-                ref: item.ref.toString(),
-                is: item.is.describe()
+                ref: item.ref.toString()
             };
+
+            if (item.is) {
+                when.is = item.is.describe();
+            }
+
+            if (item.isnt) {
+                when.isnt = item.isnt.describe();
+            }
 
             if (item.then) {
                 when.then = item.then.describe();

--- a/lib/language.js
+++ b/lib/language.js
@@ -21,7 +21,8 @@ exports.errors = {
         default: 'threw an error when running default method'
     },
     alternatives: {
-        base: 'not matching any of the allowed alternatives'
+        base: 'not matching any of the allowed alternatives',
+        isnt: 'matched isn\'t when it shouldn\'t have'
     },
     array: {
         base: 'must be an array',


### PR DESCRIPTION
This PR adds the ability to specify an `isnt` condition with alternatives. Providing some additional validation to occur for the alternatives. I have a few projects where I'm having to enforce this through some logic instead of through Joi, so I figured I would add the functionality.

The only thing I don't particularly like about this implementation right now is the [Error messages](https://github.com/DavidTPate/joi/blob/c6851eb8af20fc2937b7b9e7bc067fe9ea940cf5/lib/alternatives.js#L44). Figured I would submit it to see if I should iron it out a little bit more, it's mostly a PoC right now.

This will provide the ability to do things like:

```js
var schema = {
  a: Joi.alternatives().when('b', { is: Joi.number(), isnt:42, then: 'x', otherwise: 'y' }),
  b: Joi.any()
};
```

This way we could validate that `b` is a number but that it isn't `42` and then use that to choose our alternative.