### PR TITLE
Fix missing top-level methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,7 @@ internals.root = function () {
 
         this.assert(extensions, root.extensionsSchema);
 
-        const joi = Object.assign(new Any().clone(), this);
+        const joi = Object.create(this);
 
         for (let i = 0; i < extensions.length; ++i) {
             const extension = extensions[i];

--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,7 @@ internals.root = function () {
 
         this.assert(extensions, root.extensionsSchema);
 
-        const joi = Object.assign({}, this);
+        const joi = Object.assign(new Any().clone(), this);
 
         for (let i = 0; i < extensions.length; ++i) {
             const extension = extensions[i];

--- a/test/index.js
+++ b/test/index.js
@@ -2646,5 +2646,17 @@ describe('Joi', () => {
                 done();
             });
         });
+
+        it('should return a custom Joi as an instance of Any', (done) => {
+
+            const customJoi = Joi.extend({
+                name: 'myType'
+            });
+
+            const Any = require('../lib/any');
+            expect(customJoi).to.be.an.instanceof(Any);
+            done();
+        });
+
     });
 });


### PR DESCRIPTION
This creates a custom Joi from an instance of the Any class instead of from an empty object. This allows the custom Joi to retain the properties and functions available on the original Joi object such as `.when` and `.disallow`.

This closes #933