### PR TITLE
Validate multiple options with presence key in it

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -46,7 +46,7 @@ internals.checkOptions = function (options) {
         var key = keys[k];
         var opt = optionType[key];
         var type = opt;
-        var values;
+        var values = null;
 
         if (Array.isArray(opt)) {
             type = opt[0];

--- a/test/any.js
+++ b/test/any.js
@@ -113,6 +113,15 @@ describe('any', function () {
             }).to.throw('presence should be one of required, optional, forbidden, ignore');
             done();
         });
+
+        it('does not throw with multiple options including presence key', function (done) {
+
+            expect(function () {
+
+                Joi.any().options({ presence: 'optional', raw: true});
+            }).to.not.throw();
+            done();
+        });
     });
 
     describe('#label', function () {


### PR DESCRIPTION
The validation would throw when using `presence` and another key because `values` would keep the values from the `presence` key in it thus not validating other keys.

Fixes #601 