### PR TITLE
Use a non vulnerable moment version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hoek": "4.x.x",
     "isemail": "2.x.x",
     "items": "2.x.x",
-    "moment": "2.x.x",
+    "moment": "2.14.x",
     "topo": "2.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Joi [david-dm](https://david-dm.org/hapijs/joi) integration shows that the dependence of the moment was outdated and has DDOS vulnerabilities

Reference: https://nodesecurity.io/advisories/moment_regular-expression-denial-of-service