### PR TITLE
Date enhancements and support for Unix Timestamps

### DIFF
--- a/API.md
+++ b/API.md
@@ -54,6 +54,7 @@
     - [`date.max(date)`](#datemaxdate)
     - [`date.format(format)`](#dateformatformat)
     - [`date.iso()`](#dateiso)
+    - [`date.timestamp([type])`](#datetimestamptype)
   - [`func`](#func)
     - [`func.arity(n)`](#funcarityn)
     - [`func.minArity(n)`](#funcminarityn)
@@ -734,6 +735,18 @@ Requires the string value to be in valid ISO 8601 date format.
 
 ```javascript
 const schema = Joi.date().iso();
+```
+
+#### `date.timestamp([type])`
+
+Requires the value to be a timestamp interval from [Unix Time](https://en.wikipedia.org/wiki/Unix_time).
+
+- `type` - the type of timestamp (allowed values are `unix` or `javascript` [default])
+
+```javascript
+const schema = Joi.date().timestamp(); // defaults to javascript timestamp
+const schema = Joi.date().timestamp('javascript'); // also, for javascript timestamp (milliseconds)
+const schema = Joi.date().timestamp('unix'); // for unix timestamp (seconds)
 ```
 
 ### `func`

--- a/examples/timestamps.js
+++ b/examples/timestamps.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// Load modules
+const Joi = require('../');
+
+const now = new Date();
+const javascriptTimestamp = now.getTime();
+const unixTimestamp = now.getTime() / 1000;
+
+const schema = Joi.object().options({ abortEarly: false }).keys({
+  javascript1: Joi.date().timestamp(),
+  javascript2: Joi.date().timestamp('javascript'),
+  unix: Joi.date().timestamp('unix')
+});
+
+const data = {
+  javascript1: javascriptTimestamp,
+  javascript2: javascriptTimestamp,
+  unix: unixTimestamp
+};
+
+Joi.assert(data, schema);

--- a/lib/date.js
+++ b/lib/date.js
@@ -32,37 +32,46 @@ internals.Date = function () {
 
 Hoek.inherits(internals.Date, Any);
 
-
 internals.Date.prototype._base = function (value, state, options) {
 
     const result = {
-        value: (options.convert && internals.toDate(value, this._flags.format)) || value
+        value: (options.convert && internals.toDate(value, this._flags.format, this._flags.timestamp, this._flags.multiplier)) || value
     };
 
     if (result.value instanceof Date && !isNaN(result.value.getTime())) {
         result.errors = null;
     }
     else {
-        result.errors = this.createError(internals.isIsoDate(this._flags.format) ? 'date.isoDate' : 'date.base', null, state, options);
+        let type;
+        if (internals.isIsoDate(this._flags.format)) {
+            type = 'isoDate';
+        }
+        else if (this._flags.timestamp) {
+            type = 'timestamp.' + this._flags.timestamp;
+        }
+        else {
+            type = 'base';
+        }
+
+        result.errors = this.createError('date.' + type, null, state, options);
     }
 
     return result;
 };
 
-
-internals.toDate = function (value, format) {
+internals.toDate = function (value, format, timestamp, multiplier) {
 
     if (value instanceof Date) {
         return value;
     }
 
     if (typeof value === 'string' ||
-        Hoek.isInteger(value)) {
+        (typeof value === 'number' && !isNaN(value) && isFinite(value))) {
 
         if (typeof value === 'string' &&
-            /^[+-]?\d+$/.test(value)) {
+            /^[+-]?\d+(\.\d+)?$/.test(value)) {
 
-            value = parseInt(value, 10);
+            value = parseFloat(value);
         }
 
         let date;
@@ -75,6 +84,9 @@ internals.toDate = function (value, format) {
                 date = date.isValid() ? date.toDate() : internals.invalidDate;
             }
         }
+        else if (timestamp && multiplier) {
+            date = new Date(value * multiplier);
+        }
         else {
             date = new Date(value);
         }
@@ -86,7 +98,6 @@ internals.toDate = function (value, format) {
 
     return null;
 };
-
 
 internals.compare = function (type, compare) {
 
@@ -129,10 +140,8 @@ internals.compare = function (type, compare) {
     };
 };
 
-
 internals.Date.prototype.min = internals.compare('min', (value, date) => value >= date);
 internals.Date.prototype.max = internals.compare('max', (value, date) => value <= date);
-
 
 internals.Date.prototype.format = function (format) {
 
@@ -147,6 +156,19 @@ internals.Date.prototype.iso = function () {
 
     const obj = this.clone();
     obj._flags.format = internals.isoDate;
+    return obj;
+};
+
+internals.Date.prototype.timestamp = function (type) {
+
+    type = type || 'javascript';
+
+    const allowed = ['javascript', 'unix'];
+    Hoek.assert(allowed.indexOf(type) !== -1, '"type" must be one of "' + allowed.join('", "') + '"');
+
+    const obj = this.clone();
+    obj._flags.timestamp = type;
+    obj._flags.multiplier = type === 'unix' ? 1000 : 1;
     return obj;
 };
 

--- a/lib/language.js
+++ b/lib/language.js
@@ -58,6 +58,10 @@ exports.errors = {
         min: 'must be larger than or equal to "{{limit}}"',
         max: 'must be less than or equal to "{{limit}}"',
         isoDate: 'must be a valid ISO 8601 date',
+        timestamp: {
+            javascript: 'must be a valid timestamp or number of milliseconds',
+            unix: 'must be a valid timestamp or number of seconds'
+        },
         ref: 'references "{{ref}}" which is not a date'
     },
     function: {


### PR DESCRIPTION
_Revised_
--

This PR includes the following changes:
- Support for decimals in `date()` validation
- New constraint for `date.timestamp()` that supports both _javascript_ and _unix_ timestamps
- Updated Tests, API documentation, and added date example


_Note: Because javascript timestamps are millisecond-based and unix timestamps are second-based, the `timestamp()` constraint accepts an optional `type` parameter to ensure proper date conversion for the given input value._

closes #789