### PR TITLE
Add reference support for Number.min/max/greater/less

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,15 @@ Specifies the minimum value where:
 var schema = Joi.number().min(2);
 ```
 
+It can also be a reference to another field.
+
+```javascript
+var schema = Joi.object({
+  min: Joi.number().required(),
+  max: Joi.number().min(Joi.ref('min')).required()
+});
+```
+
 #### `number.max(limit)`
 
 Specifies the maximum value where:
@@ -789,6 +798,15 @@ Specifies the maximum value where:
 
 ```javascript
 var schema = Joi.number().max(10);
+```
+
+It can also be a reference to another field.
+
+```javascript
+var schema = Joi.object({
+  min: Joi.number().max(Joi.ref('max')).required(),
+  max: Joi.number().required()
+});
 ```
 
 #### `number.greater(limit)`
@@ -799,12 +817,28 @@ Specifies that the value must be greater than `limit`.
 var schema = Joi.number().greater(5);
 ```
 
+```javascript
+var schema = Joi.object({
+  min: Joi.number().required(),
+  max: Joi.number().greater(Joi.ref('min')).required()
+});
+```
+
 #### `number.less(limit)`
 
 Specifies that the value must be less than `limit`.
 
 ```javascript
 var schema = Joi.number().less(10);
+```
+
+It can also be a reference to another field.
+
+```javascript
+var schema = Joi.object({
+  min: Joi.number().less(Joi.ref('max')).required(),
+  max: Joi.number().required()
+});
 ```
 
 #### `number.integer()`

