### PR TITLE
Add a arity predicate for functions

### DIFF
--- a/API.md
+++ b/API.md
@@ -55,6 +55,9 @@
     - [`date.format(format)`](#dateformatformat)
     - [`date.iso()`](#dateiso)
   - [`func`](#func)
+    - [`func.arity(n)`](#funcarityn)
+    - [`func.minArity(n)`](#funcminarityn)
+    - [`func.maxArity(n)`](#funcmaxarityn)
   - [`number`](#number)
     - [`number.min(limit)`](#numberminlimit)
     - [`number.max(limit)`](#numbermaxlimit)
@@ -745,6 +748,34 @@ set to `0`).
 var func = Joi.func();
 func.validate(function () {}, function (err, value) { });
 ```
+
+#### `func.arity(n)`
+
+Specifies the arity of the function where:
+- `n` - the arity expected.
+
+```javascript
+var schema = Joi.func().arity(2);
+```
+
+#### `func.minArity(n)`
+
+Specifies the minimal arity of the function where:
+- `n` - the minimal arity expected.
+
+```javascript
+var schema = Joi.func().minArity(1);
+```
+
+#### `func.maxArity(n)`
+
+Specifies the maximal arity of the function where:
+- `n` - the maximum arity expected.
+
+```javascript
+var schema = Joi.func().arity(3);
+```
+
 
 ### `number`
 

--- a/lib/language.js
+++ b/lib/language.js
@@ -61,7 +61,10 @@ exports.errors = {
         ref: 'references "{{ref}}" which is not a date'
     },
     function: {
-        base: 'must be a Function'
+        base: 'must be a Function',
+        arity: 'must have an arity of {{n}}',
+        minArity: 'must have an arity greater or equal to {{n}}',
+        maxArity: 'must have an arity lesser or equal to {{n}}'
     },
     object: {
         base: 'must be an object',

--- a/lib/object.js
+++ b/lib/object.js
@@ -339,6 +339,48 @@ internals.Object.prototype.length = function (limit) {
     });
 };
 
+internals.Object.prototype.arity = function (n) {
+
+    Hoek.assert(Hoek.isInteger(n) && n >= 0, 'n must be a positive integer');
+
+    return this._test('arity', n, (value, state, options) => {
+
+        if (value.length === n) {
+            return null;
+        }
+
+        return Errors.create('function.arity', { n }, state, options);
+    });
+};
+
+internals.Object.prototype.minArity = function (n) {
+
+    Hoek.assert(Hoek.isInteger(n) && n > 0, 'n must be a strict positive integer');
+
+    return this._test('minArity', n, (value, state, options) => {
+
+        if (value.length >= n) {
+            return null;
+        }
+
+        return Errors.create('function.minArity', { n }, state, options);
+    });
+};
+
+internals.Object.prototype.maxArity = function (n) {
+
+    Hoek.assert(Hoek.isInteger(n) && n >= 0, 'n must be a positive integer');
+
+    return this._test('maxArity', n, (value, state, options) => {
+
+        if (value.length <= n) {
+            return null;
+        }
+
+        return Errors.create('function.maxArity', { n }, state, options);
+    });
+};
+
 
 internals.Object.prototype.min = function (limit) {
 

--- a/test/function.js
+++ b/test/function.js
@@ -27,8 +27,103 @@ describe('func', () => {
 
         Helper.validate(Joi.func().required(), [
             [function () { }, true],
-            ['', false]
+            ['', false, null, '"value" must be a Function']
         ], done);
+    });
+
+    it('validates a function arity', (done) => {
+
+        Helper.validate(Joi.func().arity(2).required(), [
+            [function (a,b) { }, true],
+            [function (a,b,c) { }, false, null, '"value" must have an arity of 2'],
+            [function (a) { }, false, null, '"value" must have an arity of 2'],
+            [(a,b) => { }, true],
+            [(a,b,c) => { }, false, null, '"value" must have an arity of 2'],
+            [(a) => { }, false, null, '"value" must have an arity of 2'],
+            ['', false, null, '"value" must be a Function']
+        ], done);
+    });
+
+    it('validates a function arity unless values are illegal', (done) => {
+
+        const schemaWithStringArity = function (){
+
+            return Joi.func().arity('deux');
+        };
+
+        const schemaWithNegativeArity = function (){
+
+            return Joi.func().arity(-2);
+        };
+
+        expect(schemaWithStringArity).to.throw(Error, 'n must be a positive integer');
+        expect(schemaWithNegativeArity).to.throw(Error, 'n must be a positive integer');
+        done();
+    });
+
+    it('validates a function min arity', (done) => {
+
+        Helper.validate(Joi.func().minArity(2).required(), [
+            [function (a,b) { }, true],
+            [function (a,b,c) { }, true],
+            [function (a) { }, false, null, '"value" must have an arity greater or equal to 2'],
+            [(a,b) => { }, true],
+            [(a,b,c) => { }, true],
+            [(a) => { }, false, null, '"value" must have an arity greater or equal to 2'],
+            ['', false, null, '"value" must be a Function']
+        ], done);
+    });
+
+    it('validates a function arity unless values are illegal', (done) => {
+
+        const schemaWithStringMinArity = function (){
+
+            return Joi.func().minArity('deux');
+        };
+
+        const schemaWithNegativeMinArity = function (){
+
+            return Joi.func().minArity(-2);
+        };
+
+        const schemaWithZeroArity = function (){
+
+            return Joi.func().minArity(0);
+        };
+
+        expect(schemaWithStringMinArity).to.throw(Error, 'n must be a strict positive integer');
+        expect(schemaWithNegativeMinArity).to.throw(Error, 'n must be a strict positive integer');
+        expect(schemaWithZeroArity).to.throw(Error, 'n must be a strict positive integer');
+        done();
+    });
+
+    it('validates a function max arity', (done) => {
+
+        Helper.validate(Joi.func().maxArity(2).required(), [
+            [function (a,b) { }, true],
+            [function (a,b,c) { }, false, null, '"value" must have an arity lesser or equal to 2'],
+            [function (a) { }, true],
+            [(a,b) => { }, true],
+            [(a,b,c) => { }, false, null, '"value" must have an arity lesser or equal to 2'],
+            [(a) => { }, true],
+            ['', false, null, '"value" must be a Function']
+        ], done);
+    });
+
+    it('validates a function arity unless values are illegal', (done) => {
+
+        const schemaWithStringMaxArity = function (){
+
+            return Joi.func().maxArity('deux');
+        };
+
+        const schemaWithNegativeMaxArity = function (){
+
+            return Joi.func().maxArity(-2);
+        };
+        expect(schemaWithStringMaxArity).to.throw('n must be a positive integer');
+        expect(schemaWithNegativeMaxArity).to.throw('n must be a positive integer');
+        done();
     });
 
     it('validates a function with keys', (done) => {
@@ -42,8 +137,8 @@ describe('func', () => {
         Helper.validate(Joi.func().keys({ a: Joi.string().required() }).required(), [
             [function () { }, false],
             [a, true],
-            [b, false],
-            ['', false]
+            [b, false, null, 'child "a" fails because ["a" must be a string]'],
+            ['', false, null, '"value" must be a Function']
         ], done);
     });
 


### PR DESCRIPTION
add a predicate to enfore number args should take provided function.

This is fully functional, but predicate for min/max should be added to.

Waiting for some feedback for this implementation, (and suggestion for name. (so far thinking about `maxArity`, `minArity`