### PR TITLE
Extending describe() to include renames in metadata

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -681,6 +681,10 @@ module.exports = internals.Any = class {
             description.unit = this._unit;
         }
 
+        if (this._inner.renames && this._inner.renames.length > 0) {
+            description.renames = this._inner.renames;
+        }
+
         const valids = this._valids.values();
         if (valids.length) {
             description.valids = valids.map((v) => {

--- a/lib/any.js
+++ b/lib/any.js
@@ -681,10 +681,6 @@ module.exports = internals.Any = class {
             description.unit = this._unit;
         }
 
-        if (this._inner.renames && this._inner.renames.length > 0) {
-            description.renames = this._inner.renames;
-        }
-
         const valids = this._valids.values();
         if (valids.length) {
             description.valids = valids.map((v) => {

--- a/lib/object.js
+++ b/lib/object.js
@@ -607,6 +607,10 @@ internals.Object = class extends Any {
             }
         }
 
+        if (this._inner.renames.length > 0) {
+            description.renames = Hoek.clone(this._inner.renames);
+        }
+
         return description;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1649,6 +1649,17 @@ describe('Joi', () => {
                     key: 'xor',
                     peers: ['required']
                 }
+            ],
+            renames: [
+                {
+                    from: 'renamed',
+                    to: 'required',
+                    options: {
+                        alias: false,
+                        multiple: false,
+                        override: false
+                    }
+                }
             ]
         };
 

--- a/test/object.js
+++ b/test/object.js
@@ -802,6 +802,46 @@ describe('object', () => {
                 done();
             });
         });
+
+        it('should fulfill describe() with defaults', (done) => {
+
+            const schema = Joi.object().rename('b', 'a');
+            const desc = schema.describe();
+
+            expect(desc).to.equal({
+                type: 'object',
+                renames: [{
+                    from: 'b',
+                    to: 'a',
+                    options: {
+                        alias: false,
+                        multiple: false,
+                        override: false
+                    }
+                }]
+            });
+            done();
+        });
+
+        it('should fulfill describe() with non-defaults', (done) => {
+
+            const schema = Joi.object().rename('b', 'a', { alias: true, multiple: true, override: true });
+            const desc = schema.describe();
+
+            expect(desc).to.equal({
+                type: 'object',
+                renames: [{
+                    from: 'b',
+                    to: 'a',
+                    options: {
+                        alias: true,
+                        multiple: true,
+                        override: true
+                    }
+                }]
+            });
+            done();
+        });
     });
 
     describe('describe()', () => {


### PR DESCRIPTION
For the `object.renames()` API, it currently stores data within the scoping of `schema._inner.renames`.  This set of schema definition is not projected within the `any.describe()` function.  I'm adding this with the intent that `renames()` meta data can be part of a common contract.  This will also help support [felicity](https://github.com/xogroup/felicity).

Please let me know of any concern with this implementation.

This is also a fix to Issue #1026 