### PR TITLE
Add the ability to provide a transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,23 @@ schema.validate(['one', 'two', true, false, 1, 2], function (err, value) {
 });
 ```
 
+#### `any.transform(function, [options])`
+
+Allows a value to be transformed.
+- `scope` - the scope of the transformer function. Valid values: `pre` - executes the transformer before validation, `post` - executes the transformer after validation
+
+```javascript
+var schema = {
+    count: Joi.number().transform(function(value) {
+      return value + 1;
+    }, { scope: 'pre' })
+};
+
+schema.validate({ count: 41 }, function (err, value) {
+    // value = { count: 42 }
+});
+```
+
 #### `any.description(desc)`
 
 Annotates the key where:

--- a/lib/any.js
+++ b/lib/any.js
@@ -67,6 +67,8 @@ module.exports = internals.Any = function () {
     this.isJoi = true;
     this._type = 'any';
     this._settings = null;
+    this._preTransformer = null;
+    this._postTransformer = null;
     this._valids = new internals.Set();
     this._invalids = new internals.Set();
     this._tests = [];
@@ -103,6 +105,8 @@ internals.Any.prototype.clone = function () {
 
     obj.isJoi = true;
     obj._type = this._type;
+    obj._preTransformer = this._preTransformer;
+    obj._postTransformer = this._postTransformer;
     obj._settings = internals.concatSettings(this._settings);
     obj._valids = Hoek.clone(this._valids);
     obj._invalids = Hoek.clone(this._invalids);
@@ -245,6 +249,30 @@ internals.Any.prototype.allow = function () {
 
     var obj = this.clone();
     obj._allow.apply(obj, arguments);
+    return obj;
+};
+
+
+internals.Any.prototype.transform = function(transformer, options) {
+    Hoek.assert(typeof transformer === 'function', 'Transformer must be a function');
+    Hoek.assert(transformer.length === 1, 'Transformer must have exactly one argument, the value to transform');
+
+    options = options || {};
+
+    Hoek.assert(typeof options === 'object', 'options must be an object');
+
+    if (options.scope) {
+        Hoek.assert(options.scope === 'pre' || options.scope === 'post', 'options.scope must be one of pre, post');
+    } else {
+        options.scope = 'pre';
+    }
+
+    var obj = this.clone();
+    if (options.scope === 'pre') {
+        obj._preTransformer = transformer;
+    } else {
+        obj._postTransformer = transformer;
+    }
     return obj;
 };
 
@@ -518,6 +546,11 @@ internals.Any.prototype._validate = function (value, state, options, reference) 
         return finish();
     }
 
+    // Transform the value before, if needed.
+    if (this._preTransformer) {
+        value = this._preTransformer(value);
+    }
+
     // Check allowed and denied values using the original value
 
     if (this._valids.has(value, state, options, this._flags.insensitive)) {
@@ -581,6 +614,11 @@ internals.Any.prototype._validate = function (value, state, options, reference) 
                 return finish();
             }
         }
+    }
+
+    // Transform the value after everything else, if needed.
+    if (this._postTransformer) {
+        value = this._postTransformer(value);
     }
 
     return finish();

--- a/test/any.js
+++ b/test/any.js
@@ -1213,6 +1213,107 @@ describe('any', function () {
         });
     });
 
+    describe('#transform', function () {
+
+        it('should transform values before by default', function (done) {
+
+            var schema = Joi.object({ a: Joi.number().valid(5).required() }).transform(function(value) {
+
+                value.a += 1;
+                return value;
+            });
+            schema.validate({ a: 4 }, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value.a).to.equal(5);
+                done();
+            });
+        });
+
+        it('should transform values before', function (done) {
+
+            var schema = Joi.object({ a: Joi.number().valid(5).required() }).transform(function(value) {
+
+                value.a += 1;
+                return value;
+            }, { scope: 'pre' });
+            schema.validate({ a: 4 }, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value.a).to.equal(5);
+                done();
+            });
+        });
+
+        it('should transform values after', function (done) {
+
+            var schema = Joi.object({ a: Joi.number().valid(4).required() }).transform(function(value) {
+
+                value.a += 1;
+                return value;
+            }, { scope: 'post' });
+            schema.validate({ a: 4 }, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value.a).to.equal(5);
+                done();
+            });
+        });
+
+        it('throws when transformer is not a function', function (done) {
+
+            expect(function () {
+
+                Joi.any().transform('Robots in disguise');
+            }).to.throw('Transformer must be a function');
+            done();
+        });
+
+        it('throws when transformer has no arguments', function (done) {
+
+            expect(function () {
+
+                Joi.any().transform(function() {
+                    return 'Robots in disguise';
+                });
+            }).to.throw('Transformer must have exactly one argument, the value to transform');
+            done();
+        });
+
+        it('throws when transformer has too many arguments', function (done) {
+
+            expect(function () {
+
+                Joi.any().transform(function(value, options) {
+                    return 'Robots in disguise';
+                });
+            }).to.throw('Transformer must have exactly one argument, the value to transform');
+            done();
+        });
+
+        it('throws when options is not an object', function (done) {
+
+            expect(function () {
+
+                Joi.any().transform(function(value) {
+                    return value;
+                }, 'Robots in disguise');
+            }).to.throw('options must be an object');
+            done();
+        });
+
+        it('throws when options.scope is invalid', function (done) {
+
+            expect(function () {
+
+                Joi.any().transform(function(value) {
+                    return value;
+                }, { scope: 'after' });
+            }).to.throw('options.scope must be one of pre, post');
+            done();
+        });
+    });
+
     describe('Set', function () {
 
         describe('#add', function () {


### PR DESCRIPTION
This PR adds the ability to pass a transformer function, which came up as part of #586. It's a pretty simple interface and it allows the transformer to execute either right after the presence checks or after all validation has occurred.

I'm on the fence about the whole `pre`/`post` implementation (and also the fact that I called it `scope`), but I think the functionality is useful to allow transforming at either the beginning or end of validation.