### PR TITLE
Add the ability to specify a comparator for `array.unique()` for objects only

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,7 +43,7 @@
     - [`array.min(limit)`](#arrayminlimit)
     - [`array.max(limit)`](#arraymaxlimit)
     - [`array.length(limit)`](#arraylengthlimit)
-    - [`array.unique()`](#arrayunique)
+    - [`array.unique(options)`](#arrayuniqueoptions)
   - [`boolean`](#boolean)
   - [`binary`](#binary)
     - [`binary.encoding(encoding)`](#binaryencodingencoding)
@@ -608,14 +608,27 @@ Specifies the exact number of items in the array where:
 const schema = Joi.array().length(5);
 ```
 
-#### `array.unique()`
+#### `array.unique(options)`
 
-Requires the array values to be unique.
+Requires the array values to be unique where:
+- `options` - an object with:
+    - `objectComparator` - a comparator function used to compare two object. Optional, if missing deep equality is performed.
 
 Be aware that a deep equality is performed on elements of the array having a type of `object`, a performance penalty is to be expected for this kind of operation.
 
 ```javascript
 const schema = Joi.array().unique();
+
+
+// Compare objects with custom logic
+const objectComparator = (left, right) => {
+
+  return left.username = right.username;
+};
+
+const objectSchema = Joi.array().unique({
+  objectComparator: objectComparator
+});
 ```
 
 ### `boolean`

--- a/lib/array.js
+++ b/lib/array.js
@@ -461,7 +461,20 @@ internals.Array.prototype.length = function (limit) {
 };
 
 
-internals.Array.prototype.unique = function () {
+internals.Array.prototype.unique = function (uniqueOptions) {
+
+    let uniqueObjectComparator = Hoek.deepEqual;
+
+    if (uniqueOptions) {
+        Hoek.assert(typeof uniqueOptions === 'object', 'options must be an object');
+
+        if (uniqueOptions.objectComparator) {
+            Hoek.assert(uniqueOptions.objectComparator instanceof Function, 'objectComparator must be a function');
+            Hoek.assert(uniqueOptions.objectComparator.length === 2, 'objectComparator must have exactly 2 parameters');
+
+            uniqueObjectComparator = uniqueOptions.objectComparator;
+        }
+    }
 
     return this._test('unique', undefined, (value, state, options) => {
 
@@ -484,7 +497,7 @@ internals.Array.prototype.unique = function () {
             if (/* $lab:coverage:off$ */ records /* $lab:coverage:on$ */) {
                 if (Array.isArray(records)) {
                     for (let j = 0; j < records.length; ++j) {
-                        if (Hoek.deepEqual(records[j], item)) {
+                        if (uniqueObjectComparator(records[j], item)) {
                             return this.createError('array.unique', { pos: i, value: item }, state, options);
                         }
                     }

--- a/test/array.js
+++ b/test/array.js
@@ -672,6 +672,61 @@ describe('array', () => {
                 [[true, false], true]
             ], done);
         });
+
+        it('validates using a comparator for objects', (done) => {
+
+            const schema = Joi.array().unique({
+                objectComparator: (left, right) => {
+
+                    return left.a === right.a;
+                }
+            });
+
+            Helper.validate(schema, [
+                [[{ a: 'b' }, { a: 'c' }], true],
+                [[{ a: 'b', c: 'd' }, { a: 'c', c: 'd' }], true],
+                [[{ a: 'b', c: 'd' }, { a: 'b', c: 'd' }], false],
+                [[{ a: 'b', c: 'c' }, { a: 'b', c: 'd' }], false]
+            ], done);
+        });
+
+        it('validates with empty options', (done) => {
+
+            const schema = Joi.array().unique({});
+
+            Helper.validate(schema, [
+                [[2, '2'], true]
+            ], done);
+        });
+
+        it('requires objectComparator to be a function with only 2 parameters', (done) => {
+
+            expect(() => {
+
+                Joi.array().unique({ objectComparator: 'a' });
+            }).to.throw(Error, 'objectComparator must be a function');
+
+            expect(() => {
+
+                Joi.array().unique({
+                    objectComparator: (left) => {
+
+                        return left;
+                    }
+                });
+            }).to.throw(Error, 'objectComparator must have exactly 2 parameters');
+
+            expect(() => {
+
+                Joi.array().unique({
+                    objectComparator: (left, right, somethingElse) => {
+
+                        return left === right;
+                    }
+                });
+            }).to.throw(Error, 'objectComparator must have exactly 2 parameters');
+            done();
+        });
     });
 
     describe('sparse()', () => {


### PR DESCRIPTION
I was looking at #859 and thought that it seemed like something that belonged in the core of Joi, not as a plugin/extension and had a pretty good idea of how I would implement it. This PR contains that initial implementation.

## What It Does
It allows a user to specify a comparator function which is used **only** for objects. 

```js
// Compare objects with custom logic
const objectComparator = (left, right) => {

  return left.username.toLowerCase() = right.username.toLowerCase();
};

const objectSchema = Joi.array().unique({
  objectComparator: objectComparator
});

Joi.attempt([{ username: 'bob' }, { username: 'BoB' }], objectSchema); // throws error
const result = Joi.attempt([{ username: 'bob', name: 'Bob' }, { username: 'bob-2', name: 'Bob' }], objectSchema); // result -> [{ username: 'bob' }, { username: 'bob-2' }]
```

In the event that a comparator isn't provided it just defaults to the standard behavior using `Hoek.deepEqual()` so the change has a default and also is backwards compatible.

## What It Doesn't Do
It doesn't allow a comparator to be provided for types other than `object`. Originally I wanted to make the parameter just `comparator` and use it for everything, but once I started implementing this I realized I couldn't do that without a noticeable decrease in performance because of how it works right now using an object map.

The only cases I can think of where a comparator function would be useful for things other than objects is when the data needs to be modified, which that could just be done prior to validation. For example, if an array of numbers needs to have `Math.floor()` run on each value and in that case I imagine you would want the value to come out of validation already run through `Math.floor()` anyways. Others would be string manipulation and such like lowercase comparisons, etc.