### PR TITLE
Implement String.regex "invalidate" configuration

### DIFF
--- a/API.md
+++ b/API.md
@@ -1542,17 +1542,20 @@ const schema = Joi.object({
 });
 ```
 
-#### `string.regex(pattern, [name | config])`
+#### `string.regex(pattern, [name | options])`
 
 Defines a regular expression rule where:
 - `pattern` - a regular expression object the string value must match against.
 - `name` - optional name for patterns (useful with multiple patterns).
-- `config` - an optional configuration object with the following supported properties:
+- `options` - an optional configuration object with the following supported properties:
   - `name` - optional pattern name.
   - `invert` - optional boolean flag. Defaults to `false` behavior. If specified as `true`, the provided pattern will be disallowed instead of required.
 
 ```js
 const schema = Joi.string().regex(/^[abc]+$/);
+
+const inlineNamedSchema = Joi.string().regex(/[0-9]/, 'numbers');
+inlineNamedSchema.validate('alpha'); // ValidationError: "value" with value "alpha" fails to match the numbers pattern
 
 const namedSchema = Joi.string().regex(/[0-9]/, { name: 'numbers'});
 namedSchema.validate('alpha'); // ValidationError: "value" with value "alpha" fails to match the numbers pattern

--- a/API.md
+++ b/API.md
@@ -109,7 +109,7 @@
     - [`string.truncate([enabled])`](#stringtruncateenabled)
     - [`string.creditCard()`](#stringcreditcard)
     - [`string.length(limit, [encoding])`](#stringlengthlimit-encoding)
-    - [`string.regex(pattern, [name])`](#stringregexpattern-name)
+    - [`string.regex(pattern, [name | options])`](#stringregexpattern-name--options)
     - [`string.replace(pattern, replacement)`](#stringreplacepattern-replacement)
     - [`string.alphanum()`](#stringalphanum)
     - [`string.token()`](#stringtoken)

--- a/API.md
+++ b/API.md
@@ -1542,14 +1542,26 @@ const schema = Joi.object({
 });
 ```
 
-#### `string.regex(pattern, [name])`
+#### `string.regex(pattern, [name | config])`
 
 Defines a regular expression rule where:
 - `pattern` - a regular expression object the string value must match against.
 - `name` - optional name for patterns (useful with multiple patterns). Defaults to 'required'.
+- `config` - an optional configuration object with the following supported properties:
+  - `name` - optional pattern name. Defaults to `required`.
+  - `invalidate` - optional boolean flag. Defaults to `false` behavior. If specified as `true`, the provided pattern will be disallowed instead of required.
 
 ```js
 const schema = Joi.string().regex(/^[abc]+$/);
+
+const namedSchema = Joi.string().regex(/[0-9]/, { name: 'numbers'});
+namedSchema.validate('alpha'); // ValidationError: "value" with value "alpha" fails to match the numbers pattern
+
+const invalidatedSchema = Joi.string().regex(/[a-z]/, { invalidate: true });
+invalidatedSchema.validate('lowercase'); // ValidationError: "value" with value "lowercase" matches the invalidated pattern: [a-z]
+
+const invalidatedNamedSchema = Joi.string().regex(/[a-z]/, { name: 'alpha', invalidate: true });
+invalidatedNamedSchema.validate('lowercase'); // ValidationError: "value" with value "lowercase" matches the invalidated alpha pattern
 ```
 
 #### `string.replace(pattern, replacement)`

--- a/API.md
+++ b/API.md
@@ -1546,10 +1546,10 @@ const schema = Joi.object({
 
 Defines a regular expression rule where:
 - `pattern` - a regular expression object the string value must match against.
-- `name` - optional name for patterns (useful with multiple patterns). Defaults to 'required'.
+- `name` - optional name for patterns (useful with multiple patterns).
 - `config` - an optional configuration object with the following supported properties:
-  - `name` - optional pattern name. Defaults to `required`.
-  - `invalidate` - optional boolean flag. Defaults to `false` behavior. If specified as `true`, the provided pattern will be disallowed instead of required.
+  - `name` - optional pattern name.
+  - `invert` - optional boolean flag. Defaults to `false` behavior. If specified as `true`, the provided pattern will be disallowed instead of required.
 
 ```js
 const schema = Joi.string().regex(/^[abc]+$/);
@@ -1557,11 +1557,11 @@ const schema = Joi.string().regex(/^[abc]+$/);
 const namedSchema = Joi.string().regex(/[0-9]/, { name: 'numbers'});
 namedSchema.validate('alpha'); // ValidationError: "value" with value "alpha" fails to match the numbers pattern
 
-const invalidatedSchema = Joi.string().regex(/[a-z]/, { invalidate: true });
-invalidatedSchema.validate('lowercase'); // ValidationError: "value" with value "lowercase" matches the invalidated pattern: [a-z]
+const invertedSchema = Joi.string().regex(/[a-z]/, { invert: true });
+invertedSchema.validate('lowercase'); // ValidationError: "value" with value "lowercase" matches the inverted pattern: [a-z]
 
-const invalidatedNamedSchema = Joi.string().regex(/[a-z]/, { name: 'alpha', invalidate: true });
-invalidatedNamedSchema.validate('lowercase'); // ValidationError: "value" with value "lowercase" matches the invalidated alpha pattern
+const invertedNamedSchema = Joi.string().regex(/[a-z]/, { name: 'alpha', invert: true });
+invertedNamedSchema.validate('lowercase'); // ValidationError: "value" with value "lowercase" matches the inverted alpha pattern
 ```
 
 #### `string.replace(pattern, replacement)`

--- a/lib/language.js
+++ b/lib/language.js
@@ -122,7 +122,9 @@ exports.errors = {
         token: 'must only contain alpha-numeric and underscore characters',
         regex: {
             base: 'with value "{{!value}}" fails to match the required pattern: {{pattern}}',
-            name: 'with value "{{!value}}" fails to match the {{name}} pattern'
+            invalidated: 'with value "{{!value}}" matches the invalidated pattern: {{pattern}}',
+            name: 'with value "{{!value}}" fails to match the {{name}} pattern',
+            invalidatedName: 'with value "{{!value}}" matches the invalidated {{name}} pattern'
         },
         email: 'must be a valid email',
         uri: 'must be a valid uri',

--- a/lib/language.js
+++ b/lib/language.js
@@ -122,9 +122,9 @@ exports.errors = {
         token: 'must only contain alpha-numeric and underscore characters',
         regex: {
             base: 'with value "{{!value}}" fails to match the required pattern: {{pattern}}',
-            invalidated: 'with value "{{!value}}" matches the invalidated pattern: {{pattern}}',
+            inverted: 'with value "{{!value}}" matches the inverted pattern: {{pattern}}',
             name: 'with value "{{!value}}" fails to match the {{name}} pattern',
-            invalidatedName: 'with value "{{!value}}" matches the invalidated {{name}} pattern'
+            invertedName: 'with value "{{!value}}" matches the inverted {{name}} pattern'
         },
         email: 'must be a valid email',
         uri: 'must be a valid uri',

--- a/lib/string.js
+++ b/lib/string.js
@@ -98,11 +98,22 @@ internals.String = class extends Any {
         const patternObject = {
             pattern: new RegExp(pattern.source, pattern.ignoreCase ? 'i' : undefined)         // Future version should break this and forbid unsupported regex flags
         };
+        let patternIsInverted = false;
 
-        const patternIsInverted = (typeof patternOptions === 'object' && patternOptions.invert);
-        if (patternIsInverted) {
-            patternObject.inverted = true;
+        if (typeof patternOptions === 'string') {
+            patternObject.name = patternOptions;
         }
+        else if (typeof patternOptions === 'object') {
+            patternIsInverted = !!patternOptions.invert;
+            patternObject.invert = patternIsInverted;
+
+            if (patternOptions.name) {
+                patternObject.name = patternOptions.name;
+            }
+        }
+
+        const baseRegex = patternIsInverted ? 'string.regex.inverted' : 'string.regex.base';
+        const nameRegex = patternIsInverted ? 'string.regex.invertedName' : 'string.regex.name';
 
         return this._test('regex', patternObject, function (value, state, options) {
 
@@ -112,13 +123,7 @@ internals.String = class extends Any {
                 return value;
             }
 
-            const name = typeof patternOptions === 'string' ?
-                patternOptions :
-                Hoek.reach(patternOptions, 'name');
-            const baseRegex = patternIsInverted ? 'string.regex.inverted' : 'string.regex.base';
-            const nameRegex = patternIsInverted ? 'string.regex.invertedName' : 'string.regex.name';
-
-            return this.createError((name ? nameRegex : baseRegex), { name, pattern, value }, state, options);
+            return this.createError((patternObject.name ? nameRegex : baseRegex), { name: patternObject.name, pattern, value }, state, options);
         });
     }
 

--- a/lib/string.js
+++ b/lib/string.js
@@ -97,10 +97,12 @@ internals.String = class extends Any {
 
         pattern = new RegExp(pattern.source, pattern.ignoreCase ? 'i' : undefined);         // Future version should break this and forbid unsupported regex flags
 
-        return this._test('regex', pattern, function (value, state, options) {
+        const patternIsInvalidated = (typeof config === 'object' && Hoek.reach(config, 'invalidate'));
+        const testName = patternIsInvalidated ? 'invalidatedRegex' : 'regex';
+
+        return this._test(testName, pattern, function (value, state, options) {
 
             const patternMatch = pattern.test(value);
-            const patternIsInvalidated = (typeof config === 'object' && Hoek.reach(config, 'invalidate'));
 
             if ((patternMatch && !patternIsInvalidated) || (!patternMatch && patternIsInvalidated)) {
                 return value;

--- a/lib/string.js
+++ b/lib/string.js
@@ -91,7 +91,7 @@ internals.String = class extends Any {
         });
     }
 
-    regex(pattern, name) {
+    regex(pattern, config) {
 
         Hoek.assert(pattern instanceof RegExp, 'pattern must be a RegExp');
 
@@ -99,11 +99,20 @@ internals.String = class extends Any {
 
         return this._test('regex', pattern, function (value, state, options) {
 
-            if (pattern.test(value)) {
+            const patternMatch = pattern.test(value);
+            const patternIsInvalidated = (typeof config === 'object' && Hoek.reach(config, 'invalidate'));
+
+            if ((patternMatch && !patternIsInvalidated) || (!patternMatch && patternIsInvalidated)) {
                 return value;
             }
 
-            return this.createError((name ? 'string.regex.name' : 'string.regex.base'), { name, pattern, value }, state, options);
+            const name = typeof config === 'string' ?
+                config :
+                Hoek.reach(config, 'name');
+            const baseRegex = patternIsInvalidated ? 'string.regex.invalidated' : 'string.regex.base';
+            const nameRegex = patternIsInvalidated ? 'string.regex.invalidatedName' : 'string.regex.name';
+
+            return this.createError((name ? nameRegex : baseRegex), { name, pattern, value }, state, options);
         });
     }
 

--- a/lib/string.js
+++ b/lib/string.js
@@ -91,28 +91,32 @@ internals.String = class extends Any {
         });
     }
 
-    regex(pattern, config) {
+    regex(pattern, patternOptions) {
 
         Hoek.assert(pattern instanceof RegExp, 'pattern must be a RegExp');
 
-        pattern = new RegExp(pattern.source, pattern.ignoreCase ? 'i' : undefined);         // Future version should break this and forbid unsupported regex flags
+        const patternObject = {
+            pattern: new RegExp(pattern.source, pattern.ignoreCase ? 'i' : undefined)         // Future version should break this and forbid unsupported regex flags
+        };
 
-        const patternIsInvalidated = (typeof config === 'object' && Hoek.reach(config, 'invalidate'));
-        const testName = patternIsInvalidated ? 'invalidatedRegex' : 'regex';
+        const patternIsInverted = (typeof patternOptions === 'object' && patternOptions.invert);
+        if (patternIsInverted) {
+            patternObject.inverted = true;
+        }
 
-        return this._test(testName, pattern, function (value, state, options) {
+        return this._test('regex', patternObject, function (value, state, options) {
 
-            const patternMatch = pattern.test(value);
+            const patternMatch = patternObject.pattern.test(value);
 
-            if ((patternMatch && !patternIsInvalidated) || (!patternMatch && patternIsInvalidated)) {
+            if (patternMatch ^ patternIsInverted) {
                 return value;
             }
 
-            const name = typeof config === 'string' ?
-                config :
-                Hoek.reach(config, 'name');
-            const baseRegex = patternIsInvalidated ? 'string.regex.invalidated' : 'string.regex.base';
-            const nameRegex = patternIsInvalidated ? 'string.regex.invalidatedName' : 'string.regex.name';
+            const name = typeof patternOptions === 'string' ?
+                patternOptions :
+                Hoek.reach(patternOptions, 'name');
+            const baseRegex = patternIsInverted ? 'string.regex.inverted' : 'string.regex.base';
+            const nameRegex = patternIsInverted ? 'string.regex.invertedName' : 'string.regex.name';
 
             return this.createError((name ? nameRegex : baseRegex), { name, pattern, value }, state, options);
         });

--- a/test/string.js
+++ b/test/string.js
@@ -81,7 +81,7 @@ describe('string', () => {
 
     describe('invalid()', () => {
 
-        it('invalidates case sensitive values', (done) => {
+        it('inverts case sensitive values', (done) => {
 
             Helper.validate(Joi.string().invalid('a', 'b'), [
                 ['a', false, null, '"value" contains an invalid value'],
@@ -91,7 +91,7 @@ describe('string', () => {
             ], done);
         });
 
-        it('invalidates case insensitive values', (done) => {
+        it('inverts case insensitive values', (done) => {
 
             Helper.validate(Joi.string().invalid('a', 'b').insensitive(), [
                 ['a', false, null, '"value" contains an invalid value'],
@@ -886,24 +886,24 @@ describe('string', () => {
             });
         });
 
-        it('should "invalidate" regex pattern if specified in options object', (done) => {
+        it('should "invert" regex pattern if specified in options object', (done) => {
 
-            const schema = Joi.string().regex(/[a-z]/, { invalidate: true });
+            const schema = Joi.string().regex(/[a-z]/, { invert: true });
             Helper.validate(schema, [
                 ['0123456789', true],
-                ['abcdefg', false, null, '"value" with value "abcdefg" matches the invalidated pattern: /[a-z]/']
+                ['abcdefg', false, null, '"value" with value "abcdefg" matches the inverted pattern: /[a-z]/']
             ], done);
         });
 
-        it('should include invalidated pattern name if specified', (done) => {
+        it('should include inverted pattern name if specified', (done) => {
 
             const schema = Joi.string().regex(/[a-z]/, {
-                name      : 'lowercase',
-                invalidate: true
+                name  : 'lowercase',
+                invert: true
             });
             Helper.validate(schema, [
                 ['0123456789', true],
-                ['abcdefg', false, null, '"value" with value "abcdefg" matches the invalidated lowercase pattern']
+                ['abcdefg', false, null, '"value" with value "abcdefg" matches the inverted lowercase pattern']
             ], done);
         });
     });
@@ -2116,7 +2116,7 @@ describe('string', () => {
             ], done);
         });
 
-        it('should invalidate invalid values', (done) => {
+        it('should invert invalid values', (done) => {
 
             const schema = Joi.string().valid('a', 'b', 'c');
             Helper.validate(schema, [
@@ -3660,10 +3660,10 @@ describe('string', () => {
             done();
         });
 
-        it('describes invalidate regex pattern', (done) => {
+        it('describes invert regex pattern', (done) => {
 
             const schema = Joi.string().regex(/[a-z]/, {
-                invalidate: true
+                invert: true
             });
             const description = schema.describe();
             expect(description).to.equal({
@@ -3671,8 +3671,11 @@ describe('string', () => {
                 invalids: [''],
                 rules: [
                     {
-                        name: 'invalidatedRegex',
-                        arg: /[a-z]/
+                        name: 'regex',
+                        arg: {
+                            pattern: /[a-z]/,
+                            inverted: true
+                        }
                     }
                 ]
             });

--- a/test/string.js
+++ b/test/string.js
@@ -875,6 +875,37 @@ describe('string', () => {
                 done();
             });
         });
+
+        it('should include a pattern name in options object', (done) => {
+
+            const schema = Joi.string().regex(/[a-z]+/, { name: 'letters' }).regex(/[0-9]+/, { name: 'numbers' });
+            schema.validate('abcd', (err, value) => {
+
+                expect(err.message).to.contain('numbers pattern');
+                done();
+            });
+        });
+
+        it('should "invalidate" regex pattern if specified in options object', (done) => {
+
+            const schema = Joi.string().regex(/[a-z]/, { invalidate: true });
+            Helper.validate(schema, [
+                ['0123456789', true],
+                ['abcdefg', false, null, '"value" with value "abcdefg" matches the invalidated pattern: /[a-z]/']
+            ], done);
+        });
+
+        it('should include invalidated pattern name if specified', (done) => {
+
+            const schema = Joi.string().regex(/[a-z]/, {
+                name      : 'lowercase',
+                invalidate: true
+            });
+            Helper.validate(schema, [
+                ['0123456789', true],
+                ['abcdefg', false, null, '"value" with value "abcdefg" matches the invalidated lowercase pattern']
+            ], done);
+        });
     });
 
     describe('ip()', () => {

--- a/test/string.js
+++ b/test/string.js
@@ -3659,5 +3659,24 @@ describe('string', () => {
             });
             done();
         });
+
+        it('describes invalidate regex pattern', (done) => {
+
+            const schema = Joi.string().regex(/[a-z]/, {
+                invalidate: true
+            });
+            const description = schema.describe();
+            expect(description).to.equal({
+                type: 'string',
+                invalids: [''],
+                rules: [
+                    {
+                        name: 'invalidatedRegex',
+                        arg: /[a-z]/
+                    }
+                ]
+            });
+            done();
+        });
     });
 });

--- a/test/string.js
+++ b/test/string.js
@@ -3674,7 +3674,7 @@ describe('string', () => {
                         name: 'regex',
                         arg: {
                             pattern: /[a-z]/,
-                            inverted: true
+                            invert: true
                         }
                     }
                 ]


### PR DESCRIPTION
Per discussions in #1033 and #1020, refactored `string().regex(pattern, [name])` to support `string().regex(pattern, [name | config])` as follows:

1. If `name` is a string it behaves as currently implemented. No change.
2. If `config` is an object, it supports the following properties:
  - `name`: {string}, behaves as currently implemented.
  - `invalidate`: {boolean}, defaults to `false` behavior; if `true`, disallows the provided regex pattern.

Usage: 
```Javascript
const schema = Joi.string().regex(/[a-z]/, {
    name      : 'lowercase',
    invalidate: true
});

schema.validate('bad', (err, value) => {
    if (err) {
        // ValidationError: "value" with value "bad" matches the invalidated lowercase pattern
    }
});
schema.validate('BAD', (err, value) => {
    if (err) {} // err === null
});

schema.describe();
/*
{
  type: 'string',
  invalids: [ '' ],
  rules: [ { name: 'invalidatedRegex', arg: /[a-z]/ } ] 
}
*/ 
```