### PR TITLE
Add "options" to describe output

### DIFF
--- a/lib/alternatives.js
+++ b/lib/alternatives.js
@@ -27,7 +27,7 @@ internals.Alternatives = class extends Any {
 
         let errors = [];
         const il = this._inner.matches.length;
-        const baseType = this._settings && this._settings.baseType;
+        const baseType = this._baseType;
 
         for (let i = 0; i < il; ++i) {
             const item = this._inner.matches[i];
@@ -103,9 +103,10 @@ internals.Alternatives = class extends Any {
             otherwise: options.otherwise !== undefined ? Cast.schema(options.otherwise) : undefined
         };
 
-        if (obj._settings && obj._settings.baseType) {
-            item.then = item.then && obj._settings.baseType.concat(item.then);
-            item.otherwise = item.otherwise && obj._settings.baseType.concat(item.otherwise);
+        if (obj._baseType) {
+
+            item.then = item.then && obj._baseType.concat(item.then);
+            item.otherwise = item.otherwise && obj._baseType.concat(item.otherwise);
         }
 
         Ref.push(obj._refs, item.ref);

--- a/lib/any.js
+++ b/lib/any.js
@@ -683,6 +683,21 @@ module.exports = internals.Any = class {
             }
         }
 
+        if (this._settings) {
+
+            const optionSet = ['abortEarly', 'convert', 'allowUnknown', 'skipFunctions', 'stripUnknown', 'language', 'presence', 'context', 'noDefaults'];
+            if (optionSet.some((option) => this._settings.hasOwnProperty(option))) {
+                description.options = {};
+
+                optionSet.forEach((option) => {
+
+                    if (this._settings.hasOwnProperty(option)) {
+                        description.options[option] = this._settings[option];
+                    }
+                });
+            }
+        }
+
         if (this._description) {
             description.description = this._description;
         }

--- a/lib/any.js
+++ b/lib/any.js
@@ -685,14 +685,15 @@ module.exports = internals.Any = class {
 
         if (this._settings) {
 
-            const settings = Object.keys(this._settings);
-            if ( settings.length > 1 || !this._settings.hasOwnProperty('baseType') ) {
+            const settings = Hoek.clone(this._settings);
+            const settingSet = Object.keys(settings);
+            if ( settingSet.length > 1 || !settings.hasOwnProperty('baseType') ) {
                 description.options = {};
 
-                settings.forEach((option) => {
+                settingSet.forEach((option) => {
 
                     if (option !== 'baseType') {
-                        description.options[option] = this._settings[option];
+                        description.options[option] = settings[option];
                     }
                 });
             }

--- a/lib/any.js
+++ b/lib/any.js
@@ -92,7 +92,7 @@ module.exports = internals.Any = class {
         obj.isJoi = true;
         obj._type = this._type;
         obj._settings = internals.concatSettings(this._settings);
-        obj._baseType = Hoek.clone(this._baseType);
+        obj._baseType = this._baseType;
         obj._valids = Hoek.clone(this._valids);
         obj._invalids = Hoek.clone(this._invalids);
         obj._tests = this._tests.slice();
@@ -685,19 +685,11 @@ module.exports = internals.Any = class {
         }
 
         if (this._settings) {
-
-            const settings = Hoek.clone(this._settings);
-            const settingSet = Object.keys(settings);
-            description.options = {};
-
-            settingSet.forEach((option) => {
-
-                description.options[option] = settings[option];
-            });
+            description.options = Hoek.clone(this._settings);
         }
 
         if (this._baseType) {
-            description.baseType = this._baseType.describe();
+            description.base = this._baseType.describe();
         }
 
         if (this._description) {

--- a/lib/any.js
+++ b/lib/any.js
@@ -92,6 +92,7 @@ module.exports = internals.Any = class {
         obj.isJoi = true;
         obj._type = this._type;
         obj._settings = internals.concatSettings(this._settings);
+        obj._baseType = Hoek.clone(this._baseType);
         obj._valids = Hoek.clone(this._valids);
         obj._invalids = Hoek.clone(this._invalids);
         obj._tests = this._tests.slice();
@@ -378,7 +379,7 @@ module.exports = internals.Any = class {
         Alternatives = Alternatives || require('./alternatives');
         const obj = Alternatives.when(ref, { is: options.is, then, otherwise });
         obj._flags.presence = 'ignore';
-        obj._settings = internals.concatSettings(obj._settings, { baseType: this });
+        obj._baseType = this;
 
         return obj;
     }
@@ -687,16 +688,16 @@ module.exports = internals.Any = class {
 
             const settings = Hoek.clone(this._settings);
             const settingSet = Object.keys(settings);
-            if ( settingSet.length > 1 || !settings.hasOwnProperty('baseType') ) {
-                description.options = {};
+            description.options = {};
 
-                settingSet.forEach((option) => {
+            settingSet.forEach((option) => {
 
-                    if (option !== 'baseType') {
-                        description.options[option] = settings[option];
-                    }
-                });
-            }
+                description.options[option] = settings[option];
+            });
+        }
+
+        if (this._baseType) {
+            description.baseType = this._baseType.describe();
         }
 
         if (this._description) {

--- a/lib/any.js
+++ b/lib/any.js
@@ -685,13 +685,13 @@ module.exports = internals.Any = class {
 
         if (this._settings) {
 
-            const optionSet = ['abortEarly', 'convert', 'allowUnknown', 'skipFunctions', 'stripUnknown', 'language', 'presence', 'context', 'noDefaults'];
-            if (optionSet.some((option) => this._settings.hasOwnProperty(option))) {
+            const settings = Object.keys(this._settings);
+            if ( settings.length > 1 || !this._settings.hasOwnProperty('baseType') ) {
                 description.options = {};
 
-                optionSet.forEach((option) => {
+                settings.forEach((option) => {
 
-                    if (this._settings.hasOwnProperty(option)) {
+                    if (option !== 'baseType') {
                         description.options[option] = this._settings[option];
                     }
                 });

--- a/test/any.js
+++ b/test/any.js
@@ -171,6 +171,16 @@ describe('any', () => {
                     abortEarly: false,
                     convert: false
                 },
+                baseType: {
+                    type: 'number',
+                    invalids: [
+                        Infinity,
+                        -Infinity
+                    ],
+                    rules: [
+                        { arg: 10, name: 'min' }
+                    ]
+                },
                 alternatives: [{
                     ref: 'ref:a',
                     is: {
@@ -1604,6 +1614,13 @@ describe('any', () => {
                 type: 'alternatives',
                 flags: {
                     presence: 'ignore'
+                },
+                baseType: {
+                    type: 'number',
+                    invalids: [Infinity, -Infinity],
+                    rules: [
+                        { arg: 10, name: 'min' }
+                    ]
                 },
                 alternatives: [{
                     ref: 'ref:a',

--- a/test/any.js
+++ b/test/any.js
@@ -149,6 +149,15 @@ describe('any', () => {
             }).to.not.throw();
             done();
         });
+
+        it('describes a schema with options', (done) => {
+
+            const schema = Joi.any().options({ abortEarly: false, convert: false });
+            const description = schema.describe();
+
+            expect(description).to.equal({ type: 'any', options: { abortEarly: false, convert: false } });
+            done();
+        });
     });
 
     describe('label()', () => {

--- a/test/any.js
+++ b/test/any.js
@@ -158,6 +158,42 @@ describe('any', () => {
             expect(description).to.equal({ type: 'any', options: { abortEarly: false, convert: false } });
             done();
         });
+
+        it('describes an alternatives schema with options', (done) => {
+
+            const schema = Joi.number().min(10).when('a', { is: 5, then: Joi.number().max(20).required() }).options({ abortEarly: false, convert: false }).describe();
+            expect(schema).to.equal({
+                type: 'alternatives',
+                flags: {
+                    presence: 'ignore'
+                },
+                options: {
+                    abortEarly: false,
+                    convert: false
+                },
+                alternatives: [{
+                    ref: 'ref:a',
+                    is: {
+                        type: 'number',
+                        flags: {
+                            allowOnly: true,
+                            presence: 'required'
+                        },
+                        valids: [5],
+                        invalids: [Infinity, -Infinity]
+                    },
+                    then: {
+                        type: 'number',
+                        flags: {
+                            presence: 'required'
+                        },
+                        invalids: [Infinity, -Infinity],
+                        rules: [{ name: 'min', arg: 10 }, { name: 'max', arg: 20 }]
+                    }
+                }]
+            });
+            done();
+        });
     });
 
     describe('label()', () => {

--- a/test/any.js
+++ b/test/any.js
@@ -171,7 +171,7 @@ describe('any', () => {
                     abortEarly: false,
                     convert: false
                 },
-                baseType: {
+                base: {
                     type: 'number',
                     invalids: [
                         Infinity,
@@ -1615,7 +1615,7 @@ describe('any', () => {
                 flags: {
                     presence: 'ignore'
                 },
-                baseType: {
+                base: {
                     type: 'number',
                     invalids: [Infinity, -Infinity],
                     rules: [

--- a/test/index.js
+++ b/test/index.js
@@ -1523,7 +1523,7 @@ describe('Joi', () => {
             defaultRef: Joi.string().default(defaultRef, 'not here'),
             defaultFn: Joi.string().default(defaultFn, 'not here'),
             defaultDescribedFn: Joi.string().default(defaultDescribedFn, 'described test')
-        }).rename('renamed', 'required').without('required', 'xor').without('xor', 'required');
+        }).options({ abortEarly: false, convert: false }).rename('renamed', 'required').without('required', 'xor').without('xor', 'required');
 
         const result = {
             type: 'object',
@@ -1660,7 +1660,11 @@ describe('Joi', () => {
                         override: false
                     }
                 }
-            ]
+            ],
+            options: {
+                abortEarly: false,
+                convert: false
+            }
         };
 
         it('describes schema (direct)', (done) => {

--- a/test/ref.js
+++ b/test/ref.js
@@ -374,7 +374,7 @@ describe('ref', () => {
         expect(desc).to.equal({
             type: 'alternatives',
             flags: { presence: 'ignore' },
-            baseType: {
+            base: {
                 type: 'any',
                 flags: {
                     allowOnly: true,

--- a/test/ref.js
+++ b/test/ref.js
@@ -374,6 +374,15 @@ describe('ref', () => {
         expect(desc).to.equal({
             type: 'alternatives',
             flags: { presence: 'ignore' },
+            baseType: {
+                type: 'any',
+                flags: {
+                    allowOnly: true,
+                    default: 'ref:a.b'
+                },
+                invalids: ['context:b.c'],
+                valids: ['ref:a.b']
+            },
             alternatives: [{
                 ref: 'ref:a.b',
                 is: {


### PR DESCRIPTION
Adds the options set by `Joi.any().options({})` to the output from `.describe()`, per #1130 

### Old Behavior
```js
Joi.any().options({ abortEarly: false, convert: false }).describe()
// { type: 'any' }
```

### New Behavior
```js
Joi.any().options({ abortEarly: false, convert: false }).describe()
// { type: 'any', options: { abortEarly: false, convert: false } }
```