### PR TITLE
allow param defaults to be set by the param validations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -288,7 +288,7 @@ internals.root = function () {
 
                         const args = Array.prototype.slice.call(arguments);
                         let hasRef = false;
-                        const arg = {};
+                        let arg = {};
 
                         for (let k = 0; k < ruleArgs.length; ++k) {
                             arg[ruleArgs[k]] = args[k];
@@ -298,7 +298,11 @@ internals.root = function () {
                         }
 
                         if (validateArgs) {
-                            joi.assert(arg, validateArgs);
+                            const res = joi.validate(arg, validateArgs);
+                            if (res.error) {
+                                throw res.error;
+                            }
+                            arg = res.value;
                         }
 
                         let schema;

--- a/lib/index.js
+++ b/lib/index.js
@@ -298,11 +298,7 @@ internals.root = function () {
                         }
 
                         if (validateArgs) {
-                            const res = joi.validate(arg, validateArgs);
-                            if (res.error) {
-                                throw res.error;
-                            }
-                            arg = res.value;
+                            arg = joi.attempt(arg, validateArgs);
                         }
 
                         let schema;

--- a/test/index.js
+++ b/test/index.js
@@ -2192,7 +2192,7 @@ describe('Joi', () => {
 
             expect(customJoi.number().multiply(2).validate(3)).to.equal({ error: null, value: 6 });
             expect(customJoi.number().multiply(5, '$').validate(7)).to.equal({ error: null, value: '$35' });
-            expect(() => customJoi.number().multiply(5, 5)).to.throw('child "currency" fails because ["currency" must be a string]');
+            expect(() => customJoi.number().multiply(5, 5)).to.throw(/"currency" must be a string/);
             expect(() => customJoi.number().multiply(5, '$', 'oops')).to.throw('Unexpected number of arguments');
 
             done();
@@ -2287,7 +2287,7 @@ describe('Joi', () => {
             expect(original.double).to.not.exist();
 
             expect(customJoi.number().multiply(5).validate(7)).to.equal({ error: null, value: '$35' });
-            expect(() => customJoi.number().multiply(5, 5)).to.throw('child "currency" fails because ["currency" must be a string]');
+            expect(() => customJoi.number().multiply(5, 5)).to.throw(/"currency" must be a string/);
 
             done();
         });

--- a/test/index.js
+++ b/test/index.js
@@ -2192,6 +2192,7 @@ describe('Joi', () => {
 
             expect(customJoi.number().multiply(2).validate(3)).to.equal({ error: null, value: 6 });
             expect(customJoi.number().multiply(5, '$').validate(7)).to.equal({ error: null, value: '$35' });
+            expect(() => customJoi.number().multiply(5, 5)).to.throw('child "currency" fails because ["currency" must be a string]');
             expect(() => customJoi.number().multiply(5, '$', 'oops')).to.throw('Unexpected number of arguments');
 
             done();
@@ -2259,6 +2260,36 @@ describe('Joi', () => {
                 [{ a: 3, b: 5 }, true, null, { a: 3, b: 15 }],
                 [{ b: 42 }, true, null, { b: 0 }]
             ], done);
+        });
+
+        it('defines a rule that sets defaults for its parameters', (done) => {
+
+            const customJoi = Joi.extend({
+                base: Joi.number(),
+                name: 'number',
+                rules: [
+                    {
+                        name: 'multiply',
+                        params: {
+                            q: Joi.number().required(),
+                            currency: Joi.string().default('$')
+                        },
+                        validate(params, value, state, options) {
+
+                            const v = value * params.q;
+                            return params.currency + v;
+                        }
+                    }
+                ]
+            });
+
+            const original = Joi.number();
+            expect(original.double).to.not.exist();
+
+            expect(customJoi.number().multiply(5).validate(7)).to.equal({ error: null, value: '$35' });
+            expect(() => customJoi.number().multiply(5, 5)).to.throw('child "currency" fails because ["currency" must be a string]');
+
+            done();
         });
 
         it('defines a rule that can change the value', (done) => {


### PR DESCRIPTION
I found it surprising while making an extension that the defaults I set in the params validation weren't being applied.