--- a/lib/language.js
+++ b/lib/language.js
@@ -91,6 +91,7 @@ exports.errors = {
         negative: 'must be a negative number',
         positive: 'must be a positive number',
         precision: 'must have no more than {{limit}} decimal places',
+        ref: 'references "{{ref}}" which is not a number',
         multiple: 'must be a multiple of {{multiple}}'
     },
     string: {

--- a/lib/number.js
+++ b/lib/number.js
@@ -38,7 +38,8 @@ internals.compare = function (type, compare) {
                 if (!Hoek.isInteger(compareTo)) {
                     return Errors.create('number.ref', { ref: limit.key }, state, options);
                 }
-            } else {
+            }
+            else {
                 compareTo = limit;
             }
 

--- a/lib/number.js
+++ b/lib/number.js
@@ -1,6 +1,7 @@
 // Load modules
 
 var Any = require('./any');
+var Ref = require('./ref');
 var Errors = require('./errors');
 var Hoek = require('hoek');
 
@@ -19,6 +20,36 @@ internals.Number = function () {
 };
 
 Hoek.inherits(internals.Number, Any);
+
+internals.compare = function (type, compare) {
+
+    return function (limit) {
+
+        var isRef = Ref.isRef(limit);
+
+        Hoek.assert(Hoek.isInteger(limit) || isRef, 'limit must be an integer or reference');
+
+        return this._test(type, limit, function (value, state, options) {
+
+            var compareTo;
+            if (isRef) {
+                compareTo = limit(state.parent);
+
+                if (!Hoek.isInteger(compareTo)) {
+                    return Errors.create('number.ref', { ref: limit.key }, state, options);
+                }
+            } else {
+                compareTo = limit;
+            }
+
+            if (compare(value, compareTo)) {
+                return null;
+            }
+
+            return Errors.create('number.' + type, { limit: compareTo, value: value }, state, options);
+        });
+    };
+};
 
 
 internals.Number.prototype._base = function (value, state, options) {
@@ -48,64 +79,28 @@ internals.Number.prototype._base = function (value, state, options) {
 };
 
 
-internals.Number.prototype.min = function (limit) {
+internals.Number.prototype.min = internals.compare('min', function (value, limit) {
 
-    Hoek.assert(Hoek.isInteger(limit), 'limit must be an integer');
-
-    return this._test('min', limit, function (value, state, options) {
-
-        if (value >= limit) {
-            return null;
-        }
-
-        return Errors.create('number.min', { limit: limit, value: value }, state, options);
-    });
-};
+    return value >= limit;
+});
 
 
-internals.Number.prototype.max = function (limit) {
+internals.Number.prototype.max = internals.compare('max', function (value, limit) {
 
-    Hoek.assert(Hoek.isInteger(limit), 'limit must be an integer');
-
-    return this._test('max', limit, function (value, state, options) {
-
-        if (value <= limit) {
-            return null;
-        }
-
-        return Errors.create('number.max', { limit: limit, value: value }, state, options);
-    });
-};
+    return value <= limit;
+});
 
 
-internals.Number.prototype.greater = function (limit) {
+internals.Number.prototype.greater = internals.compare('greater', function (value, limit) {
 
-    Hoek.assert(Hoek.isInteger(limit), 'limit must be an integer');
-
-    return this._test('greater', limit, function (value, state, options) {
-
-        if (value > limit) {
-            return null;
-        }
-
-        return Errors.create('number.greater', { limit: limit, value: value }, state, options);
-    });
-};
+    return value > limit;
+});
 
 
-internals.Number.prototype.less = function (limit) {
+internals.Number.prototype.less = internals.compare('less', function (value, limit) {
 
-    Hoek.assert(Hoek.isInteger(limit), 'limit must be an integer');
-
-    return this._test('less', limit, function (value, state, options) {
-
-        if (value < limit) {
-            return null;
-        }
-
-        return Errors.create('number.less', { limit: limit, value: value }, state, options);
-    });
-};
+    return value < limit;
+});
 
 
 internals.Number.prototype.multiple = function (base) {

--- a/test/number.js
+++ b/test/number.js
@@ -521,14 +521,14 @@ describe('number', function () {
             expect(function () {
 
                 Joi.number().min('a');
-            }).to.throw('limit must be an integer');
+            }).to.throw('limit must be an integer or reference');
             done();
         });
 
         it('supports 64bit numbers', function (done) {
 
             var schema = Joi.number().min(1394035612500);
-            var input = 1394035612552
+            var input = 1394035612552;
 
             schema.validate(input, function (err, value) {
 
@@ -536,6 +536,26 @@ describe('number', function () {
                 expect(value).to.equal(input);
                 done();
             });
+        });
+
+        it('accepts references as min value', function(done) {
+
+            var schema = Joi.object({ a: Joi.number(), b: Joi.number().min(Joi.ref('a')) });
+
+            Helper.validate(schema, [
+                [{ a: 42, b: 1337 }, true],
+                [{ a: 1337, b: 42 }, false],
+                [{ a: '1337', b: 42 }, false, null, 'child "b" fails because ["b" must be larger than or equal to 1337]']
+            ], done);
+        });
+
+        it('errors if reference is not a number', function(done) {
+
+            var schema = Joi.object({ a: Joi.string(), b: Joi.number().min(Joi.ref('a')) });
+
+            Helper.validate(schema, [
+                [{ a: 'abc', b: 42 }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
         });
     });
 
@@ -546,8 +566,92 @@ describe('number', function () {
             expect(function () {
 
                 Joi.number().max('a');
-            }).to.throw('limit must be an integer');
+            }).to.throw('limit must be an integer or reference');
             done();
+        });
+
+        it('accepts references as max value', function(done) {
+
+            var schema = Joi.object({ a: Joi.number(), b: Joi.number().max(Joi.ref('a')) });
+
+            Helper.validate(schema, [
+                [{ a: 1337, b: 42 }, true],
+                [{ a: 42, b: 1337 }, false],
+                [{ a: '42', b: 1337 }, false, null, 'child "b" fails because ["b" must be less than or equal to 42]']
+            ], done);
+        });
+
+        it('errors if reference is not a number', function(done) {
+
+            var schema = Joi.object({ a: Joi.string(), b: Joi.number().max(Joi.ref('a')) });
+
+            Helper.validate(schema, [
+                [{ a: 'abc', b: 42 }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+    });
+
+    describe('#less', function () {
+
+        it('throws when limit is not a number', function (done) {
+
+            expect(function () {
+
+                Joi.number().less('a');
+            }).to.throw('limit must be an integer or reference');
+            done();
+        });
+
+        it('accepts references as less value', function(done) {
+
+            var schema = Joi.object({ a: Joi.number(), b: Joi.number().less(Joi.ref('a')) });
+
+            Helper.validate(schema, [
+                [{ a: 1337, b: 42 }, true],
+                [{ a: 42, b: 1337 }, false],
+                [{ a: '42', b: 1337 }, false, null, 'child "b" fails because ["b" must be less than 42]']
+            ], done);
+        });
+
+        it('errors if reference is not a number', function(done) {
+
+            var schema = Joi.object({ a: Joi.string(), b: Joi.number().less(Joi.ref('a')) });
+
+            Helper.validate(schema, [
+                [{ a: 'abc', b: 42 }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+    });
+
+    describe('#greater', function () {
+
+        it('throws when limit is not a number', function (done) {
+
+            expect(function () {
+
+                Joi.number().greater('a');
+            }).to.throw('limit must be an integer or reference');
+            done();
+        });
+
+        it('accepts references as greater value', function(done) {
+
+            var schema = Joi.object({ a: Joi.number(), b: Joi.number().greater(Joi.ref('a')) });
+
+            Helper.validate(schema, [
+                [{ a: 42, b: 1337 }, true],
+                [{ a: 1337, b: 42 }, false],
+                [{ a: '1337', b: 42 }, false, null, 'child "b" fails because ["b" must be greater than 1337]']
+            ], done);
+        });
+
+        it('errors if reference is not a number', function(done) {
+
+            var schema = Joi.object({ a: Joi.string(), b: Joi.number().greater(Joi.ref('a')) });
+
+            Helper.validate(schema, [
+                [{ a: 'abc', b: 42 }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
         });
     });
 


### PR DESCRIPTION
This PR adds the ability to pass a reference for the `min`, `max`, `greater`, and `less` validation properties along with the associated documentation.