### PR TITLE
Added renameAfter() to rename keys after validation

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -18,6 +18,7 @@ internals.Object = function () {
     this._type = 'object';
     this._inner.children = null;
     this._inner.renames = [];
+    this._inner.renameAfters = [];
     this._inner.dependencies = [];
     this._inner.patterns = [];
 };
@@ -57,6 +58,7 @@ internals.Object.prototype._base = function (value, state, options) {
     // Skip if there are no other rules to test
 
     if (!this._inner.renames.length &&
+        !this._inner.renameAfters.length &&
         !this._inner.dependencies.length &&
         !this._inner.children &&                    // null allows any keys
         !this._inner.patterns.length) {
@@ -240,6 +242,34 @@ internals.Object.prototype._base = function (value, state, options) {
             for (var e = 0, el = unprocessedKeys.length; e < el; ++e) {
                 errors.push(Errors.create('object.allowUnknown', null, { key: unprocessedKeys[e], path: state.path }, options));
             }
+        }
+    }
+
+    // Rename keys
+
+    var renamedAfter = {};
+    for (var r = 0, rl = this._inner.renameAfters.length; r < rl; ++r) {
+        var item = this._inner.renameAfters[r];
+
+        if (item.options.ignoreUndefined && target[item.from] === undefined) {
+            continue;
+        }
+
+        if (target.hasOwnProperty(item.to) &&
+            !item.options.override &&
+            !renamedAfter[item.to]) {
+
+            errors.push(Errors.create('object.rename.override', { from: item.from, to: item.to }, state, options));
+            if (options.abortEarly) {
+                return finish();
+            }
+        }
+
+        target[item.to] = target[item.from];
+        renamedAfter[item.to] = true;
+
+        if (!item.options.alias) {
+            delete target[item.from];
         }
     }
 
@@ -435,6 +465,32 @@ internals.Object.prototype.rename = function (from, to, options) {
     return obj;
 };
 
+internals.renameAfterDefaults = {
+    alias: false,                   // Keep old value in place
+    override: false                 // Overrides an existing key
+};
+
+
+internals.Object.prototype.renameAfter = function (from, to, options) {
+
+    Hoek.assert(typeof from === 'string', 'Rename missing the from argument');
+    Hoek.assert(typeof to === 'string', 'Rename missing the to argument');
+    Hoek.assert(to !== from, 'Cannot rename key to same name:', from);
+
+    for (var i = 0, il = this._inner.renameAfters.length; i < il; ++i) {
+        Hoek.assert(this._inner.renameAfters[i].from !== from, 'Cannot rename the same key multiple times');
+    }
+
+    var obj = this.clone();
+
+    obj._inner.renameAfters.push({
+        from: from,
+        to: to,
+        options: Hoek.applyToDefaults(internals.renameAfterDefaults, options || {})
+    });
+
+    return obj;
+};
 
 internals.groupChildren = function (children) {
 


### PR DESCRIPTION
Adds the ability to rename keys after validation.

Related to #626.

If everything looks good I'll go through and update the documentation.