### PR TITLE
Add IP Address Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Lead Maintainer: [Nicolas Morel](https://github.com/marsup)
       - [`string.alphanum()`](#stringalphanum)
       - [`string.token()`](#stringtoken)
       - [`string.email([options])`](#stringemailoptions)
+      - [`string.ip([options])`](#stringipoptions)
       - [`string.uri([options])`](#stringurioptions)
       - [`string.guid()`](#stringguid)
       - [`string.hex()`](#stringhex)
@@ -1228,6 +1229,25 @@ Requires the string value to be a valid email address.
 
 ```javascript
 var schema = Joi.string().email();
+```
+
+#### `string.ip([options])`
+
+Requires the string value to be a valid ip address.
+
+- `options` - optional settings:
+    - `version` - One or more IP address versions to validate against. Valid values: `ipv4`, `ipv6`, `ipvfuture`
+    - `cidr` - Used to determine if a CIDR is allowed or not. Valid values: `optional`, `required`, `forbidden`
+
+```javascript
+// Accept only ipv4 and ipv6 addresses with a CIDR
+var schema = Joi.string().ip({
+  version: [
+    'ipv4',
+    'ipv6'
+  ],
+  cidr: 'required'
+});
 ```
 
 #### `string.uri([options])`

--- a/lib/language.js
+++ b/lib/language.js
@@ -116,6 +116,9 @@ exports.errors = {
         uppercase: 'must only contain uppercase characters',
         trim: 'must not have leading or trailing whitespace',
         creditCard: 'must be a credit card',
-        ref: 'references "{{ref}}" which is not a number'
+        ref: 'references "{{ref}}" which is not a number',
+        ip: 'must be a valid ip address',
+        ipCidr: 'must be a valid ip address with a {{cidr}} CIDR',
+        ipVersion: 'must be a valid ip address of one of the following versions {{version}} with a {{cidr}} CIDR'
     }
 };

--- a/lib/string.js
+++ b/lib/string.js
@@ -10,30 +10,100 @@ var Errors = require('./errors');
 
 // Declare internals
 
-var internals = {
-    createUriRegex: function (optionalScheme) {
-        /**
-         * DIGIT = %x30-39 ; 0-9
-         */
-        var digit = '0-9',
-            digitOnly = '[' + digit + ']';
+var internals = (function() {
+    var internals = {};
 
-        /**
-         * ALPHA = %x41-5A / %x61-7A   ; A-Z / a-z
-         */
-        var alpha = 'a-zA-Z',
-            alphaOnly = '[' + alpha + ']';
+    /**
+     * elements separated by forward slash ("/") are alternatives.
+     */
+    var or = '|';
 
-        /**
-         * HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
-         */
-        var hexDigit = digit + 'A-Fa-f',
-            hexDigitOnly = '[' + hexDigit + ']';
+    /**
+     * DIGIT = %x30-39 ; 0-9
+     */
+    var digit = '0-9',
+        digitOnly = '[' + digit + ']';
 
-        /**
-         * unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
-         */
-        var unreserved = alpha + digit + '-\\._~';
+    /**
+     * ALPHA = %x41-5A / %x61-7A   ; A-Z / a-z
+     */
+    var alpha = 'a-zA-Z',
+        alphaOnly = '[' + alpha + ']';
+
+    /**
+     * cidr       = DIGIT                ; 0-9
+     *            / %x31-32 DIGIT         ; 10-29
+     *            / "3" %x30-32           ; 30-32
+     */
+    var cidr = digitOnly + or + '[1-2]' + digitOnly + or + '3' + '[0-2]';
+
+    /**
+     * HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+     */
+    var hexDigit = digit + 'A-Fa-f',
+        hexDigitOnly = '[' + hexDigit + ']';
+
+    /**
+     * unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+     */
+    var unreserved = alpha + digit + '-\\._~';
+
+    /**
+     * sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+     */
+    var subDelims = '!\\$&\'\\(\\)\\*\\+,;=';
+
+    /**
+     * Rule to support zero-padded addresses.
+     */
+    var zeroPad = '0?';
+
+    /**
+     * dec-octet   = DIGIT                 ; 0-9
+     *            / %x31-39 DIGIT         ; 10-99
+     *            / "1" 2DIGIT            ; 100-199
+     *            / "2" %x30-34 DIGIT     ; 200-249
+     *            / "25" %x30-35          ; 250-255
+     */
+    var decOctect = '(?:' + zeroPad + zeroPad + digitOnly + or + zeroPad + '[1-9]' + digitOnly + or + '1' + digitOnly + digitOnly + or + '2' + '[0-4]' + digitOnly + or + '25' + '[0-5])';
+
+    /**
+     * IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet
+     */
+    var IPv4address = '(?:' + decOctect + '\\.){3}' + decOctect;
+
+    /**
+     * h16 = 1*4HEXDIG ; 16 bits of address represented in hexadecimal
+     * ls32 = ( h16 ":" h16 ) / IPv4address ; least-significant 32 bits of address
+     * IPv6address =                            6( h16 ":" ) ls32
+     *             /                       "::" 5( h16 ":" ) ls32
+     *             / [               h16 ] "::" 4( h16 ":" ) ls32
+     *             / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+     *             / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+     *             / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+     *             / [ *4( h16 ":" ) h16 ] "::"              ls32
+     *             / [ *5( h16 ":" ) h16 ] "::"              h16
+     *             / [ *6( h16 ":" ) h16 ] "::"
+     */
+    var h16 = hexDigitOnly + '{1,4}';
+    var ls32 = '(?:' + h16 + ':' + h16 + '|' + IPv4address + ')';
+    var IPv6SixHex = '(?:' + h16 + ':){6}' + ls32;
+    var IPv6FiveHex = '::(?:' + h16 + ':){5}' + ls32;
+    var IPv6FourHex = h16 + '::(?:' + h16 + ':){4}' + ls32;
+    var IPv6ThreeHex = '(?:' + h16 + ':){0,1}' + h16 + '::(?:' + h16 + ':){3}' + ls32;
+    var IPv6TwoHex = '(?:' + h16 + ':){0,2}' + h16 + '::(?:' + h16 + ':){2}' + ls32;
+    var IPv6OneHex = '(?:' + h16 + ':){0,3}' + h16 + '::' + h16 + ':' + ls32;
+    var IPv6NoneHex = '(?:' + h16 + ':){0,4}' + h16 + '::' + ls32;
+    var IPv6NoneHex2 = '(?:' + h16 + ':){0,5}' + h16 + '::' + h16;
+    var IPv6NoneHex3 = '(?:' + h16 + ':){0,6}' + h16 + '::';
+    var IPv6address = '(?:' + IPv6SixHex + or + IPv6FiveHex + or + IPv6FourHex + or + IPv6ThreeHex + or + IPv6TwoHex + or + IPv6OneHex + or + IPv6NoneHex + or + IPv6NoneHex2 + or + IPv6NoneHex3 + ')';
+
+    /**
+     * IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+     */
+    var IPvFuture = 'v' + hexDigitOnly + '+\\.[' + unreserved + subDelims + ':]+';
+
+    internals.createUriRegex = function (optionalScheme) {
 
         /**
          * pct-encoded = "%" HEXDIG HEXDIG
@@ -41,34 +111,10 @@ var internals = {
         var pctEncoded = '%' + hexDigit;
 
         /**
-         * sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
-         */
-        var subDelims = '!\\$&\'\\(\\)\\*\\+,;=';
-
-        /**
          * pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
          */
         var pchar = unreserved + pctEncoded + subDelims + ':@',
             pcharOnly = '[' + pchar + ']';
-
-        /**
-         * elements separated by forward slash ("/") are alternatives.
-         */
-        var or = '|';
-
-        /**
-         * Rule to support zero-padded addresses.
-         */
-        var zeroPad = '0?';
-
-        /**
-         * dec-octet   = DIGIT                 ; 0-9
-         *            / %x31-39 DIGIT         ; 10-99
-         *            / "1" 2DIGIT            ; 100-199
-         *            / "2" %x30-34 DIGIT     ; 200-249
-         *            / "25" %x30-35          ; 250-255
-         */
-        var decOctect = '(?:' + zeroPad + zeroPad + digitOnly + or + zeroPad + '[1-9]' + digitOnly + or + '1' + digitOnly + digitOnly + or + '2' + '[0-4]' + digitOnly + or + '25' + '[0-5])';
 
         /**
          * scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
@@ -85,42 +131,6 @@ var internals = {
          * userinfo = *( unreserved / pct-encoded / sub-delims / ":" )
          */
         var userinfo = '[' + unreserved + pctEncoded + subDelims + ':]*';
-
-        /**
-         * IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet
-         */
-        var IPv4address = '(?:' + decOctect + '\\.){3}' + decOctect;
-
-        /**
-         * h16 = 1*4HEXDIG ; 16 bits of address represented in hexadecimal
-         * ls32 = ( h16 ":" h16 ) / IPv4address ; least-significant 32 bits of address
-         * IPv6address =                            6( h16 ":" ) ls32
-         *             /                       "::" 5( h16 ":" ) ls32
-         *             / [               h16 ] "::" 4( h16 ":" ) ls32
-         *             / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
-         *             / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
-         *             / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
-         *             / [ *4( h16 ":" ) h16 ] "::"              ls32
-         *             / [ *5( h16 ":" ) h16 ] "::"              h16
-         *             / [ *6( h16 ":" ) h16 ] "::"
-         */
-        var h16 = hexDigitOnly + '{1,4}',
-            ls32 = '(?:' + h16 + ':' + h16 + '|' + IPv4address + ')',
-            IPv6SixHex = '(?:' + h16 + ':){6}' + ls32,
-            IPv6FiveHex = '::(?:' + h16 + ':){5}' + ls32,
-            IPv6FourHex = h16 + '::(?:' + h16 + ':){4}' + ls32,
-            IPv6ThreeeHex = '(?:' + h16 + ':){0,1}' + h16 + '::(?:' + h16 + ':){3}' + ls32,
-            IPv6TwoHex = '(?:' + h16 + ':){0,2}' + h16 + '::(?:' + h16 + ':){2}' + ls32,
-            IPv6OneHex = '(?:' + h16 + ':){0,3}' + h16 + '::' + h16 + ':' + ls32,
-            IPv6NoneHex = '(?:' + h16 + ':){0,4}' + h16 + '::' + ls32,
-            IPv6NoneHex2 = '(?:' + h16 + ':){0,5}' + h16 + '::' + h16,
-            IPv6NoneHex3 = '(?:' + h16 + ':){0,6}' + h16 + '::',
-            IPv6address = '(?:' + IPv6SixHex + or + IPv6FiveHex + or + IPv6FourHex + or + IPv6ThreeeHex + or + IPv6TwoHex + or + IPv6OneHex + or + IPv6NoneHex + or + IPv6NoneHex2 + or + IPv6NoneHex3 + ')';
-
-        /**
-         * IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
-         */
-        var IPvFuture = 'v' + hexDigitOnly + '+\\.[' + unreserved + subDelims + ':]+';
 
         /**
          * IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
@@ -159,11 +169,11 @@ var internals = {
          * path-absolute = "/" [ segment-nz *( "/" segment ) ]
          * path-rootless = segment-nz *( "/" segment )
          */
-        var segment = pcharOnly + '*',
-            segmentNz = pcharOnly + '+',
-            pathAbEmpty = '(?:\\/' + segment + ')*',
-            pathAbsolute = '\\/(?:' + segmentNz + pathAbEmpty + ')?',
-            pathRootless = segmentNz + pathAbEmpty;
+        var segment = pcharOnly + '*';
+        var segmentNz = pcharOnly + '+';
+        var pathAbEmpty = '(?:\\/' + segment + ')*';
+        var pathAbsolute = '\\/(?:' + segmentNz + pathAbEmpty + ')?';
+        var pathRootless = segmentNz + pathAbEmpty;
 
         /**
          * hier-part = "//" authority path
@@ -184,10 +194,39 @@ var internals = {
          * URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
          */
         return new RegExp('^' + scheme + ':' + hierPart + '(?:\\?' + query + ')?' + '(?:#' + fragment + ')?$');
-    }
-};
+    };
 
-internals.uriRegex = internals.createUriRegex();
+    internals.ipCidr = {
+        required: '\\/(?:' + cidr + ')',
+        optional: '(?:\\/(?:' + cidr + '))?',
+        forbidden: ''
+    };
+
+    internals.ipVersions = {
+        ipv4: IPv4address,
+        ipv6: IPv6address,
+        ipvfuture: IPvFuture
+    };
+
+    internals.createIpRegex = function(versions, cidr) {
+        var regex = versions.reduce(function(regex, version) {
+            // Handle initialization and no `or` on the first one
+            if (!regex) {
+                return '^(?:' + internals.ipVersions[version];
+            }
+            return regex + or + internals.ipVersions[version];
+        }, '');
+
+        regex += ')' + internals.ipCidr[cidr] + '$';
+
+        return new RegExp(regex);
+    };
+
+    internals.uriRegex = internals.createUriRegex();
+    internals.ipRegex = internals.createIpRegex(['ipv4', 'ipv6', 'ipvfuture'], 'optional');
+
+    return internals;
+}());
 
 
 internals.String = function () {
@@ -370,6 +409,66 @@ internals.String.prototype.email = function (isEmailOptions) {
         catch (e) {}
 
         return Errors.create('string.email', { value: value }, state, options);
+    });
+};
+
+
+internals.String.prototype.ip = function (ipOptions) {
+    var regex = internals.ipRegex;
+    if (ipOptions) {
+        Hoek.assert(typeof ipOptions === 'object', 'ipOptions must be an object');
+
+        if (ipOptions.cidr) {
+            Hoek.assert(typeof ipOptions.cidr === 'string', 'ipOptions.cidr must be a string');
+            ipOptions.cidr = ipOptions.cidr.toLowerCase();
+
+            Hoek.assert(ipOptions.cidr in internals.ipCidr, 'ipOptions.cidr must be one of ' + Object.keys(internals.ipCidr).join(', '));
+
+            // If we only received a `cidr` setting, create a regex for it. But we don't need to create one if `cidr` is "optional" since that is the default
+            if (!ipOptions.version && ipOptions.cidr !== 'optional') {
+                regex = internals.createIpRegex(['ipv4', 'ipv6', 'ipvfuture'], ipOptions.cidr);
+            }
+        } else {
+            // Set our default cidr strategy
+            ipOptions.cidr = 'optional';
+        }
+
+        if (ipOptions.version) {
+            if (!Array.isArray(ipOptions.version)) {
+                ipOptions.version = [ipOptions.version];
+            }
+
+            ipOptions.version = ipOptions.version.reduce(function(versions, version, index) {
+
+                Hoek.assert(typeof version === 'string', 'ipOptions.version at position ' + index + ' must be a string');
+                version = version.toLowerCase();
+                Hoek.assert(internals.ipVersions[version], 'ipOptions.version at position ' + index + ' must be one of ' + Object.keys(internals.ipVersions).join(', '));
+
+                versions.push(version);
+                return versions;
+            }, []);
+
+            // Make sure we have a set of versions
+            ipOptions.version = Hoek.unique(ipOptions.version);
+
+            regex = internals.createIpRegex(ipOptions.version, ipOptions.cidr);
+        }
+    }
+
+    return this._test('ip', ipOptions, function (value, state, options) {
+        if (regex.test(value)) {
+            return null;
+        }
+
+        if (ipOptions && ipOptions.version) {
+            return Errors.create('string.ipVersion', {value: value, cidr: ipOptions.cidr, version: ipOptions.version}, state, options);
+        }
+
+        if (ipOptions) {
+            return Errors.create('string.ipCidr', {value: value, cidr: ipOptions.cidr}, state, options);
+        }
+
+        return Errors.create('string.ip', {value: value}, state, options);
     });
 };
 

--- a/test/string.js
+++ b/test/string.js
@@ -627,6 +627,495 @@ describe('string', function () {
         });
     });
 
+    describe('#ip', function () {
+        var invalidIPs = [
+                ['ASDF', false],
+                ['192.0.2.16:80/30', false],
+                ['192.0.2.16a', false],
+                ['qwerty', false],
+                ['127.0.0.1:8000', false],
+                ['ftp://www.example.com', false],
+                ['Bananas in pajamas are coming down the stairs', false]
+            ],
+            invalidIPv4s = [
+                ['0.0.0.0/33', false],
+                ['256.0.0.0/0', false],
+                ['255.255.255.256/32', false],
+                ['256.0.0.0', false],
+                ['255.255.255.256', false]
+            ],
+            invalidIPv6s = [
+                ['2001:db8::7/33', false],
+                ['1080:0:0:0:8:800:200C:417G', false]
+            ],
+            invalidIPvFutures = [
+                ['v1.09azAZ-._~!$&\'()*+,;=:/33', false],
+                ['v1.09#', false]
+            ],
+            validIPv4sWithCidr = function(success) {
+                return [
+                    ['0.0.0.0/32', success],
+                    ['255.255.255.255/0', success],
+                    ['127.0.0.1/0', success],
+                    ['192.168.2.1/0', success],
+                    ['0.0.0.3/2', success],
+                    ['0.0.0.7/3', success],
+                    ['0.0.0.15/4', success],
+                    ['0.0.0.31/5', success],
+                    ['0.0.0.63/6', success],
+                    ['0.0.0.127/7', success],
+                    ['01.020.030.100/7', success],
+                    ['0.0.0.0/0', success],
+                    ['00.00.00.00/0', success],
+                    ['000.000.000.000/32', success]
+                ];
+            },
+            validIPv4sWithoutCidr = function(success) {
+                return [
+                    ['0.0.0.0', success],
+                    ['255.255.255.255', success],
+                    ['127.0.0.1', success],
+                    ['192.168.2.1', success],
+                    ['0.0.0.3', success],
+                    ['0.0.0.7', success],
+                    ['0.0.0.15', success],
+                    ['0.0.0.31', success],
+                    ['0.0.0.63', success],
+                    ['0.0.0.127', success],
+                    ['01.020.030.100', success],
+                    ['0.0.0.0', success],
+                    ['00.00.00.00', success],
+                    ['000.000.000.000', success]
+                ];
+            },
+            validIPv6sWithCidr = function (success) {
+                return [
+                    ['2001:db8::7/32', success],
+                    ['a:b:c:d:e::1.2.3.4/13', success],
+                    ['FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/0', success],
+                    ['FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/32', success],
+                    ['1080:0:0:0:8:800:200C:417A/27', success]
+                ];
+            },
+            validIPv6sWithoutCidr = function (success) {
+                return [
+                    ['2001:db8::7', success],
+                    ['a:b:c:d:e::1.2.3.4', success],
+                    ['FEDC:BA98:7654:3210:FEDC:BA98:7654:3210', success],
+                    ['FEDC:BA98:7654:3210:FEDC:BA98:7654:3210', success],
+                    ['1080:0:0:0:8:800:200C:417A', success]
+                ];
+            },
+            validIPvFuturesWithCidr = function (success) {
+                return [
+                    ['v1.09azAZ-._~!$&\'()*+,;=:/32', success]
+                ];
+            },
+            validIPvFuturesWithoutCidr = function (success) {
+                return [
+                    ['v1.09azAZ-._~!$&\'()*+,;=:', success]
+                ];
+            };
+
+        it('should validate all ip addresses with optional CIDR by default', function(done) {
+
+            var schema = Joi.string().ip();
+            Helper.validate(schema, []
+                .concat(validIPv4sWithCidr(true))
+                .concat(validIPv4sWithoutCidr(true))
+                .concat(validIPv6sWithCidr(true))
+                .concat(validIPv6sWithoutCidr(true))
+                .concat(validIPvFuturesWithCidr(true))
+                .concat(validIPvFuturesWithoutCidr(true))
+                .concat(invalidIPs)
+                .concat(invalidIPv4s)
+                .concat(invalidIPv6s)
+                .concat(invalidIPvFutures), done);
+        });
+
+        it('should validate all ip addresses with an optional CIDR', function(done) {
+
+            var schema = Joi.string().ip({ cidr: 'optional' });
+            Helper.validate(schema, []
+                .concat(validIPv4sWithCidr(true))
+                .concat(validIPv4sWithoutCidr(true))
+                .concat(validIPv6sWithCidr(true))
+                .concat(validIPv6sWithoutCidr(true))
+                .concat(validIPvFuturesWithCidr(true))
+                .concat(validIPvFuturesWithoutCidr(true))
+                .concat(invalidIPs)
+                .concat(invalidIPv4s)
+                .concat(invalidIPv6s)
+                .concat(invalidIPvFutures), done);
+        });
+
+        it('should validate all ip addresses with a required CIDR', function(done) {
+
+            var schema = Joi.string().ip({ cidr: 'required' });
+            Helper.validate(schema, []
+                .concat(validIPv4sWithCidr(true))
+                .concat(validIPv4sWithoutCidr(false))
+                .concat(validIPv6sWithCidr(true))
+                .concat(validIPv6sWithoutCidr(false))
+                .concat(validIPvFuturesWithCidr(true))
+                .concat(validIPvFuturesWithoutCidr(false))
+                .concat(invalidIPs)
+                .concat(invalidIPv4s)
+                .concat(invalidIPv6s)
+                .concat(invalidIPvFutures), done);
+        });
+
+        it('should validate all ip addresses with a forbidden CIDR', function(done) {
+
+            var schema = Joi.string().ip({ cidr: 'forbidden' });
+            Helper.validate(schema, []
+                .concat(validIPv4sWithCidr(false))
+                .concat(validIPv4sWithoutCidr(true))
+                .concat(validIPv6sWithCidr(false))
+                .concat(validIPv6sWithoutCidr(true))
+                .concat(validIPvFuturesWithCidr(false))
+                .concat(validIPvFuturesWithoutCidr(true))
+                .concat(invalidIPs)
+                .concat(invalidIPv4s)
+                .concat(invalidIPv6s)
+                .concat(invalidIPvFutures), done);
+        });
+
+        it('throws when options is not an object', function (done) {
+
+            expect(function () {
+                Joi.string().ip(42);
+            }).to.throw('ipOptions must be an object');
+            done();
+        });
+
+        it('throws when options.cidr is not a string', function (done) {
+
+            expect(function () {
+                Joi.string().ip({ cidr: 42 });
+            }).to.throw('ipOptions.cidr must be a string');
+            done();
+        });
+
+        it('throws when options.cidr is not a valid value', function (done) {
+
+            expect(function () {
+                Joi.string().ip({ cidr: '42' });
+            }).to.throw('ipOptions.cidr must be one of required, optional, forbidden');
+            done();
+        });
+
+        it('throws when options.version is not a string', function (done) {
+
+            expect(function () {
+                Joi.string().ip({ version: 42 });
+            }).to.throw('ipOptions.version at position 0 must be a string');
+            done();
+        });
+
+        it('throws when options.version is not a valid value', function (done) {
+
+            expect(function () {
+                Joi.string().ip({ version: '42' });
+            }).to.throw('ipOptions.version at position 0 must be one of ipv4, ipv6, ipvfuture');
+            done();
+        });
+
+        it('validates ip with a friendly error message', function (done) {
+
+            var schema = { item: Joi.string().ip() };
+            Joi.compile(schema).validate({ item: 'something' }, function (err, value) {
+
+                expect(err.message).to.contain('must be a valid ip address');
+                done();
+            });
+        });
+
+        it('validates ip and cidr presence with a friendly error message', function (done) {
+
+            var schema = { item: Joi.string().ip({cidr: 'required' }) };
+            Joi.compile(schema).validate({ item: 'something' }, function (err, value) {
+
+                expect(err.message).to.contain('must be a valid ip address with a required CIDR');
+                done();
+            });
+        });
+
+        it('validates custom ip version and cidr presence with a friendly error message', function (done) {
+
+            var schema = { item: Joi.string().ip({ version: 'ipv4', cidr: 'required' }) };
+            Joi.compile(schema).validate({ item: 'something' }, function (err, value) {
+
+                expect(err.message).to.contain('child "item" fails because ["item" must be a valid ip address of one of the following versions [ipv4] with a required CIDR]');
+                done();
+            });
+        });
+
+        describe('#ip({ version: "ipv4" })', function() {
+            it('should validate all ipv4 addresses with a default CIDR strategy', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipv4' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(true))
+                    .concat(validIPv4sWithoutCidr(true))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv4 addresses with an optional CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipv4', cidr: 'optional' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(true))
+                    .concat(validIPv4sWithoutCidr(true))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv4 addresses with a required CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipv4', cidr: 'required' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(true))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv4 addresses with a forbidden CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipv4', cidr: 'forbidden' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(true))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+        });
+
+        describe('#ip({ version: "ipv6" })', function() {
+            it('should validate all ipv6 addresses with a default CIDR strategy', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipv6' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(true))
+                    .concat(validIPv6sWithoutCidr(true))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv6 addresses with an optional CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipv6', cidr: 'optional' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(true))
+                    .concat(validIPv6sWithoutCidr(true))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv6 addresses with a required CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipv6', cidr: 'required' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(true))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv6 addresses with a forbidden CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipv6', cidr: 'forbidden' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(true))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+        });
+
+        describe('#ip({ version: "ipvfuture" })', function() {
+            it('should validate all ipvfuture addresses with a default CIDR strategy', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipvfuture' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(true))
+                    .concat(validIPvFuturesWithoutCidr(true))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipvfuture addresses with an optional CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipvfuture', cidr: 'optional' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(true))
+                    .concat(validIPvFuturesWithoutCidr(true))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipvfuture addresses with a required CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipvfuture', cidr: 'required' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(true))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipvfuture addresses with a forbidden CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: 'ipvfuture', cidr: 'forbidden' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(true))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+        });
+
+        describe('#ip({ version: [ "ipv4", "ipv6" ] })', function() {
+            it('should validate all ipv4 and ipv6 addresses with a default CIDR strategy', function(done) {
+
+                var schema = Joi.string().ip({ version: [ 'ipv4', 'ipv6' ] });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(true))
+                    .concat(validIPv4sWithoutCidr(true))
+                    .concat(validIPv6sWithCidr(true))
+                    .concat(validIPv6sWithoutCidr(true))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv4 and ipv6 addresses with an optional CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: [ 'ipv4', 'ipv6' ], cidr: 'optional' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(true))
+                    .concat(validIPv4sWithoutCidr(true))
+                    .concat(validIPv6sWithCidr(true))
+                    .concat(validIPv6sWithoutCidr(true))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv4 and ipv6 addresses with a required CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: [ 'ipv4', 'ipv6' ], cidr: 'required' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(true))
+                    .concat(validIPv4sWithoutCidr(false))
+                    .concat(validIPv6sWithCidr(true))
+                    .concat(validIPv6sWithoutCidr(false))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+
+            it('should validate all ipv4 and ipv6 addresses with a forbidden CIDR', function(done) {
+
+                var schema = Joi.string().ip({ version: [ 'ipv4', 'ipv6' ], cidr: 'forbidden' });
+                Helper.validate(schema, []
+                    .concat(validIPv4sWithCidr(false))
+                    .concat(validIPv4sWithoutCidr(true))
+                    .concat(validIPv6sWithCidr(false))
+                    .concat(validIPv6sWithoutCidr(true))
+                    .concat(validIPvFuturesWithCidr(false))
+                    .concat(validIPvFuturesWithoutCidr(false))
+                    .concat(invalidIPs)
+                    .concat(invalidIPv4s)
+                    .concat(invalidIPv6s)
+                    .concat(invalidIPvFutures), done);
+            });
+        });
+    });
+
     describe('#validate', function () {
 
         it('should, by default, allow undefined, deny empty string', function (done) {


### PR DESCRIPTION
This PR adds the ability to do IP address validation for IPv4, IPv6, and IPvFuture addresses along with a configurable part for if a CIDR is optional/required/forbidden for the validation. It includes appropriate tests and documentation.

It takes care of the original PR #458 