### PR TITLE
removes trailing "." from or path

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -141,7 +141,7 @@ internals.Object.prototype._base = function (value, state, options) {
 
             delete unprocessed[key];
 
-            localState = { key: key, path: (state.path ? state.path + '.' : '') + key, parent: target, reference: state.reference };
+            localState = { key: key, path: (state.path || '') + (state.path && key ? '.' : '') + key, parent: target, reference: state.reference };
             result = child.schema._validate(item, localState, options);
             if (result.errors) {
                 errors.push(Errors.create('object.child', { key: key, reason: result.errors }, localState, options));
@@ -235,7 +235,7 @@ internals.Object.prototype._base = function (value, state, options) {
 
     for (var d = 0, dl = this._inner.dependencies.length; d < dl; ++d) {
         var dep = this._inner.dependencies[d];
-        var err = internals[dep.type](dep.key !== null && value[dep.key], dep.peers, target, { key: dep.key, path: (state.path ? state.path + '.' : '') + (dep.key || '') }, options);
+        var err = internals[dep.type](dep.key !== null && value[dep.key], dep.peers, target, { key: dep.key, path: (state.path || '') + (dep.key ? '.' + dep.key : '') }, options);
         if (err) {
             errors.push(err);
             if (options.abortEarly) {

--- a/test/object.js
+++ b/test/object.js
@@ -1015,6 +1015,7 @@ describe('object', function () {
             }).validate({ a: { b: { c: 1 } } }, function (err, value) {
 
                 expect(err).to.exist();
+                expect(err.details[0].path).to.equal('a.b');
                 expect(err.message).to.equal('child "a" fails because [child "b" fails because ["value" must contain at least one of [x, y]]]');
                 done();
             });


### PR DESCRIPTION
I noticed that the `path` on failing `or` validators has a trailing `.` which I believe is incorrect. This fixes that.