### PR TITLE
Proposal: Add support for global refs

### DIFF
--- a/API.md
+++ b/API.md
@@ -1698,7 +1698,7 @@ const schema = {
 Generates a reference to the value of the named key. References are resolved at validation time and in order of dependency
 so that if one key validation depends on another, the dependent key is validated second after the reference is validated.
 References support the following arguments:
-- `key` - the reference target. References cannot point up the object tree, only to sibling keys, but they can point to
+- `key` - the reference target. If a key starts with the root prefix (defaults to  '/') the reference will be resolved against the complete value passed for validation. In all other cases, references cannot point up the object tree, only to sibling keys, but they can point to
   their siblings' children (e.g. 'a.b.c') using the `.` separator. If a `key` starts with `$` is signifies a context reference
   which is looked up in the `context` option object.
 - `options` - optional settings:
@@ -1713,11 +1713,13 @@ const schema = Joi.object().keys({
     a: Joi.ref('b.c'),
     b: {
         c: Joi.any()
+        d: Joi.ref('/d')
     },
     c: Joi.ref('$x')
+    d: Joi.any()
 });
 
-Joi.validate({ a: 5, b: { c: 5 } }, schema, { context: { x: 5 } }, (err, value) => {});
+Joi.validate({ a: 5, b: { c: 5, d: 3 }, d: 3 }, schema, { context: { x: 5 } }, (err, value) => {});
 ```
 
 ## Errors

--- a/lib/any.js
+++ b/lib/any.js
@@ -659,7 +659,7 @@ internals.Any.prototype._validateWithOptions = function (value, options, callbac
         internals.checkOptions(options);
     }
 
-    const settings = internals.concatSettings(internals.defaults, options);
+    const settings = internals.concatSettings(internals.defaults, Object.assign({ rootValue: value }, options));
     const result = this._validate(value, null, settings);
     const errors = Errors.process(result.errors, value);
 
@@ -673,7 +673,7 @@ internals.Any.prototype._validateWithOptions = function (value, options, callbac
 
 internals.Any.prototype.validate = function (value, callback) {
 
-    const result = this._validate(value, null, internals.defaults);
+    const result = this._validate(value, null, Object.assign({ rootValue: value }, internals.defaults));
     const errors = Errors.process(result.errors, value);
 
     if (callback) {

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -18,11 +18,13 @@ exports.create = function (key, options) {
 
     const ref = function (value, validationOptions) {
 
-        return Hoek.reach(ref.isContext ? validationOptions.context : value, ref.key, settings);
+        var obj = ref.isContext ? validationOptions.context : ref.isRoot ? validationOptions.rootValue : value;
+        return Hoek.reach(obj, ref.key, settings);
     };
 
     ref.isContext = (key[0] === ((settings && settings.contextPrefix) || '$'));
-    ref.key = (ref.isContext ? key.slice(1) : key);
+    ref.isRoot = (key[0] === ((settings && settings.rootPrefix) || '/'));
+    ref.key = (ref.isContext || ref.isRoot ? key.slice(1) : key);
     ref.path = ref.key.split((settings && settings.separator) || '.');
     ref.depth = ref.path.length;
     ref.root = ref.path[0];

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -18,7 +18,7 @@ exports.create = function (key, options) {
 
     const ref = function (value, validationOptions) {
 
-        var obj = ref.isContext ? validationOptions.context : ref.isRoot ? validationOptions.rootValue : value;
+        const obj = ref.isContext ? validationOptions.context : ref.isRoot ? validationOptions.rootValue : value;
         return Hoek.reach(obj, ref.key, settings);
     };
 

--- a/test/alternatives.js
+++ b/test/alternatives.js
@@ -287,13 +287,13 @@ describe('alternatives', () => {
             const schema = Joi.object({
                 a: Joi.number(),
                 b: {
-                    c: Joi.alternatives().when('/a', { is: 5, then: Joi.valid('x'), otherwise: Joi.valid('y') }),
+                    c: Joi.alternatives().when('/a', { is: 5, then: Joi.valid('x'), otherwise: Joi.valid('y') })
                 }
             });
             Helper.validate(schema, [
-                [{ a: 5, b: { c: 'x'} }, true],
-                [{ a: 4, b: { c: 'y'} }, true],
-                [{ a: 5, b: { c: 'y'} }, false],
+                [{ a: 5, b: { c: 'x' } }, true],
+                [{ a: 4, b: { c: 'y' } }, true],
+                [{ a: 5, b: { c: 'y' } }, false],
                 [{ a: 5 }, true]
             ], done);
         });

--- a/test/alternatives.js
+++ b/test/alternatives.js
@@ -281,6 +281,22 @@ describe('alternatives', () => {
                 [{ b: 5 }, false]
             ], done);
         });
+
+        it('validates when ref is root ref', (done) => {
+
+            const schema = Joi.object({
+                a: Joi.number(),
+                b: {
+                    c: Joi.alternatives().when('/a', { is: 5, then: Joi.valid('x'), otherwise: Joi.valid('y') }),
+                }
+            });
+            Helper.validate(schema, [
+                [{ a: 5, b: { c: 'x'} }, true],
+                [{ a: 4, b: { c: 'y'} }, true],
+                [{ a: 5, b: { c: 'y'} }, false],
+                [{ a: 5 }, true]
+            ], done);
+        });
     });
 
     describe('describe()', () => {

--- a/test/object.js
+++ b/test/object.js
@@ -380,6 +380,7 @@ describe('object', () => {
     });
 
     it('should allow root level references from nested children', (done) => {
+
         const schema = Joi.object({
             a: Joi.array(),
             b: Joi.object().keys({

--- a/test/object.js
+++ b/test/object.js
@@ -379,6 +379,21 @@ describe('object', () => {
         });
     });
 
+    it('should allow root level references from nested children', (done) => {
+        const schema = Joi.object({
+            a: Joi.array(),
+            b: Joi.object().keys({
+                c: Joi.object().keys({
+                    d: Joi.valid(Joi.ref('/a'))
+                })
+            })
+        });
+        Helper.validate(schema, [
+            [{ a: ['foo','bar'], b: { c: { d: 'foo' } } }, true],
+            [{ a: ['foo','bar'], b: { c: { d: 'baz' } } }, false]
+        ], done);
+    });
+
     it('should work on prototype-less objects', (done) => {
 
         const input = Object.create(null);

--- a/test/ref.js
+++ b/test/ref.js
@@ -130,6 +130,7 @@ describe('ref', () => {
     });
 
     it('uses ref with root key as a valid value', (done) => {
+
         const ref = Joi.ref('/a.b');
         expect(ref.root).to.equal('a');
 
@@ -151,6 +152,7 @@ describe('ref', () => {
 
 
     it('uses ref with custom rootPrefix', (done) => {
+
         const ref = Joi.ref('@a.b', { rootPrefix: '@' });
         expect(ref.root).to.equal('a');
 
@@ -171,6 +173,7 @@ describe('ref', () => {
     });
 
     it('allows ref with same rootPrefix as separator', (done) => {
+
         const ref = Joi.ref('/a/b', { separator: '/' });
         expect(ref.root).to.equal('a');
 

--- a/test/ref.js
+++ b/test/ref.js
@@ -137,13 +137,15 @@ describe('ref', () => {
             a: Joi.object({
                 b: Joi.string()
             }),
-            c: ref
+            c: Joi.object({
+                d: ref
+            })
         });
         Helper.validate(schema, [
-          [{ a: { b: 'x' }, c: 'x' }, true],
-          [{ a: { b: 'y' }, c: 'y' }, true],
-          [{ a: { b: 'x' }, c: 'y' }, false],
-          [{ c: 'y'}, false]
+          [{ a: { b: 'x' }, c: { d: 'x' } }, true],
+          [{ a: { b: 'y' }, c: { d: 'y' } }, true],
+          [{ a: { b: 'x' }, c: { d: 'y' } }, false],
+          [{ c: { d: 'y' } }, false]
         ], done);
     });
 
@@ -156,13 +158,15 @@ describe('ref', () => {
             a: Joi.object({
                 b: Joi.string()
             }),
-            c: ref
+            c: Joi.object({
+                d: ref
+            })
         });
         Helper.validate(schema, [
-          [{ a: { b: 'x' }, c: 'x' }, true],
-          [{ a: { b: 'y' }, c: 'y' }, true],
-          [{ a: { b: 'x' }, c: 'y' }, false],
-          [{ c: 'y'}, false]
+          [{ a: { b: 'x' }, c: { d: 'x' } }, true],
+          [{ a: { b: 'y' }, c: { d: 'y' } }, true],
+          [{ a: { b: 'x' }, c: { d: 'y' } }, false],
+          [{ c: { d: 'y' } }, false]
         ], done);
     });
 
@@ -174,13 +178,15 @@ describe('ref', () => {
             a: Joi.object({
                 b: Joi.string()
             }),
-            c: ref
+            c: Joi.object({
+                d: ref
+            })
         });
         Helper.validate(schema, [
-          [{ a: { b: 'x' }, c: 'x' }, true],
-          [{ a: { b: 'y' }, c: 'y' }, true],
-          [{ a: { b: 'x' }, c: 'y' }, false],
-          [{ c: 'y'}, false]
+          [{ a: { b: 'x' }, c: { d: 'x' } }, true],
+          [{ a: { b: 'y' }, c: { d: 'y' } }, true],
+          [{ a: { b: 'x' }, c: { d: 'y' } }, false],
+          [{ c: { d: 'y' } }, false]
         ], done);
     });
 

--- a/test/ref.js
+++ b/test/ref.js
@@ -29,6 +29,12 @@ describe('ref', () => {
         done();
     });
 
+    it('detects root references', (done) => {
+
+        expect(Joi.isRef(Joi.ref('/a.b'))).to.be.true();
+        done();
+    });
+
     it('uses ref as a valid value', (done) => {
 
         const schema = Joi.object({
@@ -121,6 +127,61 @@ describe('ref', () => {
                 done();
             });
         });
+    });
+
+    it('uses ref with root key as a valid value', (done) => {
+        const ref = Joi.ref('/a.b');
+        expect(ref.root).to.equal('a');
+
+        const schema = Joi.object({
+            a: Joi.object({
+                b: Joi.string()
+            }),
+            c: ref
+        });
+        Helper.validate(schema, [
+          [{ a: { b: 'x' }, c: 'x' }, true],
+          [{ a: { b: 'y' }, c: 'y' }, true],
+          [{ a: { b: 'x' }, c: 'y' }, false],
+          [{ c: 'y'}, false]
+        ], done);
+    });
+
+
+    it('uses ref with custom rootPrefix', (done) => {
+        const ref = Joi.ref('@a.b', { rootPrefix: '@' });
+        expect(ref.root).to.equal('a');
+
+        const schema = Joi.object({
+            a: Joi.object({
+                b: Joi.string()
+            }),
+            c: ref
+        });
+        Helper.validate(schema, [
+          [{ a: { b: 'x' }, c: 'x' }, true],
+          [{ a: { b: 'y' }, c: 'y' }, true],
+          [{ a: { b: 'x' }, c: 'y' }, false],
+          [{ c: 'y'}, false]
+        ], done);
+    });
+
+    it('allows ref with same rootPrefix as separator', (done) => {
+        const ref = Joi.ref('/a/b', { separator: '/' });
+        expect(ref.root).to.equal('a');
+
+        const schema = Joi.object({
+            a: Joi.object({
+                b: Joi.string()
+            }),
+            c: ref
+        });
+        Helper.validate(schema, [
+          [{ a: { b: 'x' }, c: 'x' }, true],
+          [{ a: { b: 'y' }, c: 'y' }, true],
+          [{ a: { b: 'x' }, c: 'y' }, false],
+          [{ c: 'y'}, false]
+        ], done);
     });
 
     it('uses ref reach options', (done) => {


### PR DESCRIPTION
I have been hampered by the inability of a ref to refer to anything up the object tree. I have many use cases where this limitation would require me to repeat a lot of schema definition. I think refs become much more powerful if there is an option to evaluate the ref from the root of the original value passed for validation. 

This is a working implementation that is simple and backwards compatible. When defining a reference, a user need only add the root prefix (similar to the context prefix) as shown below


```js
var Joi = require('joi')

var schema = Joi.object().keys({
  a: Joi.number(),
  b: Joi.array().items({
    c: Joi.when('/a', {
      is: 1,
      then: Joi.string().valid(['x'])
    })
  })
});

var data = { a: 1, b: [{c: 'y'}] };

Joi.validate(data, schema);

// =>
// { error: 
//    { [ValidationError: child "b" fails because ["b" at position 0 fails because [child "c" fails because ["c" must be one of [x]]]]]
//      isJoi: true,
//      name: 'ValidationError',
//      details: [ [Object] ],
//      _object: { a: 1, b: [Object] },
//      annotate: [Function] },
//   value: { a: 1, b: [ [Object] ] } }

``` 

