### PR TITLE
Alias String.guid() with String.uuid()

### DIFF
--- a/API.md
+++ b/API.md
@@ -114,7 +114,7 @@
     - [`string.email([options])`](#stringemailoptions)
     - [`string.ip([options])`](#stringipoptions)
     - [`string.uri([options])`](#stringurioptions)
-    - [`string.guid() - aliases: `uuid`](#stringguid---aliases-uuid)
+    - [`string.guid()` - aliases: `uuid`](#stringguid---aliases-uuid)
     - [`string.hex()`](#stringhex)
     - [`string.hostname()`](#stringhostname)
     - [`string.lowercase()`](#stringlowercase)

--- a/API.md
+++ b/API.md
@@ -115,6 +115,7 @@
     - [`string.ip([options])`](#stringipoptions)
     - [`string.uri([options])`](#stringurioptions)
     - [`string.guid()`](#stringguid)
+    - [`string.uuid()`](#stringuuid)
     - [`string.hex()`](#stringhex)
     - [`string.hostname()`](#stringhostname)
     - [`string.lowercase()`](#stringlowercase)
@@ -781,7 +782,7 @@ const schema = Joi.array().length(5);
 
 Requires the array values to be unique.
 
-You can provide a custom `comparator` function that takes 2 parameters to compare. This function should return whether the 2 parameters are equal or not, you are also **responsible** for this function not to fail, any `Error` would bubble out of Joi. 
+You can provide a custom `comparator` function that takes 2 parameters to compare. This function should return whether the 2 parameters are equal or not, you are also **responsible** for this function not to fail, any `Error` would bubble out of Joi.
 
 Note: remember that if you provide a custom comparator, different types can be passed as parameter depending on the rules you set on items.
 
@@ -1622,6 +1623,14 @@ Requires the string value to be a valid GUID.
 
 ```js
 const schema = Joi.string().guid();
+```
+
+#### `string.uuid()`
+
+Requires the string value to be a valid UUID.
+
+```js
+const schema = Joi.string().uuid();
 ```
 
 #### `string.hex()`

--- a/lib/string.js
+++ b/lib/string.js
@@ -475,5 +475,8 @@ internals.String.prototype.length = internals.compare('length', (value, limit, e
     return length === limit;
 });
 
+// Aliases
+
+internals.String.prototype.uuid = internals.String.prototype.guid;
 
 module.exports = new internals.String();


### PR DESCRIPTION
Had a lull so here's the alias and doc update. 

As noted I tested the alias's functionality by swapping any calls to String.guid() with calls to String.uuid() in test/string.js just in case something funky happened. All tests came back green.

I do want to note that error messages will reference the wrong acronym when using uuid(), but that would require a more complex fix.