### PR TITLE
Switch from Array.reduce() to a standard for loop

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -375,7 +375,7 @@ internals.String.prototype.email = function (isEmailOptions) {
 
 
 internals.String.prototype.uri = function (uriOptions) {
-    var customScheme,
+    var customScheme = '',
         regex = internals.uriRegex;
 
     if (uriOptions) {
@@ -388,22 +388,23 @@ internals.String.prototype.uri = function (uriOptions) {
                 uriOptions.scheme = [uriOptions.scheme];
             }
 
+            var scheme;
             // Flatten the array into a string to be used to match the schemes.
-            customScheme = uriOptions.scheme.reduce(function(accumulator, scheme, index) {
-
-                Hoek.assert(scheme instanceof RegExp || typeof scheme === 'string', 'scheme at position ' + index + ' must be a RegExp or String');
+            for (var i = 0; i < uriOptions.scheme.length; i++) {
+                scheme = uriOptions.scheme[i];
+                Hoek.assert(scheme instanceof RegExp || typeof scheme === 'string', 'scheme at position ' + i + ' must be a RegExp or String');
 
                 // Add OR separators if a value already exists
-                accumulator = accumulator ? accumulator + '|' : '';
+                customScheme = customScheme ? customScheme + '|' : '';
 
                 // If someone wants to match HTTP or HTTPS for example then we need to support both RegExp and String so we don't escape their pattern unknowingly.
                 if (scheme instanceof RegExp) {
-                    return accumulator + scheme.source;
+                    customScheme = customScheme + scheme.source;
+                } else {
+                    Hoek.assert(/[a-zA-Z][a-zA-Z0-9+-\.]*/.test(scheme), 'scheme at position ' + i + ' must be a valid scheme');
+                    customScheme = customScheme + Hoek.escapeRegex(scheme);
                 }
-
-                Hoek.assert(/[a-zA-Z][a-zA-Z0-9+-\.]*/.test(scheme), 'scheme at position ' + index + ' must be a valid scheme');
-                return accumulator + Hoek.escapeRegex(scheme);
-            }, '');
+            }
         }
     }
 


### PR DESCRIPTION
This PR switches the usage of `Array.reduce()` when create a piece of URI validation with one or more custom schemes to a standard for loop to reduce the footprint of the computations.

@Marsup I did a quick search, and this was the only usage of reduce that I saw in Joi.