### PR TITLE
Fix allowing context refs on some string, number and date methods

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -107,7 +107,7 @@ internals.compare = function (type, compare) {
                 compareTo = Date.now();
             }
             else if (isRef) {
-                compareTo = internals.toDate(date(state.parent));
+                compareTo = internals.toDate(date(state.parent, options));
 
                 if (!compareTo) {
                     return Errors.create('date.ref', { ref: date.key }, state, options);

--- a/lib/number.js
+++ b/lib/number.js
@@ -34,7 +34,7 @@ internals.compare = function (type, compare) {
 
             var compareTo;
             if (isRef) {
-                compareTo = limit(state.parent);
+                compareTo = limit(state.parent, options);
 
                 if (!(typeof compareTo === 'number' && !isNaN(compareTo))) {
                     return Errors.create('number.ref', { ref: limit.key }, state, options);

--- a/lib/string.js
+++ b/lib/string.js
@@ -39,7 +39,7 @@ internals.compare = function (type, compare) {
 
             var compareTo;
             if (isRef) {
-                compareTo = limit(state.parent);
+                compareTo = limit(state.parent, options);
 
                 if (!Hoek.isInteger(compareTo)) {
                     return Errors.create('string.ref', { ref: limit.key }, state, options);

--- a/test/date.js
+++ b/test/date.js
@@ -125,14 +125,38 @@ describe('date', function () {
                 ], done);
             });
 
+            it('accepts context references as min date', function (done) {
+
+                var schema = Joi.object({ b: Joi.date().min(Joi.ref('$a')) });
+                var now = Date.now();
+
+                Helper.validate(schema, [
+                    [{ b: now }, true, { context: { a: now } }],
+                    [{ b: now + 1e3 }, true, { context: { a: now } }],
+                    [{ b: now - 1e3 }, false, { context: { a: now } }]
+                ], done);
+            });
+
             it('errors if reference is not a date', function (done) {
 
                 var schema = Joi.object({ a: Joi.string(), b: Joi.date().min(Joi.ref('a')) });
+                var now = Date.now();
 
                 Helper.validate(schema, [
-                    [{ a: 'abc', b: new Date() }, false, null, 'child "b" fails because ["b" references "a" which is not a date]'],
-                    [{ a: '123', b: new Date() }, true],
-                    [{ a: (Date.now() + 1e3).toString(), b: new Date() }, false, null, /^child "b" fails because \["b" must be larger than or equal to/]
+                    [{ a: 'abc', b: now }, false, null, 'child "b" fails because ["b" references "a" which is not a date]'],
+                    [{ a: '123', b: now }, true],
+                    [{ a: (now + 1e3).toString(), b: now }, false, null, /^child "b" fails because \["b" must be larger than or equal to/]
+                ], done);
+            });
+
+            it('errors if context reference is not a date', function (done) {
+
+                var schema = Joi.object({ b: Joi.date().min(Joi.ref('$a')) });
+                var now = Date.now();
+
+                Helper.validate(schema, [
+                    [{ b: now }, false, { context: { a: 'abc' } }, 'child "b" fails because ["b" references "a" which is not a date]'],
+                    [{ b: now }, false, { context: { a: (now + 1e3).toString() } }, /^child "b" fails because \["b" must be larger than or equal to/]
                 ], done);
             });
         });
@@ -187,14 +211,39 @@ describe('date', function () {
                 ], done);
             });
 
+            it('accepts references as max date', function (done) {
+
+                var schema = Joi.object({ b: Joi.date().max(Joi.ref('$a')) });
+                var now = Date.now();
+
+                Helper.validate(schema, [
+                    [{ b: now }, true, { context: { a: now } }],
+                    [{ b: now + 1e3 }, false, { context: { a: now } }],
+                    [{ b: now - 1e3 }, true, { context: { a: now } }]
+                ], done);
+            });
+
             it('errors if reference is not a date', function (done) {
 
                 var schema = Joi.object({ a: Joi.string(), b: Joi.date().max(Joi.ref('a')) });
+                var now = Date.now();
 
                 Helper.validate(schema, [
                     [{ a: 'abc', b: new Date() }, false, null, 'child "b" fails because ["b" references "a" which is not a date]'],
-                    [{ a: '100000000000000', b: new Date() }, true],
-                    [{ a: (Date.now() - 1e3).toString(), b: new Date() }, false, null, /^child "b" fails because \["b" must be less than or equal to/]
+                    [{ a: '100000000000000', b: now }, true],
+                    [{ a: (now - 1e3).toString(), b: now }, false, null, /^child "b" fails because \["b" must be less than or equal to/]
+                ], done);
+            });
+
+            it('errors if context reference is not a date', function (done) {
+
+                var schema = Joi.object({ b: Joi.date().max(Joi.ref('$a')) });
+                var now = Date.now();
+
+                Helper.validate(schema, [
+                    [{ b: now }, false, { context: { a: 'abc' } }, 'child "b" fails because ["b" references "a" which is not a date]'],
+                    [{ b: now }, true, { context: { a: '100000000000000' } }],
+                    [{ b: now }, false, { context: { a: (now - 1e3).toString() } }, /^child "b" fails because \["b" must be less than or equal to/]
                 ], done);
             });
         });

--- a/test/number.js
+++ b/test/number.js
@@ -553,12 +553,35 @@ describe('number', function () {
             ], done);
         });
 
+        it('accepts context references as min value', function (done) {
+
+            var schema = Joi.object({ b: Joi.number().min(Joi.ref('$a')) });
+
+            Helper.validate(schema, [
+                [{ b: 1337 }, true, { context: { a: 42 } }],
+                [{ b: 42 }, false, { context: { a: 1337 } }],
+                [{ b: 4.2 }, true, { context: { a: 2.4 } }],
+                [{ b: 4.20000001 }, true, { context: { a: 4.2 } }],
+                [{ b: 4.2 }, false, { context: { a: 4.20000001 } }],
+                [{ b: 2.4 }, false, { context: { a: 4.2 } }, 'child "b" fails because ["b" must be larger than or equal to 4.2]']
+            ], done);
+        });
+
         it('errors if reference is not a number', function (done) {
 
             var schema = Joi.object({ a: Joi.string(), b: Joi.number().min(Joi.ref('a')) });
 
             Helper.validate(schema, [
                 [{ a: 'abc', b: 42 }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+
+        it('errors if context reference is not a number', function (done) {
+
+            var schema = Joi.object({ b: Joi.number().min(Joi.ref('$a')) });
+
+            Helper.validate(schema, [
+                [{ b: 42 }, false, { context: { a: 'abc' } }, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });
@@ -589,12 +612,35 @@ describe('number', function () {
             ], done);
         });
 
+        it('accepts context references as max value', function (done) {
+
+            var schema = Joi.object({ b: Joi.number().max(Joi.ref('$a')) });
+
+            Helper.validate(schema, [
+                [{ b: 42 }, true, { context: { a: 1337 } }],
+                [{ b: 1337 }, false, { context: { a: 42 } }],
+                [{ b: 2.4 }, true, { context: { a: 4.2 } }],
+                [{ b: 4.20000001 }, false, { context: { a: 4.2 } }],
+                [{ b: 4.2 }, true, { context: { a: 4.20000001 } }],
+                [{ b: 4.2 }, false, { context: { a: 2.4 } }, 'child "b" fails because ["b" must be less than or equal to 2.4]']
+            ], done);
+        });
+
         it('errors if reference is not a number', function (done) {
 
             var schema = Joi.object({ a: Joi.string(), b: Joi.number().max(Joi.ref('a')) });
 
             Helper.validate(schema, [
                 [{ a: 'abc', b: 42 }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+
+        it('errors if context reference is not a number', function (done) {
+
+            var schema = Joi.object({ b: Joi.number().max(Joi.ref('$a')) });
+
+            Helper.validate(schema, [
+                [{ b: 42 }, false, { context: { a: 'abc' } }, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });
@@ -625,12 +671,35 @@ describe('number', function () {
             ], done);
         });
 
+        it('accepts context references as less value', function (done) {
+
+            var schema = Joi.object({ b: Joi.number().less(Joi.ref('$a')) });
+
+            Helper.validate(schema, [
+                [{ b: 42 }, true, { context: { a: 1337 } }],
+                [{ b: 1337 }, false, { context: { a: 42 } }],
+                [{ b: 2.4 }, true, { context: { a: 4.2 } }],
+                [{ b: 4.20000001 }, false, { context: { a: 4.2 } }],
+                [{ b: 4.2 }, true, { context: { a: 4.20000001 } }],
+                [{ b: 4.2 }, false, { context: { a: 2.4 } }, 'child "b" fails because ["b" must be less than 2.4]']
+            ], done);
+        });
+
         it('errors if reference is not a number', function (done) {
 
             var schema = Joi.object({ a: Joi.string(), b: Joi.number().less(Joi.ref('a')) });
 
             Helper.validate(schema, [
                 [{ a: 'abc', b: 42 }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+
+        it('errors if context reference is not a number', function (done) {
+
+            var schema = Joi.object({ a: Joi.string(), b: Joi.number().less(Joi.ref('$a')) });
+
+            Helper.validate(schema, [
+                [{ b: 42 }, false, { context: { a: 'abc' } }, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });
@@ -661,12 +730,35 @@ describe('number', function () {
             ], done);
         });
 
+        it('accepts context references as greater value', function (done) {
+
+            var schema = Joi.object({ b: Joi.number().greater(Joi.ref('$a')) });
+
+            Helper.validate(schema, [
+                [{ b: 1337 }, true, { context: { a: 42 } }],
+                [{ b: 42 }, false, { context: { a: 1337 } }],
+                [{ b: 4.2 }, true, { context: { a: 2.4 } }],
+                [{ b: 4.20000001 }, true, { context: { a: 4.2 } }],
+                [{ b: 4.2 }, false, { context: { a: 4.20000001 } }],
+                [{ b: 2.4 }, false, { context: { a: 4.2 } }, 'child "b" fails because ["b" must be greater than 4.2]']
+            ], done);
+        });
+
         it('errors if reference is not a number', function (done) {
 
             var schema = Joi.object({ a: Joi.string(), b: Joi.number().greater(Joi.ref('a')) });
 
             Helper.validate(schema, [
                 [{ a: 'abc', b: 42 }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+
+        it('errors if context reference is not a number', function (done) {
+
+            var schema = Joi.object({ b: Joi.number().greater(Joi.ref('$a')) });
+
+            Helper.validate(schema, [
+                [{ b: 42 }, false, { context: { a: 'abc' } }, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });

--- a/test/string.js
+++ b/test/string.js
@@ -175,12 +175,31 @@ describe('string', function () {
             ], done);
         });
 
+        it('accepts context references as min length', function (done) {
+
+            var schema = Joi.object({ b: Joi.string().min(Joi.ref('$a'), 'utf8') });
+            Helper.validate(schema, [
+                [{ b: '\u00bd' }, true, { context: { a: 2 } }],
+                [{ b: 'a' }, false, { context: { a: 2 } }],
+                [{ b: 'a' }, false, { context: { a: 2 } }, 'child "b" fails because ["b" length must be at least 2 characters long]']
+            ], done);
+        });
+
         it('errors if reference is not a number', function (done) {
 
             var schema = Joi.object({ a: Joi.any(), b: Joi.string().min(Joi.ref('a'), 'utf8') });
 
             Helper.validate(schema, [
                 [{ a: 'Hi there', b: '\u00bd' }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+
+        it('errors if context reference is not a number', function (done) {
+
+            var schema = Joi.object({ b: Joi.string().min(Joi.ref('$a'), 'utf8') });
+
+            Helper.validate(schema, [
+                [{ b: '\u00bd' }, false, { context: { a: 'Hi there' } }, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });
@@ -233,12 +252,31 @@ describe('string', function () {
             ], done);
         });
 
+        it('accepts context references as min length', function (done) {
+
+            var schema = Joi.object({ b: Joi.string().max(Joi.ref('$a'), 'utf8') });
+            Helper.validate(schema, [
+                [{ b: '\u00bd' }, true, { context: { a: 2 } }],
+                [{ b: 'three' }, false, { context: { a: 2 } }],
+                [{ b: 'three' }, false, { context: { a: 2 } }, 'child "b" fails because ["b" length must be less than or equal to 2 characters long]']
+            ], done);
+        });
+
         it('errors if reference is not a number', function (done) {
 
             var schema = Joi.object({ a: Joi.any(), b: Joi.string().max(Joi.ref('a'), 'utf8') });
 
             Helper.validate(schema, [
                 [{ a: 'Hi there', b: '\u00bd' }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+
+        it('errors if context reference is not a number', function (done) {
+
+            var schema = Joi.object({ b: Joi.string().max(Joi.ref('$a'), 'utf8') });
+
+            Helper.validate(schema, [
+                [{ b: '\u00bd' }, false, { context: { a: 'Hi there' } }, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });
@@ -328,12 +366,31 @@ describe('string', function () {
             ], done);
         });
 
+        it('accepts context references as length', function (done) {
+
+            var schema = Joi.object({ b: Joi.string().length(Joi.ref('$a'), 'utf8') });
+            Helper.validate(schema, [
+                [{ b: '\u00bd' }, true, { context: { a: 2 } }],
+                [{ b: 'a' }, false, { context: { a: 2 } }],
+                [{ b: 'a' }, false, { context: { a: 2 } }, 'child "b" fails because ["b" length must be 2 characters long]']
+            ], done);
+        });
+
         it('errors if reference is not a number', function (done) {
 
             var schema = Joi.object({ a: Joi.any(), b: Joi.string().length(Joi.ref('a'), 'utf8') });
 
             Helper.validate(schema, [
                 [{ a: 'Hi there', b: '\u00bd' }, false, null, 'child "b" fails because ["b" references "a" which is not a number]']
+            ], done);
+        });
+
+        it('errors if context reference is not a number', function (done) {
+
+            var schema = Joi.object({ a: Joi.any(), b: Joi.string().length(Joi.ref('$a'), 'utf8') });
+
+            Helper.validate(schema, [
+                [{ b: '\u00bd' }, false, { context: { a: 'Hi there' } }, 'child "b" fails because ["b" references "a" which is not a number]']
             ], done);
         });
     });


### PR DESCRIPTION
Invoking the following methods:

 - number: min, max, less and greater
 - string: min, max and length
 - data: max and min

with e.g. Joi.ref('$a') causes the error: `Cannot read property 'context' of undefined` at lib/ref.js:19:256

The validation options where not being passed to the ref validation function, so only normal refs were working, but not context refs.