### PR TITLE
(docs) Improve README with clarification on callbacks (#636)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const schema = Joi.object().keys({
 const result = Joi.validate({ username: 'abc', birthyear: 1994 }, schema);
 // result.error === null -> valid
 
-// You can also pass a callback which will be called with the validation result.
+// You can also pass a callback which will be called synchronously with the validation result.
 Joi.validate({ username: 'abc', birthyear: 1994 }, schema, function (err, value) { });  // err === null -> valid
 
 ```


### PR DESCRIPTION
Without cluttering up the README.md and keeping it as minimal as possible, added clarification that the callback is executed synchronously. This matches what is included in API.md and makes it clearer to new users without having to dig through the API docs or archived issues (#636) that there is no performance benefit of passing in a callback to validate, as typical node users would expect when such a callback option is provided.