### PR TITLE
separatedBy srtring validator

### DIFF
--- a/lib/language.js
+++ b/lib/language.js
@@ -134,6 +134,7 @@ exports.errors = {
         lowercase: 'must only contain lowercase characters',
         uppercase: 'must only contain uppercase characters',
         trim: 'must not have leading or trailing whitespace',
+        separatedBy: 'fails for the following items: {{errors}}',
         creditCard: 'must be a credit card',
         ref: 'references "{{ref}}" which is not a number',
         ip: 'must be a valid ip address with a {{cidr}} CIDR',

--- a/lib/string.js
+++ b/lib/string.js
@@ -420,6 +420,46 @@ internals.String = class extends Any {
         return obj;
     }
 
+    separatedBy(separator, schema) {
+
+        if (separator instanceof String) {
+            separator = separator.valueOf();
+        }
+
+        Hoek.assert(typeof separator === 'string', '"separator" must be a string');
+        Hoek.assert(schema.isJoi, '"schema" must be a Joi validator');
+
+        const obj = this._test('separatedBy', { separator, schema }, function (value, state, options) {
+
+            const values = value.split(separator);
+            const result = [];
+            let errors = {};
+
+            values.forEach((elem) => {
+
+                const schemaResult = schema.validate(elem);
+                result.push(schemaResult.value);
+
+                if (schemaResult.error) {
+                    errors[elem] = schemaResult.error.message;
+                }
+            });
+
+            if (Object.keys(errors).length > 0) {
+                const msgs = [];
+                for (const key in errors) {
+                    msgs.push(key + ': ' + errors[key]);
+                }
+                errors = '{ ' + msgs.join(', ') + ' }';
+                return this.createError('string.separatedBy', { errors }, state, options);
+            }
+
+            return result;
+        });
+
+        return obj;
+    }
+
 };
 
 internals.compare = function (type, compare) {

--- a/test/string.js
+++ b/test/string.js
@@ -1904,6 +1904,50 @@ describe('string', () => {
         });
     });
 
+    describe('separatedBy()', () => {
+
+        it('separates a string', (done) => {
+
+            const schema = Joi.string().separatedBy(',', Joi.string().regex(/^[A-Z]{2}$/));
+
+            Helper.validate(schema, [
+                ['VE,CA,ES', true, null, ['VE', 'CA', 'ES']],
+                ['VE', true, null, ['VE']]
+            ], done);
+        });
+
+        it('fails to separate a string because of the inner schema', (done) => {
+
+            const schema = Joi.string().separatedBy(',', Joi.string().regex(/^[A-Z]{2}$/));
+
+            Helper.validate(schema, [
+                ['VE,ca,ca', false, null, '"value" fails for the following items: { ca: "value" with value "ca" fails to match the required pattern: /^[A-Z]{2}$/ }']
+            ], done);
+        });
+
+        it('only accepts a valid Joi schema and a string or String object separator', (done) => {
+
+            expect(() => {
+
+                Joi.string().separatedBy(',', /^[A-Z]{2}$/);
+            }).to.throw(Error, '\"schema\" must be a Joi validator');
+
+            expect(() => {
+
+                Joi.string().separatedBy(2, Joi.string().regex(/^[A-Z]{2}$/));
+            }).to.throw(Error, '\"separator\" must be a string');
+
+            expect(() => {
+
+                // eslint-disable-next-line no-new-wrappers
+                Joi.string().separatedBy(new String(','), Joi.string().regex(/^[A-Z]{2}$/));
+            }).to.not.throw();
+
+            done();
+        });
+
+    });
+
     describe('validate()', () => {
 
         it('should, by default, allow undefined, deny empty string', (done) => {


### PR DESCRIPTION
A few things on this PR:

I didn't know if the right way to make sure I get a Joi validator was to check for `isJoi`, maybe there needs to be a validator for Joi objects.

Another approach I had for this PR was that it only made the split of a string, and then handle the rest with `Joi.array()`, but I wasn't sure how to _compose_ Joi validators; if it's not possible, it could be a a powerful improvement.

Consider the docs example of array but starting with a string:

```js
const array = Joi.array().items(Joi.string().valid('a', 'b'))
                 .Joi.string().separatedBy('-');

array.validate("a-b-a-a");
```

Where the `.Joi` is a way of starting a new Joi object to be used before on the input and pass the result to the one in the left, kind of like functions composition.
