### PR TITLE
Fix for #833

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -13,6 +13,7 @@ const Ip = require('./string/ip');
 
 // Declare internals
 
+
 const internals = {
     uriRegex: Uri.createUriRegex(),
     ipRegex: Ip.createIpRegex(['ipv4', 'ipv6', 'ipvfuture'], 'optional')
@@ -36,7 +37,7 @@ internals.compare = function (type, compare) {
         Hoek.assert((Hoek.isInteger(limit) && limit >= 0) || isRef, 'limit must be a positive integer or reference');
         Hoek.assert(!encoding || Buffer.isEncoding(encoding), 'Invalid encoding:', encoding);
 
-        return this._test(type, limit, (value, state, options) => {
+        const testResult =  this._test(type, limit, (value, state, options) => {
 
             let compareTo;
             if (isRef) {
@@ -50,12 +51,26 @@ internals.compare = function (type, compare) {
                 compareTo = limit;
             }
 
-            if (compare(value, compareTo, encoding)) {
+
+            if (type === 'truncate') {
+                value = value.substring(0,compareTo);
+            }
+
+            const comapreResult = compare(value, compareTo, encoding);
+
+            if (comapreResult) {
                 return null;
             }
 
             return this.createError('string.' + type, { limit: compareTo, value, encoding }, state, options);
         });
+
+        if (type === 'truncate') {
+            testResult._flags.truncate = true;
+            testResult._inner.truncateLimit = limit;
+        }
+
+        return testResult;
     };
 };
 
@@ -70,6 +85,11 @@ internals.String.prototype._base = function (value, state, options) {
 
         if (this._flags.trim) {
             value = value.trim();
+        }
+
+
+        if (this._flags.truncate) {
+            value = value.substring(0,this._inner.truncateLimit);
         }
 
         if (this._inner.replacements) {
@@ -104,6 +124,14 @@ internals.String.prototype.min = internals.compare('min', (value, limit, encodin
 
 
 internals.String.prototype.max = internals.compare('max', (value, limit, encoding) => {
+
+    const length = encoding ? Buffer.byteLength(value, encoding) : value.length;
+    return length <= limit;
+});
+
+
+
+internals.String.prototype.truncate = internals.compare('truncate', (value, limit, encoding) => {
 
     const length = encoding ? Buffer.byteLength(value, encoding) : value.length;
     return length <= limit;


### PR DESCRIPTION
This is a fix for proposing to add truncate() to string(). This works like max(), only it actually modifies the string to the specified limit. Unit tests are also added.