### PR TITLE
Enables to use when on undefined properties

### DIFF
--- a/lib/alternatives.js
+++ b/lib/alternatives.js
@@ -81,7 +81,7 @@ internals.Alternatives.prototype.when = function (ref, options) {
     var obj = this.clone();
     var is = Cast.schema(options.is);
 
-    if (options.is === null || !options.is.isJoi) {
+    if (options.is === null || (options.is !== undefined && !options.is.isJoi)) {
 
         // Only apply required if this wasn't already a schema, we'll suppose people know what they're doing
         is = is.required();

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -63,9 +63,7 @@ exports.schema = function (config) {
         return internals.any.valid(config);
     }
 
-    Hoek.assert(config === null, 'Invalid schema content:', config);
-
-    return internals.any.valid(null);
+    return internals.any.valid(config);
 };
 
 

--- a/test/alternatives.js
+++ b/test/alternatives.js
@@ -189,6 +189,22 @@ describe('alternatives', function () {
             ], done);
         });
 
+        it('validates when is is undefined', function (done) {
+
+            var schema = {
+                a: Joi.alternatives().when('b', { is: undefined, then: 'x', otherwise: Joi.number() }),
+                b: Joi.any()
+            };
+
+            Helper.validate(schema, [
+                [{ a: 1 }, false],
+                [{ a: 'y' }, false],
+                [{ a: 'x' }, true],
+                [{ a: 2, b: null }, true],
+                [{ a: 3, b: 'y' }, true]
+            ], done);
+        });
+
         it('validates when is is null', function (done) {
 
             var schema = {


### PR DESCRIPTION
This PR aims to resolve a regression (occured at the v6.0.2) on alternatives. 
We can't use ``alternatives().when()`` on undefined properties anymore.
In other words, we can't say "if this property is here, then do this, otherwise, do that" anymore.