### PR TITLE
Alternatives respect subsequent "when"s if first has only "otherwise"

### DIFF
--- a/lib/alternatives.js
+++ b/lib/alternatives.js
@@ -43,6 +43,9 @@ internals.Alternatives = class extends Any {
                         return baseType._validate(value, state, options);
                     }
                 }
+                else if (item.then === undefined && i < (il - 1)) {
+                    continue;
+                }
                 else if (item.then || baseType) {
                     return (item.then || baseType)._validate(value, state, options);
                 }

--- a/lib/alternatives.js
+++ b/lib/alternatives.js
@@ -39,15 +39,13 @@ internals.Alternatives = class extends Any {
                     if (item.otherwise) {
                         return item.otherwise._validate(value, state, options);
                     }
-                    else if (baseType && i  === (il - 1)) {
-                        return baseType._validate(value, state, options);
-                    }
                 }
-                else if (item.then === undefined && i < (il - 1)) {
-                    continue;
+                else if (item.then) {
+                    return (item.then)._validate(value, state, options);
                 }
-                else if (item.then || baseType) {
-                    return (item.then || baseType)._validate(value, state, options);
+
+                if (i === (il - 1) && baseType) {
+                    return (baseType)._validate(value, state, options);
                 }
 
                 continue;

--- a/test/alternatives.js
+++ b/test/alternatives.js
@@ -222,6 +222,24 @@ describe('alternatives', () => {
             ], done);
         });
 
+        it('validates "then" when a preceding "when" has only "otherwise"', (done) => {
+
+            const schema = Joi.object({
+                a: Joi.number(),
+                b: Joi.number(),
+                c: Joi.number()
+                    .when('a', { is: 1, otherwise: Joi.number().min(1) })
+                    .when('b', { is: 1, then: Joi.number().min(1) })
+            });
+
+            Helper.validate(schema, [
+                [{ a: 1, b: 1, c: 0 }, false, null, 'child "c" fails because ["c" must be larger than or equal to 1]'],
+                [{ a: 1, b: 1, c: 1 }, true],
+                [{ a: 0, b: 1, c: 1 }, true],
+                [{ a: 1, b: 0, c: 0 }, true]
+            ], done);
+        });
+
         it('validates when is is null', (done) => {
 
             const schema = {


### PR DESCRIPTION
Addresses #1151 .

When a `.when()` has only an `otherwise`, subsequent `when()`s should now be checked until either a `then` is found or the last condition is reached.

### Previous Buggy Behavior
```js
const schema = Joi.object({
    a: Joi.number(),
    b: Joi.number(),
    c: Joi.number()
        .when('a', { is: 1, otherwise: Joi.number().min(1) })
        .when('b', { is: 1, then: Joi.number().min(1) })
});

schema.validate({
    a: 1,
    b: 1,
    c: 0
}); // { error: null, value: { a: 1, b: 1, c: 0 } }
```

### New behavior
```js
const schema = Joi.object({
    a: Joi.number(),
    b: Joi.number(),
    c: Joi.number()
        .when('a', { is: 1, otherwise: Joi.number().min(1) })
        .when('b', { is: 1, then: Joi.number().min(1) })
});

schema.validate({
    a: 1,
    b: 1,
    c: 0
}); // child "c" fails because ["c" must be larger than or equal to 1]
```