### PR TITLE
fix unknown nested key path

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -247,10 +247,7 @@ internals.annotate = function () {
     }
 
     var message = internals.safeStringify(obj, 2)
-        .replace(/\[Circular (.*?)_\$key\$_([, \d]+)_\$end\$_\]/g, function ($0, $1) {
-
-            return '[Circular ' + $1 + ']';
-        }).replace(/_\$key\$_([, \d]+)_\$end\$_\"/g, function ($0, $1) {
+        .replace(/_\$key\$_([, \d]+)_\$end\$_\"/g, function ($0, $1) {
 
             return '" \u001b[31m[' + $1 + ']\u001b[0m';
         }).replace(/\"_\$miss\$_([^\|]+)\|(\d+)_\$end\$_\"\: \"__missing__\"/g, function ($0, $1, $2) {

--- a/lib/object.js
+++ b/lib/object.js
@@ -238,7 +238,7 @@ internals.Object.prototype._base = function (value, state, options) {
             (this._flags.allowUnknown !== undefined ? !this._flags.allowUnknown : !options.allowUnknown)) {
 
             for (var e = 0, el = unprocessedKeys.length; e < el; ++e) {
-                errors.push(Errors.create('object.allowUnknown', null, { key: unprocessedKeys[e], path: state.path }, options));
+                errors.push(Errors.create('object.allowUnknown', null, { key: unprocessedKeys[e], path: state.path + '.' + unprocessedKeys[e] }, options));
             }
         }
     }

--- a/test/errors.js
+++ b/test/errors.js
@@ -344,7 +344,7 @@ describe('errors', function () {
             Joi.validate(input, schema, function (err, value) {
 
                 expect(err).to.exist();
-                expect(err.annotate()).to.equal('{\n  \"x\": {\n    \"y\" \u001b[31m[1]\u001b[0m: {\n      \"z\": 1,\n      \"foo\": \"[Circular ~.x.y]\"\n    }\n  }\n}\n\u001b[31m\n[1] \"foo\" is not allowed\u001b[0m');
+                expect(err.annotate()).to.equal('{\n  \"x\": {\n    \"y\": {\n      \"z\": 1,\n      \"foo\" \u001b[31m[1]\u001b[0m: \"[Circular ~.x.y]\"\n    }\n  }\n}\n\u001b[31m\n[1] \"foo\" is not allowed\u001b[0m');
                 done();
             });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -1305,7 +1305,7 @@ describe('Joi', function () {
                 context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined }
             }, {
                 message: '"baz" is not allowed',
-                path: 'test2.test3.2.baz.test4.0',
+                path: 'test2.test3.2.baz.test4.0.baz',
                 type: 'object.allowUnknown',
                 context: { key: 'baz' }
             }]);

--- a/test/object.js
+++ b/test/object.js
@@ -352,6 +352,18 @@ describe('object', function () {
         ], done);
     });
 
+    it('errors on unknown nested keys with the correct path', function (done) {
+
+        var schema = Joi.object({ a: Joi.object().keys({}) });
+        var obj = { a: { b: 'value' } };
+        schema.validate(obj, function (err, value) {
+
+            expect(err).to.exist();
+            expect(err.details[0].path).to.equal('a.b');
+            done();
+        });
+    });
+
     describe('#keys', function () {
 
         it('allows any key', function (done) {


### PR DESCRIPTION
While working on building a custom error message formatter for Joi validation errors, I noticed an inconsistency with the `path` attribute of unknown object keys. Nested object keys don't have the full path. For example:

```js
Joi.validate({ key: 'value' }, {}, function (err) {
  console.log(err.details[0].path); // prints "key"
});

Joi.validate({ key: { nestedKey: 'value' } }, { key: {} }, function (err) {
  console.log(err.details[0].path); // prints "key" instead of "key.nestedKey"
});
```

This patch adds the full path to validation errors of unknown nested keys.