### PR TITLE
added support for promises

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -7,6 +7,7 @@ var Errors = require('./errors');
 var Alternatives = null;                // Delay-loaded to prevent circular dependencies
 var Cast = null;
 
+var assert = Hoek.assert;
 
 // Declare internals
 
@@ -19,13 +20,13 @@ internals.defaults = {
     allowUnknown: false,
     skipFunctions: false,
     stripUnknown: false,
+    asPromise: false,
     language: {},
     presence: 'optional',
     raw: false,
     strip: false
     // context: null
 };
-
 
 internals.checkOptions = function (options) {
 
@@ -35,8 +36,10 @@ internals.checkOptions = function (options) {
         allowUnknown: 'boolean',
         skipFunctions: 'boolean',
         stripUnknown: 'boolean',
+        asPromise: 'boolean',
+        withPromises: 'function',
         language: 'object',
-        presence: ['string', 'required', 'optional', 'forbidden', 'ignore'],
+        presence: [ 'string', 'required', 'optional', 'forbidden', 'ignore' ],
         raw: 'boolean',
         context: 'object',
         strip: 'boolean'
@@ -44,20 +47,20 @@ internals.checkOptions = function (options) {
 
     var keys = Object.keys(options);
     for (var k = 0, kl = keys.length; k < kl; ++k) {
-        var key = keys[k];
-        var opt = optionType[key];
+        var key = keys[ k ];
+        var opt = optionType[ key ];
         var type = opt;
         var values = null;
 
         if (Array.isArray(opt)) {
-            type = opt[0];
+            type = opt[ 0 ];
             values = opt.slice(1);
         }
 
         Hoek.assert(type, 'unknown key ' + key);
-        Hoek.assert(typeof options[key] === type, key + ' should be of type ' + type);
+        Hoek.assert(typeof options[ key ] === type, key + ' should be of type ' + type);
         if (values) {
-            Hoek.assert(values.indexOf(options[key]) >= 0, key + ' should be one of ' + values.join(', '));
+            Hoek.assert(values.indexOf(options[ key ]) >= 0, key + ' should be one of ' + values.join(', '));
         }
     }
 };
@@ -72,17 +75,19 @@ module.exports = internals.Any = function () {
     this._invalids = new internals.Set();
     this._tests = [];
     this._refs = [];
-    this._flags = { /*
-        presence: 'optional',                   // optional, required, forbidden, ignore
-        allowOnly: false,
-        allowUnknown: undefined,
-        default: undefined,
-        forbidden: false,
-        encoding: undefined,
-        insensitive: false,
-        trim: false,
-        case: undefined                         // upper, lower
-    */ };
+    this._flags = {
+        /*
+         presence: 'optional',                   // optional, required, forbidden, ignore
+         allowOnly: false,
+         allowUnknown: undefined,
+         default: undefined,
+         forbidden: false,
+         encoding: undefined,
+         insensitive: false,
+         trim: false,
+         case: undefined                         // upper, lower
+         */
+    };
 
     this._description = null;
     this._unit = null;
@@ -121,8 +126,8 @@ internals.Any.prototype.clone = function () {
     obj._inner = {};
     var inners = Object.keys(this._inner);
     for (var i = 0, il = inners.length; i < il; ++i) {
-        var key = inners[i];
-        obj._inner[key] = this._inner[key] ? this._inner[key].slice() : null;
+        var key = inners[ i ];
+        obj._inner[ key ] = this._inner[ key ] ? this._inner[ key ].slice() : null;
     }
 
     return obj;
@@ -139,11 +144,11 @@ internals.Any.prototype.concat = function (schema) {
     if (this._type === 'any' && schema._type !== 'any') {
         // Reset values as if we were "this"
         var target = schema.clone();
-        var keys = ['_settings', '_valids', '_invalids', '_tests', '_refs', '_flags', '_description', '_unit', '_notes',
-            '_tags', '_examples', '_meta', '_inner'];
+        var keys = [ '_settings', '_valids', '_invalids', '_tests', '_refs', '_flags', '_description', '_unit', '_notes',
+            '_tags', '_examples', '_meta', '_inner' ];
 
         for (var k = 0, kl = keys.length; k < kl; ++k) {
-            target[keys[k]] = obj[keys[k]];
+            target[ keys[ k ] ] = obj[ keys[ k ] ];
         }
 
         obj = target;
@@ -166,37 +171,37 @@ internals.Any.prototype.concat = function (schema) {
     var inners = Object.keys(schema._inner);
     var isObject = obj._type === 'object';
     for (var i = 0, il = inners.length; i < il; ++i) {
-        var key = inners[i];
-        var source = schema._inner[key];
+        var key = inners[ i ];
+        var source = schema._inner[ key ];
         if (source) {
-            var target = obj._inner[key];
+            var target = obj._inner[ key ];
             if (target) {
                 if (isObject && key === 'children') {
                     var keys = {};
 
                     for (var k = 0, kl = target.length; k < kl; ++k) {
-                        keys[target[k].key] = k;
+                        keys[ target[ k ].key ] = k;
                     }
 
                     for (k = 0, kl = source.length; k < kl; ++k) {
-                        var sourceKey = source[k].key;
-                        if (keys[sourceKey] >= 0) {
-                            target[keys[sourceKey]] = {
+                        var sourceKey = source[ k ].key;
+                        if (keys[ sourceKey ] >= 0) {
+                            target[ keys[ sourceKey ] ] = {
                                 key: sourceKey,
-                                schema: target[keys[sourceKey]].schema.concat(source[k].schema)
+                                schema: target[ keys[ sourceKey ] ].schema.concat(source[ k ].schema)
                             };
                         }
                         else {
-                            target.push(source[k]);
+                            target.push(source[ k ]);
                         }
                     }
                 }
                 else {
-                    obj._inner[key] = obj._inner[key].concat(source);
+                    obj._inner[ key ] = obj._inner[ key ].concat(source);
                 }
             }
             else {
-                obj._inner[key] = source.slice();
+                obj._inner[ key ] = source.slice();
             }
         }
     }
@@ -248,7 +253,7 @@ internals.Any.prototype._allow = function () {
 
     var values = Hoek.flatten(Array.prototype.slice.call(arguments));
     for (var i = 0, il = values.length; i < il; ++i) {
-        var value = values[i];
+        var value = values[ i ];
         this._invalids.remove(value);
         this._valids.add(value, this._refs);
     }
@@ -278,7 +283,7 @@ internals.Any.prototype.invalid = internals.Any.prototype.disallow = internals.A
     var obj = this.clone();
     var values = Hoek.flatten(Array.prototype.slice.call(arguments));
     for (var i = 0, il = values.length; i < il; ++i) {
-        value = values[i];
+        value = values[ i ];
         obj._valids.remove(value);
         obj._invalids.add(value, this._refs);
     }
@@ -323,10 +328,10 @@ internals.Any.prototype.applyFunctionToChildren = function (children, fn, args, 
 
     children = [].concat(children);
 
-    if (children.length !== 1 || children[0] !== '') {
+    if (children.length !== 1 || children[ 0 ] !== '') {
         root = root ? (root + '.') : '';
 
-        var extraChildren = (children[0] === '' ? children.slice(1) : children).map(function (child) {
+        var extraChildren = (children[ 0 ] === '' ? children.slice(1) : children).map(function (child) {
 
             return root + child;
         });
@@ -334,14 +339,13 @@ internals.Any.prototype.applyFunctionToChildren = function (children, fn, args, 
         throw new Error('unknown key(s) ' + extraChildren.join(', '));
     }
 
-    return this[fn].apply(this, args);
+    return this[ fn ].apply(this, args);
 };
 
 
 internals.Any.prototype.default = function (value, description) {
 
-    if (typeof value === 'function' &&
-        !Ref.isRef(value)) {
+    if (typeof value === 'function' && !Ref.isRef(value)) {
 
         if (!value.description &&
             description) {
@@ -481,8 +485,7 @@ internals.Any.prototype._validate = function (value, state, options, reference) 
             else if (Ref.isRef(self._flags.default)) {
                 finalValue = self._flags.default(state.parent, options);
             }
-            else if (typeof self._flags.default === 'function' &&
-                    !(self._type === 'func' && !self._flags.default.description)) {
+            else if (typeof self._flags.default === 'function' && !(self._type === 'func' && !self._flags.default.description)) {
 
                 var arg;
 
@@ -524,7 +527,7 @@ internals.Any.prototype._validate = function (value, state, options, reference) 
         }
     }
     else if (presence === 'required' &&
-            value === undefined) {
+        value === undefined) {
 
         errors.push(Errors.create('any.required', null, state, options));
         return finish();
@@ -593,7 +596,7 @@ internals.Any.prototype._validate = function (value, state, options, reference) 
     // Helper.validate tests
 
     for (var i = 0, il = this._tests.length; i < il; ++i) {
-        var test = this._tests[i];
+        var test = this._tests[ i ];
         var err = test.func.call(this, value, state, options);
         if (err) {
             errors.push(err);
@@ -619,6 +622,27 @@ internals.Any.prototype._validateWithOptions = function (value, options, callbac
 
     if (callback) {
         return callback(errors, result.value);
+    }
+
+    if (settings.asPromise) {
+
+        if (typeof settings.withPromises === 'undefined') {
+            if (typeof global.Promise === 'undefined') {
+                require('es6-promise').polyfill();
+            }
+            settings.withPromises = global.Promise;
+        }
+
+        var Promise = settings.withPromises;
+
+        var msg = 'options.asPromise requires a Promises library (set to options.withPromises) ' +
+            'that supports Promise.resolve() and Promise.reject()';
+
+        Hoek.assert(typeof Promise === 'function', msg);
+        Hoek.assert(typeof Promise.resolve === 'function', msg);
+        Hoek.assert(typeof Promise.reject === 'function', msg);
+
+        return (errors === null) ? Promise.resolve(result.value) : Promise.reject(errors);
     }
 
     return { error: errors, value: result.value };
@@ -685,7 +709,7 @@ internals.Any.prototype.describe = function () {
     description.rules = [];
 
     for (var i = 0, il = this._tests.length; i < il; ++i) {
-        var validator = this._tests[i];
+        var validator = this._tests[ i ];
         var item = { name: validator.name };
         if (validator.arg !== void 0) {
             item.arg = validator.arg;
@@ -744,11 +768,11 @@ internals.Set.prototype.add = function (value, refs) {
 internals.Set.prototype.merge = function (add, remove) {
 
     for (var i = 0, il = add._set.length; i < il; ++i) {
-        this.add(add._set[i]);
+        this.add(add._set[ i ]);
     }
 
     for (i = 0, il = remove._set.length; i < il; ++i) {
-        this.remove(remove._set[i]);
+        this.remove(remove._set[ i ]);
     }
 };
 
@@ -765,18 +789,18 @@ internals.Set.prototype.remove = function (value) {
 internals.Set.prototype.has = function (value, state, options, insensitive) {
 
     for (var i = 0, il = this._set.length; i < il; ++i) {
-        var items = this._set[i];
+        var items = this._set[ i ];
 
         if (Ref.isRef(items)) {
             items = items(state.reference || state.parent, options);
         }
 
         if (!Array.isArray(items)) {
-            items = [items];
+            items = [ items ];
         }
 
         for (var j = 0, jl = items.length; j < jl; ++j) {
-            var item = items[j];
+            var item = items[ j ];
             if (typeof value !== typeof item) {
                 continue;
             }
@@ -801,7 +825,7 @@ internals.Set.prototype.values = function (options) {
         var values = [];
 
         for (var i = 0, il = this._set.length; i < il; ++i) {
-            var item = this._set[i];
+            var item = this._set[ i ];
             if (item !== undefined) {
                 values.push(item);
             }
@@ -818,8 +842,7 @@ internals.concatSettings = function (target, source) {
 
     // Used to avoid cloning context
 
-    if (!target &&
-        !source) {
+    if (!target && !source) {
 
         return null;
     }
@@ -829,22 +852,21 @@ internals.concatSettings = function (target, source) {
     if (target) {
         var tKeys = Object.keys(target);
         for (var i = 0, il = tKeys.length; i < il; ++i) {
-            key = tKeys[i];
-            obj[key] = target[key];
+            key = tKeys[ i ];
+            obj[ key ] = target[ key ];
         }
     }
 
     if (source) {
         var sKeys = Object.keys(source);
         for (var j = 0, jl = sKeys.length; j < jl; ++j) {
-            key = sKeys[j];
-            if (key !== 'language' ||
-                !obj.hasOwnProperty(key)) {
+            key = sKeys[ j ];
+            if (key !== 'language' || !obj.hasOwnProperty(key)) {
 
-                obj[key] = source[key];
+                obj[ key ] = source[ key ];
             }
             else {
-                obj[key] = Hoek.applyToDefaults(obj[key], source[key]);
+                obj[ key ] = Hoek.applyToDefaults(obj[ key ], source[ key ]);
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joi",
   "description": "Object schema validation",
-  "version": "6.3.0",
+  "version": "6.2.0",
   "repository": "git://github.com/hapijs/joi",
   "main": "index",
   "keywords": [
@@ -12,12 +12,17 @@
     "node": ">=0.10.30"
   },
   "dependencies": {
+    "es6-promise": "^2.1.1",
     "hoek": "^2.2.x",
-    "topo": "1.x.x",
     "isemail": "1.x.x",
-    "moment": "2.x.x"
+    "moment": "2.x.x",
+    "topo": "1.x.x"
   },
   "devDependencies": {
+    "bluebird": "^2.9.24",
+    "q": "^1.2.0",
+    "vow": "^0.4.9",
+    "when": "^3.7.2",
     "code": "1.x.x",
     "lab": "5.x.x",
     "markdown-toc": "^0.11.0"

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,0 +1,309 @@
+// Load modules
+
+var Lab = require('lab');
+var Code = require('code');
+var Joi = require('../lib');
+var Hoek = require('hoek');
+
+// Test shortcuts
+
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var before = lab.before;
+var after = lab.after;
+var expect = Code.expect;
+var deepEqual = Hoek.deepEqual;
+
+var common = function () {
+
+    var options = this.options;
+    var schema = this.schema;
+    var expected = this.expected;
+    var F = function () {
+
+        return  function () {
+
+        };
+    };
+
+    it('should validate without options', function (done) {
+
+        Joi.validate(expected, schema);
+        done();
+    });
+
+    it('should validate with global.Promise', function (done) {
+
+        global.Promise = require('bluebird');
+        Joi.validate(expected, schema, { asPromise: true })
+            .then(function (actual) {
+
+                expect(actual).to.equal(expected);
+                delete global.Promise;
+                done();
+            });
+    });
+
+    it('should not fail without a withPromises', function (done) {
+
+        Joi.validate(expected, schema, { asPromise: true })
+            .then(function (actual) {
+
+                expect(actual).to.equal(expected);
+                done();
+            });
+    });
+
+    it('should fail with a non-function withPromises', function (done) {
+
+        expect(function () {
+
+            Joi.validate(expected, schema, { asPromise: true, withPromises: null });
+        }).to.throw();
+        done();
+    });
+
+    it('should fail without Promises.resolve() and Promises.reject()', function (done) {
+
+        var Promises = F();
+        expect(function () {
+
+            Joi.validate(expected, schema, {
+                asPromise: true,
+                withPromises: Promises
+            });
+        }).to.throw(Error, /options\.asPromise/);
+        done();
+    });
+
+    it('fails without Promises.resolve()', function (done) {
+
+        var Promises = F();
+        Promises.reject = F();
+        expect(function () {
+
+            Joi.validate(expected, schema, {
+                asPromise: true,
+                withPromises: Promises
+            });
+        }).to.throw(Error, /options\.asPromise/);
+        done();
+    });
+
+    it('fails without Promises.reject()', function (done) {
+
+        var Promises = F();
+        Promises.resolve = F();
+        expect(function () {
+
+            Joi.validate(expected, schema, {
+                asPromise: true,
+                withPromises: Promises
+            });
+        }).to.throw(Error, /options\.asPromise/);
+        done();
+    });
+
+    it('resolves', function (done) {
+
+        Joi.validate(expected, schema, options)
+            .then(function (actual) {
+
+                expect(actual).to.equal(expected);
+                done();
+            })
+            .catch(function (err) {
+
+                expect(err).to.be.null();
+                done();
+            });
+    });
+
+    it('resolves', function (done) {
+
+        var expected = 100;
+        Joi.validate(expected, schema, options)
+            .then(function (actual) {
+
+                expect(actual).to.equal(expected);
+                done();
+            })
+            .catch(function (err) {
+
+                expect(err).to.not.be.null();
+                done();
+            });
+    });
+
+};
+
+describe('asPromise (bluebird)', function () {
+
+    var Promise = require('bluebird');
+    var options = {
+        asPromise: true,
+        withPromises: Promise
+    };
+    var schema = Joi.number().min(1).max(10);
+    var expected = 1;
+
+    it('provides a promise when requested', function (done) {
+
+        var result = Joi.validate(expected, schema, options);
+        expect(result).to.be.an.instanceof(Promise);
+        done();
+    });
+
+    it('does not unexpectedly provide a promise', function (done) {
+
+        var result = Joi.validate(expected, schema, {});
+        expect(result).to.not.be.a.function();
+        done();
+    });
+
+    common.call({ expected: 1, schema: schema, options: options });
+});
+
+describe('asPromise (q)', function () {
+
+    var Promise = require('q');
+    var options = {
+        asPromise: true,
+        withPromises: Promise
+    };
+    var schema = Joi.number().min(1).max(10);
+
+    it('provides a promise when requested', function (done) {
+
+        var result = Joi.validate(1, schema, options);
+        expect(Promise.isPromise(result)).to.be.true();
+        done();
+    });
+
+    it('does not unexpectedly provide a promise', function (done) {
+
+        var result = Joi.validate(1, schema, {});
+        expect(Promise.isPromise(result)).to.be.false();
+        done();
+    });
+
+    common.call({ schema: schema, options: options });
+});
+
+describe('asPromise (when)', function () {
+
+    var Promise = require('when/es6-shim/Promise');
+    var options = {
+        asPromise: true,
+        withPromises: Promise
+    };
+    var schema = Joi.number().min(1).max(10);
+
+    it('provides a promise when requested', function (done) {
+
+        var result = Joi.validate(1, schema, options);
+        expect(result).to.be.an.instanceof(Promise);
+        done();
+    });
+
+    it('does not unexpectedly provide a promise', function (done) {
+
+        var result = Joi.validate(1, schema, {});
+        expect(result).to.not.be.an.instanceof(Promise);
+        done();
+    });
+
+    common.call({ schema: schema, options: options });
+});
+
+describe('asPromise (vow)', function () {
+
+    var Promise = require('vow').Promise;
+    var options = {
+        asPromise: true,
+        withPromises: Promise
+    };
+    var schema = Joi.number().min(1).max(10);
+
+    it('provides a promise when requested', function (done) {
+
+        var result = Joi.validate(1, schema, options);
+        expect(result).to.be.an.instanceof(Promise);
+        done();
+    });
+
+    it('does not unexpectedly provide a promise', function (done) {
+
+        var result = Joi.validate(1, schema, {});
+        expect(result).to.not.be.an.instanceof(Promise);
+        done();
+    });
+
+    common.call({ schema: schema, options: options });
+});
+
+describe('asPromise (es6-promise)', function () {
+
+    var Promise = require('es6-promise').Promise;
+    var options = {
+        asPromise: true,
+        withPromises: Promise
+    };
+    var schema = Joi.number().min(1).max(10);
+
+    it('provides a promise when requested', function (done) {
+
+        var result = Joi.validate(1, schema, options);
+        expect(result).to.be.an.instanceof(Promise);
+        done();
+    });
+
+    it('does not unexpectedly provide a promise', function (done) {
+
+        var result = Joi.validate(1, schema, {});
+        expect(result).to.not.be.an.instanceof(Promise);
+        done();
+    });
+
+    common.call({ schema: schema, options: options });
+});
+
+
+describe('asPromise (es6-promise/polyfill)', function () {
+
+    before(function (done) {
+
+        delete global.Promise;
+        require('es6-promise').polyfill();
+        done();
+    });
+
+    var options = {
+        asPromise: true,
+        withPromises: Promise
+    };
+    var schema = Joi.number().min(1).max(10);
+
+    it('provides a promise when requested', function (done) {
+
+        var result = Joi.validate(1, schema, options);
+        expect(result).to.be.an.instanceof(Promise);
+        done();
+    });
+
+    it('does not unexpectedly provide a promise', function (done) {
+
+        var result = Joi.validate(1, schema, {});
+        expect(result).to.not.be.an.instanceof(Promise);
+        done();
+    });
+
+    common.call({ schema: schema, options: options });
+
+    after(function (done) {
+
+        delete global.Promise;
+        done();
+    });
+});


### PR DESCRIPTION
Extends `Joi.validate()` to return an ES6-compliant "resolve" or "reject" Promise, 
configureable via options.

If `options.asPromise` is `true`, joi.validate() returns `Promise.resolve(value)` 
on success and `Promise.reject(errors)` on failure.

If optional `options.withPromises` is set to an ES6 Promise Specification compliant 
Promise function, it will be used instead of the default Promise implementation,
(which is native Promise on ES6 platforms or [require('es6-promise').polyfill()](https://github.com/jakearchibald/es6-promise)).

Supports any ES6 compliant Promise implementation that provides `Promise.resolve()` 
and `Promise.reject()`.

Tests provided for:

- [bluebird](https://github.com/petkaantonov/bluebird)
- [q](https://github.com/kriskowal/q)
- [when](https://github.com/cujojs/when)
- [vow](https://github.com/dfilatov/vow)
- [es6-promise](https://github.com/jakearchibald/es6-promise) (with polyfill)

README.md updated with usage, working examples, and links to tested Promise modules 
and pertinent specs.