### PR TITLE
test: prototype-less objects

### DIFF
--- a/test/object.js
+++ b/test/object.js
@@ -1186,5 +1186,21 @@ describe('object', function () {
             expect(description.rules).to.deep.include({ name: 'type', arg: 'RegExp' });
             done();
         });
+
+        it('should work on prototype-less objects', function (done) {
+
+            var input = Object.create(null);
+            var schema = Joi.object().keys({
+                a: Joi.number()
+            });
+
+            input.a = 1337;
+
+            Joi.validate(input, schema, function (err) {
+
+                expect(err).to.not.exist();
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
It turns out that I didn't manage to reproduce the issue reported in #693, and I believe that the error must lie in an external error. Nevertheless, I thought it would be good to add a test for this as to prevent it from happening in the future.