### PR TITLE
updated documentation for string.uri and relativeOnly flag

### DIFF
--- a/API.md
+++ b/API.md
@@ -1639,6 +1639,7 @@ Requires the string value to be a valid [RFC 3986](http://tools.ietf.org/html/rf
 - `options` - optional settings:
     - `scheme` - Specifies one or more acceptable Schemes, should only include the scheme name. Can be an Array or String (strings are automatically escaped for use in a Regular Expression).
     - `allowRelative` - Allow relative URIs. Defaults to `false`.
+    - `relativeOnly` - Restrict only relative URIs.  Defaults to `false`.
 
 ```js
 // Accept git or git http/https


### PR DESCRIPTION
Updating documentation to include `option.relativeOnly` flag for `string.uri()` API.