### PR TITLE
Add ignoreUndefined flag for rename()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,7 @@ Renames a key to another name (deletes the renamed key) where:
     - `alias` - if `true`, does not delete the old key name, keeping both the new and old keys in place. Defaults to `false`.
     - `multiple` - if `true`, allows renaming multiple keys to the same destination where the last rename wins. Defaults to `false`.
     - `override` - if `true`, allows renaming a key over an existing key. Defaults to `false`.
+    - `ignoreUndefined` - if `true`, skip renaming of a key if it's undefined. Defaults to `false`.
 
 Keys are renamed before any other validation rules are applied.
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -84,6 +84,10 @@ internals.Object.prototype._base = function (value, state, options) {
     for (var r = 0, rl = this._inner.renames.length; r < rl; ++r) {
         var item = this._inner.renames[r];
 
+        if (item.options.ignoreUndefined && target[item.from] === undefined){
+            continue;
+        }
+
         if (!item.options.multiple &&
             renamed[item.to]) {
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -84,7 +84,7 @@ internals.Object.prototype._base = function (value, state, options) {
     for (var r = 0, rl = this._inner.renames.length; r < rl; ++r) {
         var item = this._inner.renames[r];
 
-        if (item.options.ignoreUndefined && target[item.from] === undefined){
+        if (item.options.ignoreUndefined && target[item.from] === undefined) {
             continue;
         }
 

--- a/test/object.js
+++ b/test/object.js
@@ -670,6 +670,23 @@ describe('object', function () {
                 done();
             });
         });
+
+        it('should ignore a key with ignoredUndefined if from does not exist', function(done){
+
+            var schema = Joi.object().rename('b', 'a', { ignoreUndefined: true });
+
+            var input = {
+                a: 'something'
+            };
+
+            schema.validate(input, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(Object.keys(value)).to.include('a');
+                expect(value.a).to.equal('something');
+                done();
+            });
+        });
     });
 
     describe('#describe', function () {

--- a/test/object.js
+++ b/test/object.js
@@ -682,7 +682,23 @@ describe('object', function () {
             schema.validate(input, function (err, value) {
 
                 expect(err).to.not.exist();
-		expect(value).to.deep.equal({ a: 'something' });
+                expect(value).to.deep.equal({ a: 'something' });
+                done();
+            });
+        });
+
+        it('shouldn\'t delete a key with override and ignoredUndefined if from does not exist', function(done){
+
+            var schema = Joi.object().rename('b', 'a', { ignoreUndefined: true, override: true });
+
+            var input = {
+                a: 'something'
+            };
+
+            schema.validate(input, function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value).to.deep.equal({ a: 'something' });
                 done();
             });
         });

--- a/test/object.js
+++ b/test/object.js
@@ -682,8 +682,7 @@ describe('object', function () {
             schema.validate(input, function (err, value) {
 
                 expect(err).to.not.exist();
-                expect(Object.keys(value)).to.include('a');
-                expect(value.a).to.equal('something');
+		expect(value).to.deep.equal({ a: 'something' });
                 done();
             });
         });


### PR DESCRIPTION
Add a flag to ignore a missing key when renaming it.

```js
var schema = Joi.object().rename('b', 'a', { ignoreUndefined: true });

            var input = {
                a: 'something'
            };

            schema.validate(input, function (err, value) {

               // input : {a: 'something'}
            });
```

close #614 