### PR TITLE
Protective check for error flag

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -117,7 +117,7 @@ exports.process = function (errors, object) {
         for (let i = 0; i < localErrors.length; ++i) {
             const item = localErrors[i];
 
-            if (item.flags.error) {
+            if (item.flags && item.flags.error) {
                 return item.flags.error;
             }
 


### PR DESCRIPTION
Was seeing a particularly difficult to trace error which read `Cannot read property error of undefined`. This fixes that.

P.S: Smallest PR ever.