### PR TITLE
add hapi to package.json keywords so joi is searchable

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "git://github.com/hapijs/joi",
   "main": "lib/index.js",
   "keywords": [
+    "hapi",
     "schema",
     "validation"
   ],


### PR DESCRIPTION
joi isn't coming up in https://hapi-plugins.com/ results because `hapi` isn't in the keywords.