### PR TITLE
Add support for truthy/falsy boolean values

### DIFF
--- a/API.md
+++ b/API.md
@@ -816,7 +816,7 @@ Allows for additional strings to be considered valid boolean values in addition 
 
 ```js
 const boolean = Joi.boolean().truthy('Y');
-boolean.validate('Y', (err, value) => { });
+boolean.validate('Y', (err, value) => { }); // Valid
 ```
 
 #### `boolean.falsy(value)`
@@ -825,7 +825,7 @@ Allows for additional strings to be considered valid boolean values in addition 
 
 ```js
 const boolean = Joi.boolean().falsy('N');
-boolean.validate('N', (err, value) => { });
+boolean.validate('N', (err, value) => { }); // Valid
 ```
 
 ### `binary`

--- a/API.md
+++ b/API.md
@@ -813,7 +813,7 @@ boolean.validate(1, (err, value) => { }); // Invalid
 ```
 
 #### `boolean.truthy(value)`
-``
+
 Allows for additional values to be considered valid booleans by converting them to `true` during validation. Accepts a value or an array of values.
 
 ```js

--- a/API.md
+++ b/API.md
@@ -801,18 +801,20 @@ const schema = Joi.array().unique((a, b) => a.property === b.property);
 
 ### `boolean`
 
