### PR TITLE
Add isValid() method that returns boolean

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,6 +8,7 @@
 
 - [Joi](#joi)
   - [`validate(value, schema, [options], [callback])`](#validatevalue-schema-options-callback)
+  - [`isValid(value, schema, [options])`](#isvalidvalue-schema-options)
   - [`compile(schema)`](#compileschema)
   - [`assert(value, schema, [message])`](#assertvalue-schema-message)
   - [`attempt(value, schema, [message])`](#attemptvalue-schema-message)
@@ -156,6 +157,10 @@ var result = Joi.validate(value, schema);
 // result.error -> null
 // result.value -> { "a" : 123 }
 ```
+
+### `isValid(value, schema, [options])`
+
+The same as `validate`, but returns `true` if the validation passed, otherwise `false`.
 
 ### `compile(schema)`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,7 @@ internals.root = function () {
 
     root.isValid = function (value, schema, options) {
 
-        return !!root.validate(value, schema, options).error;
+        return !root.validate(value, schema, options).error;
     };
 
     root.assert = function (value, schema, message) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,11 @@ internals.root = function () {
         return Cast.schema(schema);
     };
 
+    root.isValid = function (value, schema, options) {
+
+        return !!root.validate(value, schema, options).error;
+    };
+
     root.assert = function (value, schema, message) {
 
         root.attempt(value, schema, message);

--- a/test/index.js
+++ b/test/index.js
@@ -1595,6 +1595,32 @@ describe('Joi', function () {
         });
     });
 
+    describe('#isValid', function () {
+
+        it('returns true on valid value', function (done) {
+
+            var result = Joi.isValid('4', Joi.number());
+            expect(result).to.be.a.boolean().and.to.equal(true);
+            done();
+        });
+
+        it('returns false on invalid value', function (done) {
+
+            var result = Joi.isValid('x', Joi.number());
+            expect(result).to.be.a.boolean().and.to.equal(false);
+            done();
+        });
+
+        it('does not throw on invalid value', function (done) {
+
+            expect(function () {
+
+                Joi.isValid('x', Joi.number());
+            }).to.not.throw();
+            done();
+        });
+    });
+
     describe('#assert', function () {
 
         it('does not have a return value', function (done) {


### PR DESCRIPTION
Sometimes validating with a boolean is desirable if you're not interested in the error reason or the converted value and also don't want to use assert(). This adds method isValid() that works like validate, but returns nothing but a boolean. Opinions?