### PR TITLE
fix exmaple() to not flatten array values.

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -444,7 +444,7 @@ internals.Any.prototype.example = function (value) {
     Hoek.assert(!result.errors, 'Bad example:', result.errors && Errors.process(result.errors, value));
 
     const obj = this.clone();
-    obj._examples = obj._examples.concat(value);
+    Array.isArray(value) ? obj._examples.push(value) : obj._examples = obj._examples.concat(value);
     return obj;
 };
 


### PR DESCRIPTION
ticket no. #828