### PR TITLE
Update `string.regex` examples

### DIFF
--- a/API.md
+++ b/API.md
@@ -1572,16 +1572,16 @@ Defines a regular expression rule where:
 ```js
 const schema = Joi.string().regex(/^[abc]+$/);
 
-const inlineNamedSchema = Joi.string().regex(/[0-9]/, 'numbers');
+const inlineNamedSchema = Joi.string().regex(/^[0-9]+$/, 'numbers');
 inlineNamedSchema.validate('alpha'); // ValidationError: "value" with value "alpha" fails to match the numbers pattern
 
-const namedSchema = Joi.string().regex(/[0-9]/, { name: 'numbers'});
+const namedSchema = Joi.string().regex(/^[0-9]+$/, { name: 'numbers'});
 namedSchema.validate('alpha'); // ValidationError: "value" with value "alpha" fails to match the numbers pattern
 
-const invertedSchema = Joi.string().regex(/[a-z]/, { invert: true });
+const invertedSchema = Joi.string().regex(/^[a-z]+$/, { invert: true });
 invertedSchema.validate('lowercase'); // ValidationError: "value" with value "lowercase" matches the inverted pattern: [a-z]
 
-const invertedNamedSchema = Joi.string().regex(/[a-z]/, { name: 'alpha', invert: true });
+const invertedNamedSchema = Joi.string().regex(/^[a-z]+$/, { name: 'alpha', invert: true });
 invertedNamedSchema.validate('lowercase'); // ValidationError: "value" with value "lowercase" matches the inverted alpha pattern
 ```
 


### PR DESCRIPTION
The examples in the documentation for `string.regex` didn't really validate what they were proposing to.

For example, `regex(/[0-9]/)` doesn't validate `alpha`, but it does validate `alpha1`, `numb3r`, `d00d`, etc. because it will match any strings that contain at least one number. `regex(/^[0-9]+$/)` however will only validate strings strings consisting entirely of numbers.

Similarly, `regex(/[a-z]/)` will validate `lowercase`, but it will also validate `LowerCase`, `Lowercase`, `LOWERCASe`, etc. because it will match any strings that contain at least one lowercase letter. `regex(/^[a-z]+$/)` however will only validate strings consisting entirely of lowercase letters.