### PR TITLE
Implementation of white space normalisation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Lead Maintainer: [Nicolas Morel](https://github.com/marsup)
       - [`string.creditCard()`](#stringcreditcard)
       - [`string.length(limit, [encoding])`](#stringlengthlimit-encoding)
       - [`string.regex(pattern, [name])`](#stringregexpattern-name)
+      - [`string.replace(pattern, replacement)`](#stringreplacepattern-replacement)
       - [`string.alphanum()`](#stringalphanum)
       - [`string.token()`](#stringtoken)
       - [`string.email([options])`](#stringemailoptions)
@@ -1237,6 +1238,23 @@ Defines a regular expression rule where:
 ```javascript
 var schema = Joi.string().regex(/^[abc]+$/);
 ```
+
+#### `string.replace(pattern, replacement)`
+
+Replace characters matching the given _pattern_ with the specified
+_replacement_ string where:
+- `pattern` - a regular expression object to match against, or a string of which _all_ occurrences will be replaced.
+- `replacement` - the string that will replace the pattern.
+
+
+```javascript
+var schema = Joi.string().replace(/b/gi, 'x');
+schema.validate('abBc', function (err, value) {
+  // here value will be 'axxc'
+});
+```
+
+When `pattern` is a _string_ all its occurrences will be replaced.
 
 #### `string.alphanum()`
 

--- a/lib/string.js
+++ b/lib/string.js
@@ -70,6 +70,14 @@ internals.String.prototype._base = function (value, state, options) {
         if (this._flags.trim) {
             value = value.trim();
         }
+
+        if (this._inner.replacements) {
+
+            for (var r = 0, rl = this._inner.replacements.length; r < rl; ++r) {
+                var replacement = this._inner.replacements[r];
+                value = value.replace(replacement.pattern, replacement.replacement);
+            }
+        }
     }
 
     return {
@@ -427,6 +435,32 @@ internals.String.prototype.trim = function () {
     });
 
     obj._flags.trim = true;
+    return obj;
+};
+
+
+internals.String.prototype.replace = function (pattern, replacement) {
+
+    if (typeof pattern === 'string') {
+        pattern = new RegExp(Hoek.escapeRegex(pattern), 'g');
+    }
+
+    Hoek.assert(pattern instanceof RegExp, 'pattern must be a RegExp');
+    Hoek.assert(typeof replacement === 'string', 'replacement must be a String');
+
+    // This can not be considere a test like trim, we can't "reject"
+    // anything from this rule, so just clone the current object
+    var obj = this.clone();
+
+    if (!obj._inner.replacements) {
+        obj._inner.replacements = [];
+    }
+
+    obj._inner.replacements.push({
+        pattern: pattern,
+        replacement: replacement
+    });
+
     return obj;
 };
 

--- a/test/string.js
+++ b/test/string.js
@@ -555,6 +555,17 @@ describe('string', function () {
                 [1, false]
             ], done);
         });
+
+        it('should work in combination with a replacement', function (done) {
+
+            var schema = Joi.string().lowercase().replace(/\s+/g, ' ');
+            Helper.validate(schema, [
+                ['a\r b\n c', true, null, 'a b c'],
+                ['A\t B  C', true, null, 'a b c'],
+                ['ABC', true, null, 'abc'],
+                [1, false]
+            ], done);
+        });
     });
 
     describe('#uppercase', function () {
@@ -590,6 +601,17 @@ describe('string', function () {
                 [' abc', true],
                 [' ABC', true],
                 ['ABC', true],
+                [1, false]
+            ], done);
+        });
+
+        it('works in combination with a forced replacement', function (done) {
+
+            var schema = Joi.string().uppercase().replace(/\s+/g, ' ');
+            Helper.validate(schema, [
+                ['a\r b\n c', true, null, 'A B C'],
+                ['A\t B  C', true, null, 'A B C'],
+                ['ABC', true, null, 'ABC'],
                 [1, false]
             ], done);
         });
@@ -670,6 +692,95 @@ describe('string', function () {
                 ['ABC', true]
             ], done);
         });
+    });
+
+    describe('#replace', function () {
+
+        it('successfully replaces the first occurrence of the expression', function (done) {
+
+            var schema = Joi.string().replace(/\s+/, ''); // no "g" flag
+            Helper.validateOptions(schema, [
+                ['\tsomething', true, null, 'something'],
+                ['something\r', true, null, 'something'],
+                ['something  ', true, null, 'something'],
+                ['some  thing', true, null, 'something'],
+                ['so me thing', true, null, 'some thing'] // first occurrence!
+            ], { convert: true }, done);
+        });
+
+        it('successfully replaces all occurrences of the expression', function (done) {
+
+            var schema = Joi.string().replace(/\s+/g, ''); // has "g" flag
+            Helper.validateOptions(schema, [
+                ['\tsomething', true, null, 'something'],
+                ['something\r', true, null, 'something'],
+                ['something  ', true, null, 'something'],
+                ['some  thing', true, null, 'something'],
+                ['so me thing', true, null, 'something']
+            ], { convert: true }, done);
+        });
+
+        it('successfully replaces all occurrences of a string pattern', function (done) {
+
+            var schema = Joi.string().replace('foo', 'X'); // has "g" flag
+            Helper.validateOptions(schema, [
+                ['foobarfoobazfoo', true, null, 'XbarXbazX']
+            ], { convert: true }, done);
+        });
+
+        it('successfully replaces multiple times', function (done) {
+
+            var schema = Joi.string().replace(/a/g, 'b').replace(/b/g, 'c');
+            schema.validate('a quick brown fox', function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value).to.equal('c quick crown fox');
+                done();
+            });
+        });
+
+        it('should work in combination with trim', function (done) {
+
+            // The string below is the name "Yamada Tarou" separated by a
+            // carriage return, a "full width" ideographic space and a newline
+
+            var schema = Joi.string().trim().replace(/\s+/g, ' ');
+            schema.validate(' \u5C71\u7530\r\u3000\n\u592A\u90CE ', function (err, value) {
+
+                expect(err).to.not.exist();
+                expect(value).to.equal('\u5C71\u7530 \u592A\u90CE');
+                done();
+            });
+        });
+
+        it('should work in combination with min', function (done) {
+
+            var schema = Joi.string().min(4).replace(/\s+/g, ' ');
+            Helper.validate(schema, [
+                ['   a   ', false],
+                ['abc    ', true, null, 'abc '],
+                ['a\t\rbc', true, null, 'a bc']
+            ], done);
+        });
+
+        it('should work in combination with max', function (done) {
+
+            var schema = Joi.string().max(5).replace(/ CHANGE ME /g, '-b-');
+            Helper.validate(schema, [
+                ['a CHANGE ME c', true, null, 'a-b-c'],
+                ['a-b-c', true, null, 'a-b-c'] // nothing changes here!
+            ], done);
+        });
+
+        it('should work in combination with length', function (done) {
+
+            var schema = Joi.string().length(5).replace(/\s+/g, ' ');
+            Helper.validate(schema, [
+                ['a    bc', false],
+                ['a\tb\nc', true, null, 'a b c']
+            ], done);
+        });
+
     });
 
     describe('#regex', function () {


### PR DESCRIPTION
This is an implementation of the request made at hapijs/joi#648

I have added the `string.normalize()` function (basically inspired by `trim()`) following the name XSLT/XPath/XQuery gave to it (I was in doubt whether to call this `normalizeSpace()` or `normalize_space()`, but it seems JOI prefers shorter names).

I'm always baffled by `normalise` vs. `normalize`... I guess I'll go with the latter (again, XSLT/XPath/XQuery...)
