### PR TITLE
removes leading "." from path at root object level

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -231,7 +231,7 @@ internals.Object.prototype._base = function (value, state, options) {
             (this._flags.allowUnknown !== undefined ? !this._flags.allowUnknown : !options.allowUnknown)) {
 
             for (var e = 0, el = unprocessedKeys.length; e < el; ++e) {
-                errors.push(Errors.create('object.allowUnknown', null, { key: unprocessedKeys[e], path: state.path + '.' + unprocessedKeys[e] }, options));
+                errors.push(Errors.create('object.allowUnknown', null, { key: unprocessedKeys[e], path: state.path + (state.path ? '.' : '') + unprocessedKeys[e] }, options));
             }
         }
     }

--- a/test/object.js
+++ b/test/object.js
@@ -362,6 +362,17 @@ describe('object', function () {
         });
     });
 
+    it('errors on unknown nested keys with the correct path at the root level', function (done) {
+
+        var schema = Joi.object({ a: Joi.object().keys({}) });
+        var obj = { c: 'hello' };
+        schema.validate(obj, function (err, value) {
+
+            expect(err).to.exist();
+            expect(err.details[0].path).to.equal('c');
+            done();
+        });
+    });
 
     it('should work on prototype-less objects', function (done) {
 


### PR DESCRIPTION
Small bug fix for the `path` returned in the details when unknown keys are not allowed at the root level. The path contained a leading `.` that was not necessary.

Related to #690 and #684.