### PR TITLE
Wwarren 833 truncate

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -481,9 +481,9 @@ internals.String.prototype.replace = function (pattern, replacement) {
 
 internals.String.prototype.truncate = function (maxLength) {
 	// Test the parameters of the method: The maxLength should be an integer
-	Hoek.assert(Number.isInteger(maxLength), 'String length must be an integer');
+	Hoek.assert(Number.isInteger(maxLength), 'max size must be an integer');
 	// Make sure that the integer is greater than zero
-	Hoek.assert(maxLength >= 0);
+	Hoek.assert(maxLength >= 0, 'max size must be a POSITIVE integer');
 	// Just like in replace(), this is not a test where a failure can be thrown, so 
 	// just clone this
 	const obj = this.clone();

--- a/lib/string.js
+++ b/lib/string.js
@@ -462,7 +462,7 @@ internals.String.prototype.replace = function (pattern, replacement) {
     Hoek.assert(pattern instanceof RegExp, 'pattern must be a RegExp');
     Hoek.assert(typeof replacement === 'string', 'replacement must be a String');
 
-    // This can not be considere a test like trim, we can't "reject"
+    // This can not be considered a test like trim, we can't "reject"
     // anything from this rule, so just clone the current object
     const obj = this.clone();
 
@@ -482,6 +482,8 @@ internals.String.prototype.replace = function (pattern, replacement) {
 internals.String.prototype.truncate = function (maxLength) {
 	// Test the parameters of the method: The maxLength should be an integer
 	Hoek.assert(Number.isInteger(maxLength), 'String length must be an integer');
+	// Make sure that the integer is greater than zero
+	Hoek.assert(maxLength >= 0);
 	// Just like in replace(), this is not a test where a failure can be thrown, so 
 	// just clone this
 	const obj = this.clone();

--- a/lib/string.js
+++ b/lib/string.js
@@ -60,17 +60,17 @@ internals.compare = function (type, compare) {
 };
 
 internals.String.prototype._base = function (value, state, options) {
-	
+
     if (typeof value === 'string' &&
         options.convert) {
-    	
-    	if (this._flags.truncate){
-    		// If the current max is greater than or equal to our String's length, return this object, unaltered
-    		if (this._flags.truncate < value.length){
-    			value = value.substring(0, this._flags.truncate);
-    		}
-    	}
-    	
+
+        if (this._flags.truncate){
+            // If the current max is greater than or equal to our String's length, return this object, unaltered
+            if (this._flags.truncate < value.length){
+                value = value.substring(0, this._flags.truncate);
+            }
+        }
+
         if (this._flags.case) {
             value = (this._flags.case === 'upper' ? value.toLocaleUpperCase() : value.toLocaleLowerCase());
         }
@@ -480,17 +480,17 @@ internals.String.prototype.replace = function (pattern, replacement) {
 
 
 internals.String.prototype.truncate = function (maxLength) {
-	// Test the parameters of the method: The maxLength should be an integer
-	Hoek.assert(Number.isInteger(maxLength), 'max size must be an integer');
-	// Make sure that the integer is greater than zero
-	Hoek.assert(maxLength >= 0, 'max size must be a POSITIVE integer');
-	// Just like in replace(), this is not a test where a failure can be thrown, so 
-	// just clone this
-	const obj = this.clone();
-	// Register the flag that will fire the appropriate action when _base() is called
-	obj._flags.truncate = maxLength;
-	return obj;
-    
+
+    // Test the parameters of the method: The maxLength should be an integer
+    Hoek.assert(Number.isInteger(maxLength), 'max size must be an integer');
+    // Make sure that the integer is greater than zero
+    Hoek.assert(maxLength >= 0, 'max size must be a POSITIVE integer');
+    // Just like in replace(), this is not a test where a failure can be thrown, so
+    // just clone this
+    const obj = this.clone();
+    // Register the flag that will fire the appropriate action when _base() is called
+    obj._flags.truncate = maxLength;
+    return obj;
 };
 
 module.exports = new internals.String();

--- a/lib/string.js
+++ b/lib/string.js
@@ -60,10 +60,17 @@ internals.compare = function (type, compare) {
 };
 
 internals.String.prototype._base = function (value, state, options) {
-
+	
     if (typeof value === 'string' &&
         options.convert) {
-
+    	
+    	if (this._flags.truncate){
+    		// If the current max is greater than or equal to our String's length, return this object, unaltered
+    		if (this._flags.truncate < value.length){
+    			value = value.substring(0, this._flags.truncate);
+    		}
+    	}
+    	
         if (this._flags.case) {
             value = (this._flags.case === 'upper' ? value.toLocaleUpperCase() : value.toLocaleLowerCase());
         }
@@ -469,6 +476,19 @@ internals.String.prototype.replace = function (pattern, replacement) {
     });
 
     return obj;
+};
+
+
+internals.String.prototype.truncate = function (maxLength) {
+	// Test the parameters of the method: The maxLength should be an integer
+	Hoek.assert(Number.isInteger(maxLength), 'String length must be an integer');
+	// Just like in replace(), this is not a test where a failure can be thrown, so 
+	// just clone this
+	const obj = this.clone();
+	// Register the flag that will fire the appropriate action when _base() is called
+	obj._flags.truncate = maxLength;
+	return obj;
+    
 };
 
 module.exports = new internals.String();

--- a/test/string.js
+++ b/test/string.js
@@ -3210,7 +3210,7 @@ describe('string', () => {
                 expect(() => {
 
                     Joi.string().truncate('a');
-                }).to.throw('max size must be a positive integer or reference');
+                }).to.throw('max size must be an integer');
                 done();
             });
 
@@ -3218,7 +3218,7 @@ describe('string', () => {
                 expect(() => {
 
                     Joi.string().truncate(5.1);
-                }).to.throw('max size must be a positive integer or reference');
+                }).to.throw('max size must be an integer');
                 done();
             });
 
@@ -3226,7 +3226,7 @@ describe('string', () => {
                 expect(() => {
 
                     Joi.string().truncate(-1);
-                }).to.throw('max size must be a positive integer or reference');
+                }).to.throw('max size must be a POSITIVE integer');
                 done();
             });
             

--- a/test/string.js
+++ b/test/string.js
@@ -3202,5 +3202,44 @@ describe('string', () => {
                 [null, false]
             ], done);
         });
