### PR TITLE
Allow for inverting the string regex test

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -136,23 +136,20 @@ internals.String.prototype.length = internals.compare('length', (value, limit, e
 });
 
 
-internals.String.prototype.regex = function (pattern, name, invert) {
+internals.String.prototype.regex = function (pattern, name, invert = false) {
 
     Hoek.assert(pattern instanceof RegExp, 'pattern must be a RegExp');
+    Hoek.assert(invert instanceof Boolean, 'invert must be a Boolean');
 
     pattern = new RegExp(pattern.source, pattern.ignoreCase ? 'i' : undefined);         // Future version should break this and forbid unsupported regex flags
-    invert = !!invert;
 
     return this._test('regex', pattern, (value, state, options) => {
 
-        if (!invert && pattern.test(value)) {
-            return null;
-        }
-        else if (invert && !pattern.test(value)) {
+        if (pattern.test(value) ? !invert : invert) {                                   // A proper XOR
             return null;
         }
 
-        return this.createError((name ? 'string.regex.name' : 'string.regex.base'), { name, pattern, value }, state, options);
+        return this.createError((name ? 'string.regex.name' : 'string.regex.base'), { name, pattern, value, invert }, state, options);
     });
 };
 

--- a/lib/string.js
+++ b/lib/string.js
@@ -136,15 +136,19 @@ internals.String.prototype.length = internals.compare('length', (value, limit, e
 });
 
 
-internals.String.prototype.regex = function (pattern, name) {
+internals.String.prototype.regex = function (pattern, name, invert) {
 
     Hoek.assert(pattern instanceof RegExp, 'pattern must be a RegExp');
 
     pattern = new RegExp(pattern.source, pattern.ignoreCase ? 'i' : undefined);         // Future version should break this and forbid unsupported regex flags
+    invert = !!invert;
 
     return this._test('regex', pattern, (value, state, options) => {
 
-        if (pattern.test(value)) {
+        if (!invert && pattern.test(value)) {
+            return null;
+        }
+        else if (invert && !pattern.test(value)) {
             return null;
         }
 


### PR DESCRIPTION
This assists for doing whitelists without evil regexes.
For example, creating a whitelist regex making sure that there are no word characters.

If we can invert the test, it can be as simple as /\w/ with invert set to true.

Thanks for reading, and I think joi and all of your modules are awesome!