### PR TITLE
allow npm 3 in package.json engines entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "engines": {
     "node": ">=0.10.30",
-    "npm": "2.x"
+    "npm": ">=2.0.0"
   },
   "dependencies": {
     "hoek": "^2.2.x",


### PR DESCRIPTION
As [npm 3](https://github.com/npm/npm/releases/tag/v3.2.1) is out (still in beta though).
I don't see why not support it in package.json.