### PR TITLE
Fix custom error (validate) options

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -55,7 +55,8 @@ module.exports = internals.Any = class {
              case: undefined,                        // upper, lower
              empty: undefined,
              func: false,
-             raw: false
+             raw: false,
+             error: undefined
              */
         };
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -117,6 +117,9 @@ exports.process = function (errors, object) {
         for (let i = 0; i < localErrors.length; ++i) {
             const item = localErrors[i];
 
+            if (item.options.error) {
+                return item.options.error;
+            }
             if (item.flags.error) {
                 return item.flags.error;
             }

--- a/test/errors.js
+++ b/test/errors.js
@@ -297,7 +297,7 @@ describe('errors', () => {
             done();
         });
     });
-    
+
     it('returns custom error (validate options)', (done) => {
 
         const schema = Joi.object({
@@ -350,7 +350,7 @@ describe('errors', () => {
             done();
         });
     });
-    
+
     it('returns custom error (options)', (done) => {
 
         const schema = Joi.object({

--- a/test/errors.js
+++ b/test/errors.js
@@ -297,6 +297,24 @@ describe('errors', () => {
             done();
         });
     });
+    
+    it('returns custom error (validate options)', (done) => {
+
+        const schema = Joi.object({
+            a: Joi.string(),
+            b: {
+                c: Joi.number()
+            }
+        });
+
+        Joi.validate({ a: 'abc', b: { c: 'x' } }, schema, { error: new Error('Really wanted a number!') }, (err) => {
+
+            expect(err).to.exist();
+            expect(err.isJoi).to.not.exist();
+            expect(err.message).to.equal('Really wanted a number!');
+            done();
+        });
+    });
 
     it('returns first custom error with multiple errors', (done) => {
 
@@ -329,6 +347,24 @@ describe('errors', () => {
 
             expect(err).to.exist();
             expect(err.isJoi).to.be.true();
+            done();
+        });
+    });
+    
+    it('returns custom error (options)', (done) => {
+
+        const schema = Joi.object({
+            a: Joi.string(),
+            b: {
+                c: Joi.number().options({ error: new Error('Really wanted a number!') })
+            }
+        });
+
+        Joi.validate({ a: 'abc', b: { c: 'x' } }, schema, (err) => {
+
+            expect(err).to.exist();
+            expect(err.isJoi).to.not.exist();
+            expect(err.message).to.equal('Really wanted a number!');
             done();
         });
     });


### PR DESCRIPTION
#### Context

* *joi version*: 9.2.0

#### What are you trying to achieve or the steps to reproduce ?

Re-instate tests for custom error (validate) options and add supersede an item's error flag with its error option.

Fixes changes in commit 8c48da5a955a05c7315b5eaf29813ee2fe510806 from issue #874

See https://github.com/hapijs/joi/pull/1010
