### PR TITLE
Adding any.noChange() for change checking with a sister object

### DIFF
--- a/API.md
+++ b/API.md
@@ -20,6 +20,7 @@
     - [`any.optional()`](#anyoptional)
     - [`any.forbidden()`](#anyforbidden)
     - [`any.strip()`](#anystrip)
+    - [`any.noChange(value)`](#anynochangevalue)
     - [`any.description(desc)`](#anydescriptiondesc)
     - [`any.notes(notes)`](#anynotesnotes)
     - [`any.tags(tags)`](#anytagstags)
@@ -318,6 +319,17 @@ const schema = Joi.array().items(Joi.string(), Joi.any().strip());
 schema.validate(['one', 'two', true, false, 1, 2], (err, value) => {
     // value = ['one', 'two']
 });
+```
+
+#### `any.noChange(value)`
+
+Checks that the value being checked exactly equals the the corresponding value in `value`.
+- `value` - any primitive or object to check against
+
+```js
+const schema = Joi.object().keys({ nested: 'nestedValue' });
+schema.validate({ nested: 'nestedValue' }); // returns { error: null, value: { nested: 'nestedValue' } }
+schema.validate({ nested: 'differentValue' }); // returns { error: "value" is not allowed to be changed, value: { nested: 'nestedValue' } }
 ```
 
 #### `any.description(desc)`

--- a/lib/any.js
+++ b/lib/any.js
@@ -227,6 +227,20 @@ internals.Any.prototype._test = function (name, arg, func) {
 };
 
 
+internals.Any.prototype.noChange = function (sourceObj) {
+
+    return this._test('noChange', null, (value, state, options) => {
+
+        const path = state.path === '' ? null : state.path;
+        const origValue = Hoek.reach(sourceObj, path);
+        if (Hoek.deepEqual(origValue, value)) {
+            return null;
+        }
+        return this.createError('any.noChange', null, state, options);
+    });
+};
+
+
 internals.Any.prototype.options = function (options) {
 
     Hoek.assert(!options.context, 'Cannot override context');

--- a/lib/language.js
+++ b/lib/language.js
@@ -20,6 +20,7 @@ exports.errors = {
         empty: 'is not allowed to be empty',
         required: 'is required',
         allowOnly: 'must be one of {{valids}}',
+        noChange: 'is not allowed to be changed',
         default: 'threw an error when running default method'
     },
     alternatives: {

--- a/test/any.js
+++ b/test/any.js
@@ -715,6 +715,61 @@ describe('any', () => {
         });
     });
 
+    describe('noChange()', () => {
+
+        it('validates and returns undefined for a non-nested change check', (done) => {
+
+            const schema = Joi.string().noChange('test');
+
+            schema.validate('test', (err, value) => {
+
+                expect(err).to.not.exist();
+                expect(value).to.equal('test');
+                done();
+            });
+        });
+
+        it('validates and returns undefined for a nested change check', (done) => {
+
+            const schema = Joi.object().keys({
+                nested: Joi.string().noChange({ nested: 'test' })
+            });
+
+            schema.validate({ nested: 'test' }, (err, value) => {
+
+                expect(err).to.not.exist();
+                expect(value).to.deep.equal({ nested: 'test' });
+                done();
+            });
+        });
+
+        it('validates and returns an error for a non-nested change check', (done) => {
+
+            const schema = Joi.string().noChange('test');
+
+            schema.validate('change!', (err, value) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('"value" is not allowed to be changed');
+                done();
+            });
+        });
+
+        it('validates and returns an error for a nested change check', (done) => {
+
+            const schema = Joi.object().keys({
+                nested: Joi.string().noChange({ nested: 'test' })
+            });
+
+            schema.validate({ nested: 'change!' }, (err, value) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('child "nested" fails because ["nested" is not allowed to be changed]');
+                done();
+            });
+        });
+    });
+
     describe('description()', () => {
 
         it('sets the description', (done) => {


### PR DESCRIPTION
This PR introduces `any.noChange(value)`. The intention is to check that the field `noChange(value)` is attached to matches the provided argument at the same path. This is similar in concept to `any.valid()`, except that `undefined` is allowed to be passed in as a valid argument, and of course, the path traversal on the object to check against.

For example:
```js
// this will be the object we validate values against
const validateObj = { isAwesome: 'yes' };
const checkObj = { isAwesome: 'yes' };

const schema = Joi.object().keys({
    nested: Joi.string().noChange(checkObj) // value at /isAwesome should not change
});

schema.validate(validateObj, (err, value) => {

    // checks internally that the `validateObj.isAwesome` field matches `checkObj.isAwesome`
    // 'yes' === 'yes' via a deep equal check
    // if the values are not the same, an error would result
    expect(err).to.not.exist();
    expect(value).to.deep.equal({ nested: 'test' });
    done();
});
```

I would also be OK with the possibility of making this a Joi plugin as I know there are discussions around a plugin model in #577 . Please let me know what you think. Thanks!