### PR TITLE
adding validation for unnecessary arguments in primary types.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,8 @@ internals.root = function () {
     const root = any.clone();
     root.any = function () {
 
+        Hoek.assert(arguments.length === 0, 'Joi.any() does not allow arguments.');
+
         return any;
     };
 
@@ -41,30 +43,42 @@ internals.root = function () {
 
     root.array = function () {
 
+        Hoek.assert(arguments.length === 0, 'Joi.array() does not allow arguments.');
+
         return internals.array;
     };
 
     root.boolean = root.bool = function () {
+
+        Hoek.assert(arguments.length === 0, 'Joi.boolean() does not allow arguments.');
 
         return internals.boolean;
     };
 
     root.binary = function () {
 
+        Hoek.assert(arguments.length === 0, 'Joi.binary() does not allow arguments.');
+
         return internals.binary;
     };
 
     root.date = function () {
+
+        Hoek.assert(arguments.length === 0, 'Joi.date() does not allow arguments.');
 
         return internals.date;
     };
 
     root.func = function () {
 
+        Hoek.assert(arguments.length === 0, 'Joi.func() does not allow arguments.');
+
         return internals.object._func();
     };
 
     root.number = function () {
+
+        Hoek.assert(arguments.length === 0, 'Joi.number() does not allow arguments.');
 
         return internals.number;
     };
@@ -75,6 +89,8 @@ internals.root = function () {
     };
 
     root.string = function () {
+
+        Hoek.assert(arguments.length === 0, 'Joi.string() does not allow arguments.');
 
         return internals.string;
     };

--- a/test/any.js
+++ b/test/any.js
@@ -23,6 +23,15 @@ const expect = Code.expect;
 
 describe('any', () => {
 
+    it('should throw an exception if arguments were passed.', (done) => {
+
+        expect(
+          () => Joi.any('invalid argument.')
+        ).to.throw('Joi.any() does not allow arguments.');
+
+        done();
+    });
+
     describe('equal()', () => {
 
         it('validates valid values', (done) => {

--- a/test/array.js
+++ b/test/array.js
@@ -23,6 +23,15 @@ const expect = Code.expect;
 
 describe('array', () => {
 
+    it('should throw an exception if arguments were passed.', (done) => {
+
+        expect(
+          () => Joi.array('invalid argument.')
+        ).to.throw('Joi.array() does not allow arguments.');
+
+        done();
+    });
+
     it('converts a string to an array', (done) => {
 
         Joi.array().validate('[1,2,3]', (err, value) => {

--- a/test/binary.js
+++ b/test/binary.js
@@ -23,6 +23,15 @@ const expect = Code.expect;
 
 describe('binary', () => {
 
+    it('should throw an exception if arguments were passed.', (done) => {
+
+        expect(
+          () => Joi.binary('invalid argument.')
+        ).to.throw('Joi.binary() does not allow arguments.');
+
+        done();
+    });
+
     it('converts a string to a buffer', (done) => {
 
         Joi.binary().validate('test', (err, value) => {

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -23,6 +23,15 @@ const expect = Code.expect;
 
 describe('boolean', () => {
 
+    it('should throw an exception if arguments were passed.', (done) => {
+
+        expect(
+          () => Joi.boolean('invalid argument.')
+        ).to.throw('Joi.boolean() does not allow arguments.');
+
+        done();
+    });
+
     it('does not convert a string to a boolean', (done) => {
 
         Joi.boolean().validate('true', (err, value) => {

--- a/test/date.js
+++ b/test/date.js
@@ -23,6 +23,15 @@ const expect = Code.expect;
 
 describe('date', () => {
 
+    it('should throw an exception if arguments were passed.', (done) => {
+
+        expect(
+          () => Joi.date('invalid argument.')
+        ).to.throw('Joi.date() does not allow arguments.');
+
+        done();
+    });
+
     it('fails on boolean', (done) => {
 
         const schema = Joi.date();

--- a/test/function.js
+++ b/test/function.js
@@ -23,6 +23,15 @@ const expect = Code.expect;
 
 describe('func', () => {
 
+    it('should throw an exception if arguments were passed.', (done) => {
+
+        expect(
+          () => Joi.func('invalid argument.')
+        ).to.throw('Joi.func() does not allow arguments.');
+
+        done();
+    });
+
     it('validates a function', (done) => {
 
         Helper.validate(Joi.func().required(), [

--- a/test/number.js
+++ b/test/number.js
@@ -23,6 +23,15 @@ const expect = Code.expect;
 
 describe('number', () => {
 
+    it('should throw an exception if arguments were passed.', (done) => {
+
+        expect(
+          () => Joi.number('invalid argument.')
+        ).to.throw('Joi.number() does not allow arguments.');
+
+        done();
+    });
+
     it('fails on boolean', (done) => {
 
         const schema = Joi.number();

--- a/test/string.js
+++ b/test/string.js
@@ -23,6 +23,15 @@ const expect = Code.expect;
 
 describe('string', () => {
 
+    it('should throw an exception if arguments were passed.', (done) => {
+
+        expect(
+          () => Joi.string('invalid argument.')
+        ).to.throw('Joi.string() does not allow arguments.');
+
+        done();
+    });
+
     it('fails on boolean', (done) => {
 
         const schema = Joi.string();


### PR DESCRIPTION
solution: throw an error when argument is passed in types that don't needed.
example: `Joi.string('argument') => throws 'Joi.string() does not allow arguments.'`
issue: https://github.com/hapijs/joi/issues/1009