### PR TITLE
Extend describe() for type

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -725,6 +725,11 @@ module.exports = internals.Any = class {
                 else if (typeof options.description === 'function') {
                     item.description = options.description(item.arg);
                 }
+                
+                if (options.constructor) {
+                    // console.log(typeof options.constructor);
+                    item.constructor = options.constructor;
+                }
             }
 
             description.rules.push(item);

--- a/lib/any.js
+++ b/lib/any.js
@@ -725,10 +725,6 @@ module.exports = internals.Any = class {
                 else if (typeof options.description === 'function') {
                     item.description = options.description(item.arg);
                 }
-
-                if (options.ctor) {
-                    item.ctor = options.ctor;
-                }
             }
 
             description.rules.push(item);

--- a/lib/any.js
+++ b/lib/any.js
@@ -725,10 +725,9 @@ module.exports = internals.Any = class {
                 else if (typeof options.description === 'function') {
                     item.description = options.description(item.arg);
                 }
-                
-                if (options.constructor) {
-                    // console.log(typeof options.constructor);
-                    item.constructor = options.constructor;
+
+                if (options.ctor) {
+                    item.ctor = options.ctor;
                 }
             }
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -651,17 +651,18 @@ internals.Object = class extends Any {
     type(constructor, name) {
 
         Hoek.assert(typeof constructor === 'function', 'type must be a constructor function');
-        name = name || constructor.name;
+        const typeData = {
+            name: name || constructor.name,
+            ctor: constructor
+        };
 
-        return this._test('type', name, function (value, state, options) {
+        return this._test('type', typeData, function (value, state, options) {
 
             if (value instanceof constructor) {
                 return value;
             }
 
-            return this.createError('object.type', { type: name }, state, options);
-        }, {
-            ctor: constructor
+            return this.createError('object.type', { type: typeData.name }, state, options);
         });
     }
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -656,6 +656,8 @@ internals.Object = class extends Any {
             }
 
             return this.createError('object.type', { type: name }, state, options);
+        }, {
+            constructor: constructor
         });
     }
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -657,7 +657,7 @@ internals.Object = class extends Any {
 
             return this.createError('object.type', { type: name }, state, options);
         }, {
-            constructor: constructor
+            ctor: constructor
         });
     }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -37,7 +37,6 @@ exports.validateOptions = function (schema, config, options, callback) {
             if (!shouldValidate) {
                 expect(expectedValueOrError, 'Failing tests messages must be tested').to.exist();
             }
-
             const result = Joi.validate(input, compiled, validationOptions || options);
 
             const err = result.error;

--- a/test/object.js
+++ b/test/object.js
@@ -1365,7 +1365,7 @@ describe('object', () => {
 
             const description = Joi.object().type(RegExp).describe();
 
-            expect(description.rules).to.include({ name: 'type', arg: 'RegExp', ctor: RegExp });
+            expect(description.rules).to.include({ name: 'type', arg: { name: 'RegExp', ctor: RegExp } });
             done();
         });
 
@@ -1374,7 +1374,7 @@ describe('object', () => {
             const Foo = function Foo() { };
             const description = Joi.object().type(Foo).describe();
 
-            expect(new Foo()).to.be.an.instanceof(description.rules[0].ctor);
+            expect(new Foo()).to.be.an.instanceof(description.rules[0].arg.ctor);
             done();
         });
     });

--- a/test/object.js
+++ b/test/object.js
@@ -1325,16 +1325,16 @@ describe('object', () => {
 
             const description = Joi.object().type(RegExp).describe();
 
-            expect(description.rules).to.include({ name: 'type', arg: 'RegExp' });
+            expect(description.rules).to.include({ name: 'type', arg: 'RegExp', ctor: RegExp });
             done();
         });
 
-        it.only('uses the constructor reference in the schema description', (done) => {
+        it('uses the constructor reference in the schema description', (done) => {
 
             const Foo = function Foo() { };
             const description = Joi.object().type(Foo).describe();
 
-            expect(new Foo()).to.be.an.instanceof(description.rules[0].constructor);
+            expect(new Foo()).to.be.an.instanceof(description.rules[0].ctor);
             done();
         });
     });

--- a/test/object.js
+++ b/test/object.js
@@ -1328,6 +1328,15 @@ describe('object', () => {
             expect(description.rules).to.include({ name: 'type', arg: 'RegExp' });
             done();
         });
+
+        it.only('uses the constructor reference in the schema description', (done) => {
+
+            const Foo = function Foo() { };
+            const description = Joi.object().type(Foo).describe();
+
+            expect(new Foo()).to.be.an.instanceof(description.rules[0].constructor);
+            done();
+        });
     });
 
     describe('schema()', () => {


### PR DESCRIPTION
For the API `object.type()`.  I'm extending the meta data storage of the constructor within the schema to be placed in `options`.  Also extending `any.describe()` to project it to a new item schema within the `rules` array.  This will help facilitate an object generation of the exact type specified by this API contract.  Problem right now is that the type is translated to a `name` of type `String` and the ability to reproduce via `Object.create()` is lost since there is no way to cast it back to the original reference.  Support is being added within [felicity](https://github.com/xogroup/felicity)  

Let me know if there is a better way of implementing this.

**Using the Joi API**
```Javascript
Joi.object().type(RegExp);
```
**Storage within the schema**
```Javascript
{
    _test: [{
        name: 'type',
        arg: 'RegExp',
        options: {
            ctor: [Function RegExp]  //This is new
        }
    }]
}
```

**Within the Transform of `any.describe()`**
````Javascript
{
    rules: [{
        name: 'type',
        arg: 'RegExp',
        ctor: [Function RegExp] //This is new
    }]
}
````
