### PR TITLE
Add reference support for String.min/max/length

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,15 @@ Specifies the minimum number string characters where:
 var schema = Joi.string().min(2);
 ```
 
+It can also be a reference to another field.
+
+```javascript
+var schema = Joi.object({
+  min: Joi.string().required(),
+  value: Joi.string().min(Joi.ref('min'), 'utf8').required()
+});
+```
+
 #### `string.max(limit, [encoding])`
 
 Specifies the maximum number of string characters where:
@@ -1109,6 +1118,15 @@ Specifies the maximum number of string characters where:
 
 ```javascript
 var schema = Joi.string().max(10);
+```
+
+It can also be a reference to another field.
+
+```javascript
+var schema = Joi.object({
+  max: Joi.string().required(),
+  value: Joi.string().max(Joi.ref('max'), 'utf8').required()
+});
 ```
 
 #### `string.creditCard()`
@@ -1128,6 +1146,15 @@ Specifies the exact string length required where:
 
 ```javascript
 var schema = Joi.string().length(5);
+```
+
+It can also be a reference to another field.
+
+```javascript
+var schema = Joi.object({
+  length: Joi.string().required(),
+  value: Joi.string().length(Joi.ref('length'), 'utf8').required()
+});
 ```
 
 #### `string.regex(pattern, [name])`

--- a/lib/language.js
+++ b/lib/language.js
@@ -114,6 +114,7 @@ exports.errors = {
         lowercase: 'must only contain lowercase characters',
         uppercase: 'must only contain uppercase characters',
         trim: 'must not have leading or trailing whitespace',
-        creditCard: 'must be a credit card'
+        creditCard: 'must be a credit card',
+        ref: 'references "{{ref}}" which is not a number'
     }
 };

--- a/lib/string.js
+++ b/lib/string.js
@@ -4,6 +4,7 @@ var Net = require('net');
 var Hoek = require('hoek');
 var Isemail = require('isemail');
 var Any = require('./any');
+var Ref = require('./ref');
 var JoiDate = require('./date');
 var Errors = require('./errors');
 
@@ -23,6 +24,38 @@ internals.String = function () {
 };
 
 Hoek.inherits(internals.String, Any);
+
+internals.compare = function (type, compare) {
+
+    return function (limit, encoding) {
+
+        var isRef = Ref.isRef(limit);
+
+        Hoek.assert((Hoek.isInteger(limit) && limit >= 0) || isRef, 'limit must be a positive integer or reference');
+        Hoek.assert(!encoding || Buffer.isEncoding(encoding), 'Invalid encoding:', encoding);
+
+        return this._test(type, limit, function (value, state, options) {
+
+            var compareTo;
+            if (isRef) {
+                compareTo = limit(state.parent);
+
+                if (!Hoek.isInteger(compareTo)) {
+                    return Errors.create('string.ref', { ref: limit.key }, state, options);
+                }
+            }
+            else {
+                compareTo = limit;
+            }
+
+            if (compare(value, compareTo, encoding)) {
+                return null;
+            }
+
+            return Errors.create('string.' + type, { limit: compareTo, value: value, encoding: encoding }, state, options);
+        });
+    };
+};
 
 internals.String.prototype._base = function (value, state, options) {
 
@@ -53,38 +86,18 @@ internals.String.prototype.insensitive = function () {
 };
 
 
-internals.String.prototype.min = function (limit, encoding) {
+internals.String.prototype.min = internals.compare('min', function (value, limit, encoding) {
 
-    Hoek.assert(Hoek.isInteger(limit) && limit >= 0, 'limit must be a positive integer');
-    Hoek.assert(!encoding || Buffer.isEncoding(encoding), 'Invalid encoding:', encoding);
-
-    return this._test('min', limit, function (value, state, options) {
-
-        var length = encoding ? Buffer.byteLength(value, encoding) : value.length;
-        if (length >= limit) {
-            return null;
-        }
-
-        return Errors.create('string.min', { limit: limit, value: value }, state, options);
-    });
-};
+    var length = encoding ? Buffer.byteLength(value, encoding) : value.length;
+    return length >= limit;
+});
 
 
-internals.String.prototype.max = function (limit, encoding) {
+internals.String.prototype.max = internals.compare('max', function (value, limit, encoding) {
 
-    Hoek.assert(Hoek.isInteger(limit) && limit >= 0, 'limit must be a positive integer');
-    Hoek.assert(!encoding || Buffer.isEncoding(encoding), 'Invalid encoding:', encoding);
-
-    return this._test('max', limit, function (value, state, options) {
-
-        var length = encoding ? Buffer.byteLength(value, encoding) : value.length;
-        if (length <= limit) {
-            return null;
-        }
-
-        return Errors.create('string.max', { limit: limit, value: value }, state, options);
-    });
-};
+    var length = encoding ? Buffer.byteLength(value, encoding) : value.length;
+    return length <= limit;
+});
 
 
 internals.String.prototype.creditCard = function () {
@@ -107,22 +120,11 @@ internals.String.prototype.creditCard = function () {
     });
 };
 
+internals.String.prototype.length = internals.compare('length', function (value, limit, encoding) {
 
-internals.String.prototype.length = function (limit, encoding) {
-
-    Hoek.assert(Hoek.isInteger(limit) && limit >= 0, 'limit must be a positive integer');
-    Hoek.assert(!encoding || Buffer.isEncoding(encoding), 'Invalid encoding:', encoding);
-
-    return this._test('length', limit, function (value, state, options) {
-
-        var length = encoding ? Buffer.byteLength(value, encoding) : value.length;
-        if (length === limit) {
-            return null;
-        }
-
-        return Errors.create('string.length', { limit: limit, value: value }, state, options);
-    });
-};
+    var length = encoding ? Buffer.byteLength(value, encoding) : value.length;
+    return length === limit;
+});
 
 
 internals.String.prototype.regex = function (pattern, name) {

--- a/test/index.js
+++ b/test/index.js
@@ -1282,27 +1282,27 @@ describe('Joi', function () {
                 message: '"foo" length must be less than or equal to 3 characters long',
                 path: 'test.0.foo',
                 type: 'string.max',
-                context: { limit: 3, key: 'foo', value: 'test1' }
+                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined }
             }, {
                 message: '"bar" length must be less than or equal to 5 characters long',
                 path: 'test.0.bar',
                 type: 'string.max',
-                context: { limit: 5, key: 'bar', value: 'testfailed' }
+                context: { limit: 5, value: 'testfailed', key: 'bar', encoding: undefined }
             }, {
                 message: '"foo" length must be less than or equal to 3 characters long',
                 path: 'test2.test3.1.foo',
                 type: 'string.max',
-                context: { limit: 3, key: 'foo', value: 'test1' }
+                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined }
             }, {
                 message: '"bar" length must be less than or equal to 5 characters long',
                 path: 'test2.test3.1.bar',
                 type: 'string.max',
-                context: { limit: 5, key: 'bar', value: 'testfailed' }
+                context: { limit: 5, value: 'testfailed', key: 'bar', encoding: undefined }
             }, {
                 message: '"foo" length must be less than or equal to 3 characters long',
                 path: 'test2.test3.2.baz.test4.0.foo',
                 type: 'string.max',
-                context: { limit: 3, key: 'foo', value: 'test1' }
+                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined }
             }, {
                 message: '"baz" is not allowed',
                 path: 'test2.test3.2.baz.test4.0',

--- a/test/string.js
+++ b/test/string.js
@@ -134,7 +134,7 @@ describe('string', function () {
             expect(function () {
 
                 Joi.string().min('a');
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -143,7 +143,16 @@ describe('string', function () {
             expect(function () {
 
                 Joi.string().min(1.2);
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
+            done();
+        });
+
+        it('throws when limit is not a positive integer', function (done) {
+
+            expect(function () {
+
+                Joi.string().min(-1);
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -155,6 +164,25 @@ describe('string', function () {
                 ['a', false]
             ], done);
         });
+
+        it('accepts references as min length', function(done) {
+
+            var schema = Joi.object({ a: Joi.number(), b: Joi.string().min(Joi.ref('a'), 'utf8') });
+            Helper.validate(schema, [
+                [{ a: 2, b: '\u00bd' }, true],
+                [{ a: 2, b: 'a' }, false],
+                [{ a: 2, b: 'a' }, false, null, 'child "b" fails because ["b" length must be at least 2 characters long]']
+            ], done);
+        });
+
+        it('errors if reference is not a number', function(done) {
+
+            var schema = Joi.object({ a: Joi.any(), b: Joi.string().min(Joi.ref('a'), 'utf8') });
+
+            Helper.validate(schema, [
+                [{ a: 'Hi there', b: '\u00bd' }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
     });
 
     describe('#max', function () {
@@ -164,7 +192,7 @@ describe('string', function () {
             expect(function () {
 
                 Joi.string().max('a');
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -173,7 +201,16 @@ describe('string', function () {
             expect(function () {
 
                 Joi.string().max(1.2);
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
+            done();
+        });
+
+        it('throws when limit is not a positive integer', function (done) {
+
+            expect(function () {
+
+                Joi.string().max(-1);
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -183,6 +220,25 @@ describe('string', function () {
             Helper.validate(schema, [
                 ['\u00bd', false],
                 ['a', true]
+            ], done);
+        });
+
+        it('accepts references as min length', function(done) {
+
+            var schema = Joi.object({ a: Joi.number(), b: Joi.string().max(Joi.ref('a'), 'utf8') });
+            Helper.validate(schema, [
+                [{ a: 2, b: '\u00bd' }, true],
+                [{ a: 2, b: 'three' }, false],
+                [{ a: 2, b: 'three' }, false, null, 'child "b" fails because ["b" length must be less than or equal to 2 characters long]']
+            ], done);
+        });
+
+        it('errors if reference is not a number', function(done) {
+
+            var schema = Joi.object({ a: Joi.any(), b: Joi.string().max(Joi.ref('a'), 'utf8') });
+
+            Helper.validate(schema, [
+                [{ a: 'Hi there', b: '\u00bd' }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });
@@ -231,7 +287,7 @@ describe('string', function () {
             expect(function () {
 
                 Joi.string().length('a');
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -240,7 +296,16 @@ describe('string', function () {
             expect(function () {
 
                 Joi.string().length(1.2);
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
+            done();
+        });
+
+        it('throws when limit is not a positive integer', function (done) {
+
+            expect(function () {
+
+                Joi.string().length(-42);
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -250,6 +315,25 @@ describe('string', function () {
             Helper.validate(schema, [
                 ['\u00bd', true],
                 ['a', false]
+            ], done);
+        });
+
+        it('accepts references as length', function(done) {
+
+            var schema = Joi.object({ a: Joi.number(), b: Joi.string().length(Joi.ref('a'), 'utf8') });
+            Helper.validate(schema, [
+                [{ a: 2, b: '\u00bd' }, true],
+                [{ a: 2, b: 'a' }, false],
+                [{ a: 2, b: 'a' }, false, null, 'child "b" fails because ["b" length must be 2 characters long]']
+            ], done);
+        });
+
+        it('errors if reference is not a number', function(done) {
+
+            var schema = Joi.object({ a: Joi.any(), b: Joi.string().length(Joi.ref('a'), 'utf8') });
+
+            Helper.validate(schema, [
+                [{ a: 'Hi there', b: '\u00bd' }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });


### PR DESCRIPTION
This PR adds support for using references or String `min()`, `max()`, `length()` and the supporting documentation.