### PR TITLE
Generate versioned API Reference link in README

### DIFF
--- a/generate-readme-toc.js
+++ b/generate-readme-toc.js
@@ -9,13 +9,18 @@ const Package = require('./package.json');
 // Declare internals
 
 const internals = {
-    filename: './API.md'
+    api: {
+        filename: './API.md',
+        contents: Fs.readFileSync('./API.md', 'utf8')
+    },
+    readme: {
+        filename: './README.md',
+        contents: Fs.readFileSync('./README.md', 'utf8')
+    }
 };
 
+internals.generateToc = function () {
 
-internals.generate = function () {
-
-    const api = Fs.readFileSync(internals.filename, 'utf8');
     const tocOptions = {
         bullets: '-',
         slugify: function (text) {
@@ -26,10 +31,19 @@ internals.generate = function () {
         }
     };
 
-    const output = Toc.insert(api, tocOptions)
-        .replace(/<!-- version -->(.|\n)*<!-- versionstop -->/, '<!-- version -->\n# ' + Package.version + ' API Reference\n<!-- versionstop -->');
+    const api = Toc.insert(internals.api.contents, tocOptions)
+        .replace(/<!-- version -->(.|\n)*<!-- versionstop -->/, `<!-- version -->\n# ${Package.version} API Reference\n<!-- versionstop -->`);
 
-    Fs.writeFileSync(internals.filename, output);
+    Fs.writeFileSync(internals.api.filename, api);
 };
 
-internals.generate();
+internals.generateLink = function () {
+    // create absolute URL for versioned docs
+    const readme = internals.readme.contents
+        .replace(/\[API Reference\]\(.*\)/gi, `[API Reference](${Package.homepage || ''}/blob/v${Package.version}/${internals.api.filename})`);
+
+    Fs.writeFileSync(internals.readme.filename, readme);
+};
+
+internals.generateToc();
+internals.generateLink();

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "joi",
   "description": "Object schema validation",
   "version": "7.2.0",
+  "homepage": "https://github.com/hapijs/joi",
   "repository": "git://github.com/hapijs/joi",
   "main": "lib/index.js",
   "keywords": [
@@ -27,7 +28,7 @@
     "test": "lab -t 100 -a code -L",
     "test-cov-html": "lab -r html -o coverage.html -a code",
     "toc": "node generate-readme-toc.js",
-    "version": "npm run toc && git add API.md"
+    "version": "npm run toc && git add API.md README.md"
   },
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Currently, the _API Reference_ link in the README takes users to `master`. This is ok most of the time, but when master has been updated but not yet published users are taken to documentation that does not match the current version.

This Pull Request updates the toc generator script to also version the _API Reference_ link in the README.
_…as well as uses ES6 template strings._