+        
+        
+        describe('truncate()', () => {
+
+            it('throws when max size is not a number', (done) => {
+                expect(() => {
+
+                    Joi.string().truncate('a');
+                }).to.throw('max size must be a positive integer or reference');
+                done();
+            });
+
+            it('throws when max size is not an integer', (done) => {
+                expect(() => {
+
+                    Joi.string().truncate(5.1);
+                }).to.throw('max size must be a positive integer or reference');
+                done();
+            });
+
+            it('throws when max size is not positive', (done) => {
+                expect(() => {
+
+                    Joi.string().truncate(-1);
+                }).to.throw('max size must be a positive integer or reference');
+                done();
+            });
+            
+            it('should truncate a string longer than the max length provided', (done) => {
+                const schema = Joi.string().truncate(3);
+                Helper.validate(schema, [
+                    ['foo', true, null, 'foo'],
+                    ['barfoo', true, null, 'bar'],
+                    ['fo', true, null, 'fo']
+                ], done);
+            });
+
+        
+        });
     });
 });

--- a/test/string.js
+++ b/test/string.js
@@ -3202,11 +3202,12 @@ describe('string', () => {
                 [null, false]
             ], done);
         });
-        
-        
+
+
         describe('truncate()', () => {
 
             it('throws when max size is not a number', (done) => {
+
                 expect(() => {
 
                     Joi.string().truncate('a');
@@ -3215,6 +3216,7 @@ describe('string', () => {
             });
 
             it('throws when max size is not an integer', (done) => {
+
                 expect(() => {
 
                     Joi.string().truncate(5.1);
@@ -3223,14 +3225,16 @@ describe('string', () => {
             });
 
             it('throws when max size is not positive', (done) => {
+
                 expect(() => {
 
                     Joi.string().truncate(-1);
                 }).to.throw('max size must be a POSITIVE integer');
                 done();
             });
-            
+
             it('should truncate a string longer than the max length provided', (done) => {
+
                 const schema = Joi.string().truncate(3);
                 Helper.validate(schema, [
                     ['foo', true, null, 'foo'],
@@ -3239,7 +3243,7 @@ describe('string', () => {
                 ], done);
             });
 
-        
+
         });
     });
 });


### PR DESCRIPTION
Adds a truncate function which acts like length(), but enforces it by trimming the original string value in the Schema.