-Generates a schema object that matches a boolean data type (as well as the strings 'true', 'false', 'yes', 'no', 'on', 'off', 1, 0, '1', or '0'). Can also be called via `bool()`.
+Generates a schema object that matches a boolean data type. Can also be called via `bool()`.
 
 Supports the same methods of the [`any()`](#any) type.
 
 ```js
 const boolean = Joi.boolean();
-boolean.validate(true, (err, value) => { });
+boolean.validate(true, (err, value) => { }); // Valid
+
+boolean.validate(1, (err, value) => { }); // Invalid
 ```
 
 #### `boolean.truthy(value)`
-
-Allows for additional strings to be considered valid boolean values in addition to default 'truthy' strings: ['true', 'yes', '1', 'on']. Accepts a string or an array of strings.
+``
+Allows for additional values to be considered valid booleans by converting them to `true` during validation. Accepts a value or an array of values.
 
 ```js
 const boolean = Joi.boolean().truthy('Y');
@@ -821,7 +823,7 @@ boolean.validate('Y', (err, value) => { }); // Valid
 
 #### `boolean.falsy(value)`
 
-Allows for additional strings to be considered valid boolean values in addition to default 'falsy' strings: ['false', 'no', '0', 'off']. Accepts a string or an array of strings.
+Allows for additional values to be considered valid booleans by converting them to `false` during validation. Accepts a value or an array of values.
 
 ```js
 const boolean = Joi.boolean().falsy('N');

--- a/API.md
+++ b/API.md
@@ -52,6 +52,8 @@
     - [`array.length(limit)`](#arraylengthlimit)
     - [`array.unique([comparator])`](#arrayuniquecomparator)
   - [`boolean`](#boolean)
+    - [`boolean.truthy(value)`](#booleantruthyvalue)
+    - [`boolean.falsy(value)`](#booleanfalsyvalue)
   - [`binary`](#binary)
     - [`binary.encoding(encoding)`](#binaryencodingencoding)
     - [`binary.min(limit)`](#binaryminlimit)
@@ -806,6 +808,24 @@ Supports the same methods of the [`any()`](#any) type.
 ```js
 const boolean = Joi.boolean();
 boolean.validate(true, (err, value) => { });
+```
+
+#### `boolean.truthy(value)`
+
+Allows for additional strings to be considered valid boolean values in addition to default 'truthy' strings: ['true', 'yes', '1', 'on']. Accepts a string or an array of strings.
+
+```js
+const boolean = Joi.boolean().truthy('Y');
+boolean.validate('Y', (err, value) => { });
+```
+
+#### `boolean.falsy(value)`
+
+Allows for additional strings to be considered valid boolean values in addition to default 'falsy' strings: ['false', 'no', '0', 'off']. Accepts a string or an array of strings.
+
+```js
+const boolean = Joi.boolean().falsy('N');
+boolean.validate('N', (err, value) => { });
 ```
 
 ### `binary`

--- a/lib/any.js
+++ b/lib/any.js
@@ -12,7 +12,7 @@ let Cast = null;
 // Declare internals
 
 const internals = {
-    Set: require('./set').Set
+    Set: require('./set')
 };
 
 

--- a/lib/any.js
+++ b/lib/any.js
@@ -12,7 +12,7 @@ let Cast = null;
 // Declare internals
 
 const internals = {
-    Set: require('./set')
+    Set: require('./set').Set
 };
 
 

--- a/lib/any.js
+++ b/lib/any.js
@@ -11,7 +11,9 @@ let Cast = null;
 
 // Declare internals
 
-const internals = {};
+const internals = {
+    Set: require('./set')
+};
 
 
 internals.defaults = {
@@ -783,97 +785,6 @@ internals._try = function (fn, arg) {
         error: err
     };
 };
-
-
-internals.Set = class {
-
-    constructor() {
-
-        this._set = [];
-    }
-
-    add(value, refs) {
-
-        if (!Ref.isRef(value) && this.has(value, null, null, false)) {
-
-            return;
-        }
-
-        if (refs !== undefined) { // If it's a merge, we don't have any refs
-            Ref.push(refs, value);
-        }
-
-        this._set.push(value);
-    }
-
-    merge(add, remove) {
-
-        for (let i = 0; i < add._set.length; ++i) {
-            this.add(add._set[i]);
-        }
-
-        for (let i = 0; i < remove._set.length; ++i) {
-            this.remove(remove._set[i]);
-        }
-    }
-
-    remove(value) {
-
-        this._set = this._set.filter((item) => value !== item);
-    }
-
-    has(value, state, options, insensitive) {
-
-        for (let i = 0; i < this._set.length; ++i) {
-            let items = this._set[i];
-
-            if (state && Ref.isRef(items)) { // Only resolve references if there is a state, otherwise it's a merge
-                items = items(state.reference || state.parent, options);
-            }
-
-            if (!Array.isArray(items)) {
-                items = [items];
-            }
-
-            for (let j = 0; j < items.length; ++j) {
-                const item = items[j];
-                if (typeof value !== typeof item) {
-                    continue;
-                }
-
-                if (value === item ||
-                    (value instanceof Date && item instanceof Date && value.getTime() === item.getTime()) ||
-                    (insensitive && typeof value === 'string' && value.toLowerCase() === item.toLowerCase()) ||
-                    (Buffer.isBuffer(value) && Buffer.isBuffer(item) && value.length === item.length && value.toString('binary') === item.toString('binary'))) {
-
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    values(options) {
-
-        if (options && options.stripUndefined) {
-            const values = [];
-
-            for (let i = 0; i < this._set.length; ++i) {
-                const item = this._set[i];
-                if (item !== undefined) {
-                    values.push(item);
-                }
-            }
-
-            return values;
-        }
-
-        return this._set.slice();
-    }
-
-};
-
 
 internals.concatSettings = function (target, source) {
 

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -35,39 +35,29 @@ internals.Boolean = class extends Any {
         return result;
     }
 
-    _truthy() {
-
-        const values = Hoek.flatten(Array.prototype.slice.call(arguments));
-        for (let i = 0; i < values.length; ++i) {
-            const value = values[i];
-
-            Hoek.assert(value !== undefined, 'Cannot call truthy/falsy with undefined');
-            this._inner._truthySet.add(value);
-        }
-    }
-
     truthy() {
 
         const obj = this.clone();
-        obj._truthy.apply(obj, arguments);
-        return obj;
-    }
-
-    _falsy() {
-
         const values = Hoek.flatten(Array.prototype.slice.call(arguments));
         for (let i = 0; i < values.length; ++i) {
             const value = values[i];
 
             Hoek.assert(value !== undefined, 'Cannot call truthy/falsy with undefined');
-            this._inner._falsySet.add(value);
+            obj._inner._truthySet.add(value);
         }
+        return obj;
     }
 
     falsy() {
 
         const obj = this.clone();
-        obj._falsy.apply(obj, arguments);
+        const values = Hoek.flatten(Array.prototype.slice.call(arguments));
+        for (let i = 0; i < values.length; ++i) {
+            const value = values[i];
+
+            Hoek.assert(value !== undefined, 'Cannot call truthy/falsy with undefined');
+            obj._inner._falsySet.add(value);
+        }
         return obj;
     }
 

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Any = require('./any');
+const Hoek = require('hoek');
 
 
 // Declare internals
@@ -15,6 +16,18 @@ internals.Boolean = class extends Any {
 
         super();
         this._type = 'boolean';
+        this._inner._truthySet = [
+            'true',
+            'yes',
+            'on',
+            '1'
+        ];
+        this._inner._falsySet = [
+            'false',
+            'no',
+            'off',
+            '0'
+        ];
     }
 
     _base(value, state, options) {
@@ -27,8 +40,8 @@ internals.Boolean = class extends Any {
             options.convert) {
 
             const lower = value.toLowerCase();
-            result.value = (lower === 'true' || lower === 'yes' || lower === 'on' || lower === '1' ? true
-                                                            : (lower === 'false' || lower === 'no' || lower === 'off' || lower === '0' ? false : value));
+            result.value = (this._inner._truthySet.indexOf(lower) !== -1 ? true
+                                                            : (this._inner._falsySet.indexOf(lower) !== -1 ? false : value));
         }
 
         if (typeof value === 'number' &&
@@ -40,6 +53,50 @@ internals.Boolean = class extends Any {
 
         result.errors = (typeof result.value === 'boolean') ? null : this.createError('boolean.base', null, state, options);
         return result;
+    }
+
+    truthy(truthyValue) {
+
+        let truthySet = [];
+
+        if (Array.isArray(truthyValue)) {
+            truthySet = truthyValue.map((value) => {
+
+                Hoek.assert(typeof value === 'string', 'truthy value must be a string');
+
+                return value.toLowerCase();
+            });
+        }
+        else {
+            Hoek.assert(typeof truthyValue === 'string', 'truthy value must be a string');
+            truthySet.push(truthyValue.toLowerCase());
+        }
+
+        const obj = this.clone();
+        obj._inner._truthySet = truthySet.concat(obj._truthySet);
+        return obj;
+    }
+
+    falsy(falsyValue) {
+
+        let falsySet = [];
+
+        if (Array.isArray(falsyValue)) {
+            falsySet = falsyValue.map((value) => {
+
+                Hoek.assert(typeof value === 'string', 'falsy value must be a string');
+
+                return value.toLowerCase();
+            });
+        }
+        else {
+            Hoek.assert(typeof falsyValue === 'string', 'falsy value must be a string');
+            falsySet.push(falsyValue.toLowerCase());
+        }
+
+        const obj = this.clone();
+        obj._inner._falsySet = falsySet.concat(obj._falsySet);
+        return obj;
     }
 };
 

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -57,20 +57,14 @@ internals.Boolean = class extends Any {
 
     truthy(truthyValue) {
 
-        let truthySet = [];
+        truthyValue = Array.isArray(truthyValue) ? truthyValue : [truthyValue];
 
-        if (Array.isArray(truthyValue)) {
-            truthySet = truthyValue.map((value) => {
+        const truthySet = truthyValue.map((value) => {
 
-                Hoek.assert(typeof value === 'string', 'truthy value must be a string');
+            Hoek.assert(typeof value === 'string', 'truthy value must be a string');
 
-                return value.toLowerCase();
-            });
-        }
-        else {
-            Hoek.assert(typeof truthyValue === 'string', 'truthy value must be a string');
-            truthySet.push(truthyValue.toLowerCase());
-        }
+            return value.toLowerCase();
+        });
 
         const obj = this.clone();
         obj._inner._truthySet = truthySet.concat(obj._truthySet);
@@ -79,20 +73,14 @@ internals.Boolean = class extends Any {
 
     falsy(falsyValue) {
 
-        let falsySet = [];
+        falsyValue = Array.isArray(falsyValue) ? falsyValue : [falsyValue];
 
-        if (Array.isArray(falsyValue)) {
-            falsySet = falsyValue.map((value) => {
+        const falsySet = falsyValue.map((value) => {
 
-                Hoek.assert(typeof value === 'string', 'falsy value must be a string');
+            Hoek.assert(typeof value === 'string', 'falsy value must be a string');
 
-                return value.toLowerCase();
-            });
-        }
-        else {
-            Hoek.assert(typeof falsyValue === 'string', 'falsy value must be a string');
-            falsySet.push(falsyValue.toLowerCase());
-        }
+            return value.toLowerCase();
+        });
 
         const obj = this.clone();
         obj._inner._falsySet = falsySet.concat(obj._falsySet);

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -8,7 +8,9 @@ const Hoek = require('hoek');
 
 // Declare internals
 
-const internals = {};
+const internals = {
+    Set: require('./set')
+};
 
 
 internals.Boolean = class extends Any {
@@ -16,8 +18,8 @@ internals.Boolean = class extends Any {
 
         super();
         this._type = 'boolean';
-        this._inner._truthySet = [];
-        this._inner._falsySet = [];
+        this._inner._truthySet = new internals.Set();
+        this._inner._falsySet = new internals.Set();
     }
 
     _base(value, state, options) {
@@ -26,8 +28,8 @@ internals.Boolean = class extends Any {
             value
         };
 
-        result.value = (this._inner._truthySet.indexOf(value) !== -1 ? true
-            : (this._inner._falsySet.indexOf(value) !== -1 ? false : value));
+        result.value = (this._inner._truthySet.has(value) ? true
+            : (this._inner._falsySet.has(value) ? false : value));
 
         result.errors = (typeof result.value === 'boolean') ? null : this.createError('boolean.base', null, state, options);
         return result;
@@ -40,7 +42,7 @@ internals.Boolean = class extends Any {
             const value = values[i];
 
             Hoek.assert(value !== undefined, 'Cannot call truthy/falsy with undefined');
-            this._inner._truthySet.push(value);
+            this._inner._truthySet.add(value);
         }
     }
 
@@ -58,7 +60,7 @@ internals.Boolean = class extends Any {
             const value = values[i];
 
             Hoek.assert(value !== undefined, 'Cannot call truthy/falsy with undefined');
-            this._inner._falsySet.push(value);
+            this._inner._falsySet.add(value);
         }
     }
 
@@ -67,6 +69,31 @@ internals.Boolean = class extends Any {
         const obj = this.clone();
         obj._falsy.apply(obj, arguments);
         return obj;
+    }
+
+    describe() {
+
+        const description = Any.prototype.describe.call(this);
+
+        if (this._inner._truthySet.values().length) {
+            description.truthyValues = [];
+            const truthyValues = this._inner._truthySet.values();
+
+            for (let i = 0; i < truthyValues.length; ++i) {
+                description.truthyValues.push(truthyValues[i]);
+            }
+        }
+
+        if (this._inner._falsySet.values().length) {
+            description.falsyValues = [];
+            const falsyValues = this._inner._falsySet.values();
+
+            for (let i = 0; i < falsyValues.length; ++i) {
+                description.falsyValues.push(falsyValues[i]);
+            }
+        }
+
+        return description;
     }
 };
 

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -9,7 +9,7 @@ const Hoek = require('hoek');
 // Declare internals
 
 const internals = {
-    Set: require('./set')
+    Set: require('./set').Set
 };
 
 
@@ -76,21 +76,11 @@ internals.Boolean = class extends Any {
         const description = Any.prototype.describe.call(this);
 
         if (this._inner._truthySet.values().length) {
-            description.truthyValues = [];
-            const truthyValues = this._inner._truthySet.values();
-
-            for (let i = 0; i < truthyValues.length; ++i) {
-                description.truthyValues.push(truthyValues[i]);
-            }
+            description.truthyValues = this._inner._truthySet.values();
         }
 
         if (this._inner._falsySet.values().length) {
-            description.falsyValues = [];
-            const falsyValues = this._inner._falsySet.values();
-
-            for (let i = 0; i < falsyValues.length; ++i) {
-                description.falsyValues.push(falsyValues[i]);
-            }
+            description.falsyValues = this._inner._falsySet.values();
         }
 
         return description;

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -16,18 +16,8 @@ internals.Boolean = class extends Any {
 
         super();
         this._type = 'boolean';
-        this._inner._truthySet = [
-            'true',
-            'yes',
-            'on',
-            '1'
-        ];
-        this._inner._falsySet = [
-            'false',
-            'no',
-            'off',
-            '0'
-        ];
+        this._inner._truthySet = [];
+        this._inner._falsySet = [];
     }
 
     _base(value, state, options) {
@@ -36,54 +26,46 @@ internals.Boolean = class extends Any {
             value
         };
 
-        if (typeof value === 'string' &&
-            options.convert) {
-
-            const lower = value.toLowerCase();
-            result.value = (this._inner._truthySet.indexOf(lower) !== -1 ? true
-                                                            : (this._inner._falsySet.indexOf(lower) !== -1 ? false : value));
-        }
-
-        if (typeof value === 'number' &&
-            options.convert) {
-
-            result.value = (value === 1 ? true
-                    : (value === 0 ? false : value));
-        }
+        result.value = (this._inner._truthySet.indexOf(value) !== -1 ? true
+            : (this._inner._falsySet.indexOf(value) !== -1 ? false : value));
 
         result.errors = (typeof result.value === 'boolean') ? null : this.createError('boolean.base', null, state, options);
         return result;
     }
 
-    truthy(truthyValue) {
+    _truthy() {
 
-        truthyValue = Array.isArray(truthyValue) ? truthyValue : [truthyValue];
+        const values = Hoek.flatten(Array.prototype.slice.call(arguments));
+        for (let i = 0; i < values.length; ++i) {
+            const value = values[i];
 
-        const truthySet = truthyValue.map((value) => {
+            Hoek.assert(value !== undefined, 'Cannot call truthy/falsy with undefined');
+            this._inner._truthySet.push(value);
+        }
+    }
 
-            Hoek.assert(typeof value === 'string', 'truthy value must be a string');
-
-            return value.toLowerCase();
-        });
+    truthy() {
 
         const obj = this.clone();
-        obj._inner._truthySet = truthySet.concat(obj._truthySet);
+        obj._truthy.apply(obj, arguments);
         return obj;
     }
 
-    falsy(falsyValue) {
+    _falsy() {
 
-        falsyValue = Array.isArray(falsyValue) ? falsyValue : [falsyValue];
+        const values = Hoek.flatten(Array.prototype.slice.call(arguments));
+        for (let i = 0; i < values.length; ++i) {
+            const value = values[i];
 
-        const falsySet = falsyValue.map((value) => {
+            Hoek.assert(value !== undefined, 'Cannot call truthy/falsy with undefined');
+            this._inner._falsySet.push(value);
+        }
+    }
 
-            Hoek.assert(typeof value === 'string', 'falsy value must be a string');
-
-            return value.toLowerCase();
-        });
+    falsy() {
 
         const obj = this.clone();
-        obj._inner._falsySet = falsySet.concat(obj._falsySet);
+        obj._falsy.apply(obj, arguments);
         return obj;
     }
 };

--- a/lib/boolean.js
+++ b/lib/boolean.js
@@ -9,7 +9,7 @@ const Hoek = require('hoek');
 // Declare internals
 
 const internals = {
-    Set: require('./set').Set
+    Set: require('./set')
 };
 
 

--- a/lib/set.js
+++ b/lib/set.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const Ref = require('./ref');
+
+const Set = class {
+
+    constructor() {
+
+        this._set = [];
+    }
+
+    add(value, refs) {
+
+        if (!Ref.isRef(value) && this.has(value, null, null, false)) {
+
+            return;
+        }
+
+        if (refs !== undefined) { // If it's a merge, we don't have any refs
+            Ref.push(refs, value);
+        }
+
+        this._set.push(value);
+    }
+
+    merge(add, remove) {
+
+        for (let i = 0; i < add._set.length; ++i) {
+            this.add(add._set[i]);
+        }
+
+        if (remove) {
+            for (let i = 0; i < remove._set.length; ++i) {
+                this.remove(remove._set[i]);
+            }
+        }
+    }
+
+    remove(value) {
+
+        this._set = this._set.filter((item) => value !== item);
+    }
+
+    has(value, state, options, insensitive) {
+
+        for (let i = 0; i < this._set.length; ++i) {
+            let items = this._set[i];
+
+            if (state && Ref.isRef(items)) { // Only resolve references if there is a state, otherwise it's a merge
+                items = items(state.reference || state.parent, options);
+            }
+
+            if (!Array.isArray(items)) {
+                items = [items];
+            }
+
+            for (let j = 0; j < items.length; ++j) {
+                const item = items[j];
+                if (typeof value !== typeof item) {
+                    continue;
+                }
+
+                if (value === item ||
+                    (value instanceof Date && item instanceof Date && value.getTime() === item.getTime()) ||
+                    (insensitive && typeof value === 'string' && value.toLowerCase() === item.toLowerCase()) ||
+                    (Buffer.isBuffer(value) && Buffer.isBuffer(item) && value.length === item.length && value.toString('binary') === item.toString('binary'))) {
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    values(options) {
+
+        if (options && options.stripUndefined) {
+            const values = [];
+
+            for (let i = 0; i < this._set.length; ++i) {
+                const item = this._set[i];
+                if (item !== undefined) {
+                    values.push(item);
+                }
+            }
+
+            return values;
+        }
+
+        return this._set.slice();
+    }
+
+    slice() {
+
+        const newSet = new Set();
+        newSet.merge(this);
+
+        return newSet;
+    }
+
+    concat(source) {
+
+        const newSet = new Set();
+        newSet.merge(this);
+        newSet.merge(source);
+
+        return newSet;
+    }
+};
+
+module.exports = Set;

--- a/lib/set.js
+++ b/lib/set.js
@@ -2,7 +2,7 @@
 
 const Ref = require('./ref');
 
-exports.Set = class Set {
+module.exports = class Set {
 
     constructor() {
 

--- a/lib/set.js
+++ b/lib/set.js
@@ -2,7 +2,7 @@
 
 const Ref = require('./ref');
 
-const Set = class {
+exports.Set = class Set {
 
     constructor() {
 
@@ -29,10 +29,8 @@ const Set = class {
             this.add(add._set[i]);
         }
 
-        if (remove) {
-            for (let i = 0; i < remove._set.length; ++i) {
-                this.remove(remove._set[i]);
-            }
+        for (let i = 0; i < remove._set.length; ++i) {
+            this.remove(remove._set[i]);
         }
     }
 
@@ -94,7 +92,7 @@ const Set = class {
     slice() {
 
         const newSet = new Set();
-        newSet.merge(this);
+        newSet._set = this._set.slice();
 
         return newSet;
     }
@@ -102,11 +100,8 @@ const Set = class {
     concat(source) {
 
         const newSet = new Set();
-        newSet.merge(this);
-        newSet.merge(source);
+        newSet._set = this._set.concat(source._set);
 
         return newSet;
     }
 };
-
-module.exports = Set;

--- a/test/any.js
+++ b/test/any.js
@@ -1812,5 +1812,40 @@ describe('any', () => {
                 done();
             });
         });
+
+        describe('slice', () => {
+
+            it('returns a new Set', (done) => {
+
+                const any = Joi.any().clone();
+                any._valids.add(null);
+                const otherValids = any._valids.slice();
+                otherValids.add('null');
+                expect(any._valids.has(null)).to.equal(true);
+                expect(otherValids.has(null)).to.equal(true);
+                expect(any._valids.has('null')).to.equal(false);
+                expect(otherValids.has('null')).to.equal(true);
+                done();
+            });
+        });
+
+        describe('concat', () => {
+
+            it('merges _set into a new Set', (done) => {
+
+                const any = Joi.any().clone();
+                const otherValids = any._valids.slice();
+                any._valids.add(null);
+                otherValids.add('null');
+                const thirdSet = otherValids.concat(any._valids);
+                expect(any._valids.has(null)).to.equal(true);
+                expect(otherValids.has(null)).to.equal(false);
+                expect(any._valids.has('null')).to.equal(false);
+                expect(otherValids.has('null')).to.equal(true);
+                expect(thirdSet.has(null)).to.equal(true);
+                expect(thirdSet.has('null')).to.equal(true);
+                done();
+            });
+        });
     });
 });

--- a/test/any.js
+++ b/test/any.js
@@ -228,7 +228,7 @@ describe('any', () => {
             const tests = [
                 [Joi.array(), '[1,2,3]'],
                 [Joi.binary(), 'abc'],
-                [Joi.boolean(), 'false'],
+                [Joi.boolean(), false],
                 [Joi.date().format('YYYYMMDD'), '19700101'],
                 [Joi.number(), '12'],
                 [Joi.object(), '{ "a": 1 }'],

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -23,29 +23,28 @@ const expect = Code.expect;
 
 describe('boolean', () => {
 
-    it('converts a string to a boolean', (done) => {
+    it('does not convert a string to a boolean', (done) => {
 
         Joi.boolean().validate('true', (err, value) => {
 
-            expect(err).to.not.exist();
-            expect(value).to.equal(true);
+            expect(err).to.exist();
+            expect(value).to.not.equal(true);
             done();
         });
     });
 
-    it('errors on a number not 0 or 1', (done) => {
+    it('errors on a number', (done) => {
 
-        Joi.boolean().validate(2, (err, value) => {
-
-            expect(err).to.exist();
-            expect(value).to.equal(2);
-            done();
-        });
+        Helper.validate(Joi.boolean(), [
+            [1, false, null, '"value" must be a boolean'],
+            [0, false, null, '"value" must be a boolean'],
+            [2, false, null, '"value" must be a boolean']
+        ], done);
     });
 
     describe('validate()', () => {
 
-        it('converts string values and validates', (done) => {
+        it('does not convert string values and validates', (done) => {
 
             const rule = Joi.boolean();
             Helper.validate(rule, [
@@ -53,45 +52,15 @@ describe('boolean', () => {
                 [false, true],
                 [true, true],
                 [null, false, null, '"value" must be a boolean'],
-                ['on', true],
-                ['off', true],
-                ['true', true],
-                ['false', true],
-                ['yes', true],
-                ['no', true],
-                ['1', true],
-                ['0', true]
+                ['on', false, null, '"value" must be a boolean'],
+                ['off', false, null, '"value" must be a boolean'],
+                ['true', false, null, '"value" must be a boolean'],
+                ['false', false, null, '"value" must be a boolean'],
+                ['yes', false, null, '"value" must be a boolean'],
+                ['no', false, null, '"value" must be a boolean'],
+                ['1', false, null, '"value" must be a boolean'],
+                ['0', false, null, '"value" must be a boolean']
             ], done);
-        });
-
-        it('converts number values and validates', (done) => {
-
-            const rule = Joi.boolean();
-            Helper.validate(rule, [
-                [1234, false, null, '"value" must be a boolean'],
-                [1, true],
-                [0, true]
-            ], done);
-        });
-
-        it('converts 1 to true', (done) => {
-
-            Joi.boolean().validate(1, (err, value) => {
-
-                expect(err).to.not.exist();
-                expect(value).to.equal(true);
-                done();
-            });
-        });
-
-        it('converts 0 to false', (done) => {
-
-            Joi.boolean().validate(0, (err, value) => {
-
-                expect(err).to.not.exist();
-                expect(value).to.equal(false);
-                done();
-            });
         });
 
         it('should handle work with required', (done) => {
@@ -99,7 +68,7 @@ describe('boolean', () => {
             const rule = Joi.boolean().required();
             Helper.validate(rule, [
                 ['1234', false, null, '"value" must be a boolean'],
-                ['true', true],
+                ['true', false, null, '"value" must be a boolean'],
                 [false, true],
                 [true, true],
                 [null, false, null, '"value" must be a boolean']
@@ -165,10 +134,10 @@ describe('boolean', () => {
             const rule = Joi.boolean().truthy('Y');
             Helper.validate(rule, [
                 ['Y', true],
-                ['y', true],
                 [true, true],
                 [false, true],
-                ['N', false, null, '"value" must be a boolean']
+                ['N', false, null, '"value" must be a boolean'],
+                [null, false, null, '"value" must be a boolean']
             ], done);
         });
 
@@ -177,9 +146,7 @@ describe('boolean', () => {
             const rule = Joi.boolean().truthy(['Y', 'Si']);
             Helper.validate(rule, [
                 ['Si', true],
-                ['si', true],
                 ['Y', true],
-                ['y', true],
                 [true, true],
                 [false, true],
                 ['N', false, null, '"value" must be a boolean'],
@@ -192,10 +159,10 @@ describe('boolean', () => {
             const rule = Joi.boolean().falsy('N');
             Helper.validate(rule, [
                 ['N', true],
-                ['n', true],
                 ['Y', false, null, '"value" must be a boolean'],
                 [true, true],
-                [false, true]
+                [false, true],
+                [null, false, null, '"value" must be a boolean']
             ], done);
         });
 
@@ -204,9 +171,7 @@ describe('boolean', () => {
             const rule = Joi.boolean().falsy(['N', 'Never']);
             Helper.validate(rule, [
                 ['N', true],
-                ['n', true],
                 ['Never', true],
-                ['never', true],
                 ['Y', false, null, '"value" must be a boolean'],
                 [null, false, null, '"value" must be a boolean'],
                 [true, true],
@@ -216,49 +181,21 @@ describe('boolean', () => {
 
         it('should handle work with required, null allowed, and both additional truthy and falsy values', (done) => {
 
-            const rule = Joi.boolean().truthy(['Y', 'Si']).falsy(['N', 'Never']).allow(null).required();
+            const rule = Joi.boolean().truthy(['Y', 'Si', 1]).falsy(['N', 'Never', 0]).allow(null).required();
             Helper.validate(rule, [
                 ['N', true],
-                ['n', true],
                 ['Never', true],
-                ['never', true],
                 ['Y', true],
-                ['y', true],
                 ['Si', true],
-                ['si', true],
                 [true, true],
                 [false, true],
+                [1, true],
+                [0, true],
                 [null, true],
-                ['M', false, null, '"value" must be a boolean']
+                ['M', false, null, '"value" must be a boolean'],
+                ['Yes', false, null, '"value" must be a boolean'],
+                ['y', false, null, '"value" must be a boolean']
             ], done);
-        });
-
-        it('errors on non-string truthy value', (done) => {
-
-            expect(() => {
-
-                Joi.boolean().truthy({});
-            }).to.throw('truthy value must be a string');
-
-            expect(() => {
-
-                Joi.boolean().truthy(['valid', {}]);
-            }).to.throw('truthy value must be a string');
-            done();
-        });
-
-        it('errors on non-string falsy value', (done) => {
-
-            expect(() => {
-
-                Joi.boolean().falsy({});
-            }).to.throw('falsy value must be a string');
-
-            expect(() => {
-
-                Joi.boolean().falsy(['valid', {}]);
-            }).to.throw('falsy value must be a string');
-            done();
         });
     });
 });

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -159,5 +159,106 @@ describe('boolean', () => {
                 [null, true]
             ], done);
         });
+
+        it('should handle work with additional truthy value', (done) => {
+
+            const rule = Joi.boolean().truthy('Y');
+            Helper.validate(rule, [
+                ['Y', true],
+                ['y', true],
+                [true, true],
+                [false, true],
+                ['N', false, null, '"value" must be a boolean']
+            ], done);
+        });
+
+        it('should handle work with additional truthy array', (done) => {
+
+            const rule = Joi.boolean().truthy(['Y', 'Si']);
+            Helper.validate(rule, [
+                ['Si', true],
+                ['si', true],
+                ['Y', true],
+                ['y', true],
+                [true, true],
+                [false, true],
+                ['N', false, null, '"value" must be a boolean'],
+                [null, false, null, '"value" must be a boolean']
+            ], done);
+        });
+
+        it('should handle work with additional falsy value', (done) => {
+
+            const rule = Joi.boolean().falsy('N');
+            Helper.validate(rule, [
+                ['N', true],
+                ['n', true],
+                ['Y', false, null, '"value" must be a boolean'],
+                [true, true],
+                [false, true]
+            ], done);
+        });
+
+        it('should handle work with additional falsy array', (done) => {
+
+            const rule = Joi.boolean().falsy(['N', 'Never']);
+            Helper.validate(rule, [
+                ['N', true],
+                ['n', true],
+                ['Never', true],
+                ['never', true],
+                ['Y', false, null, '"value" must be a boolean'],
+                [null, false, null, '"value" must be a boolean'],
+                [true, true],
+                [false, true]
+            ], done);
+        });
+
+        it('should handle work with required, null allowed, and both additional truthy and falsy values', (done) => {
+
+            const rule = Joi.boolean().truthy(['Y', 'Si']).falsy(['N', 'Never']).allow(null).required();
+            Helper.validate(rule, [
+                ['N', true],
+                ['n', true],
+                ['Never', true],
+                ['never', true],
+                ['Y', true],
+                ['y', true],
+                ['Si', true],
+                ['si', true],
+                [true, true],
+                [false, true],
+                [null, true],
+                ['M', false, null, '"value" must be a boolean']
+            ], done);
+        });
+
+        it('errors on non-string truthy value', (done) => {
+
+            expect(() => {
+
+                Joi.boolean().truthy({});
+            }).to.throw('truthy value must be a string');
+
+            expect(() => {
+
+                Joi.boolean().truthy(['valid', {}]);
+            }).to.throw('truthy value must be a string');
+            done();
+        });
+
+        it('errors on non-string falsy value', (done) => {
+
+            expect(() => {
+
+                Joi.boolean().falsy({});
+            }).to.throw('falsy value must be a string');
+
+            expect(() => {
+
+                Joi.boolean().falsy(['valid', {}]);
+            }).to.throw('falsy value must be a string');
+            done();
+        });
     });
 });

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -197,5 +197,40 @@ describe('boolean', () => {
                 ['y', false, null, '"value" must be a boolean']
             ], done);
         });
+
+        it('should handle concatenated schema', (done) => {
+
+            const a = Joi.boolean().truthy('yes');
+            const b = Joi.boolean().falsy('no');
+
+            Helper.validate(a, [
+                ['yes', true],
+                ['no', false, null, '"value" must be a boolean']
+            ]);
+
+            Helper.validate(b, [
+                ['no', true],
+                ['yes', false, null, '"value" must be a boolean']
+            ]);
+
+            Helper.validate(a.concat(b), [
+                ['yes', true],
+                ['no', true]
+            ], done);
+        });
+
+        it('should describe truthy and falsy values', (done) => {
+
+            const schema = Joi.boolean().truthy('yes').falsy('no').required().describe();
+            expect(schema).to.equal({
+                type: 'boolean',
+                flags: {
+                    presence: 'required'
+                },
+                truthyValues: ['yes'],
+                falsyValues : ['no']
+            });
+            done();
+        });
     });
 });


### PR DESCRIPTION
This commit resolves #991 by adding the following support:

- Implements `Joi.boolean().truthy()` and `Joi.boolean().falsy()`
  - Both methods accept either a string, or an array of strings.
  - Both methods utilize `Hoek.assert` to ensure that the values passed are strings.
  - Both methods have 100% test coverage.
  - Both methods are documented in API.md.