### PR TITLE
Fix #1167 - make err.context.key the original key, add err.context.label

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -74,12 +74,11 @@ exports.Err = class {
 
         const localized = this.options.language;
 
-        if (this.flags.label) {
-            this.context.key = this.flags.label;
-        }
-        else if (this.context.key === '' || this.context.key === null) {
+        if (this.context.key === '' || this.context.key === null) {
             this.context.key = localized.root || Language.errors.root;
         }
+
+        this.context.label = this.flags.label || this.context.key;
 
         format = format || Hoek.reach(localized, this.type) || Hoek.reach(Language.errors, this.type);
 
@@ -109,7 +108,8 @@ exports.Err = class {
 
         return format.replace(/\{\{(\!?)([^}]+)\}\}/g, ($0, isSecure, name) => {
 
-            const value = Hoek.reach(this.context, name);
+            const context = Object.assign({}, this.context, { key: this.context.label });
+            const value = Hoek.reach(context, name);
             const normalized = internals.stringify(value, wrapArrays);
             return (isSecure ? Hoek.escapeHtml(normalized) : normalized);
         });

--- a/test/any.js
+++ b/test/any.js
@@ -1953,7 +1953,7 @@ describe('any', () => {
                         message: '"c" must be a number',
                         path: 'b.c',
                         type: 'number.base',
-                        context: { key: 'c' }
+                        context: { key: 'c', label: 'c' }
                     }]);
                     done();
                 });
@@ -1981,13 +1981,13 @@ describe('any', () => {
                             message: '"c" must be larger than or equal to 0',
                             path: 'b.c',
                             type: 'number.min',
-                            context: { limit: 0, value: -1.5, key: 'c' }
+                            context: { limit: 0, value: -1.5, key: 'c', label: 'c' }
                         },
                         {
                             message: '"c" must be an integer',
                             path: 'b.c',
                             type: 'number.integer',
-                            context: { value: -1.5, key: 'c' }
+                            context: { value: -1.5, key: 'c', label: 'c' }
                         }
                     ]);
                     done();
@@ -2031,13 +2031,13 @@ describe('any', () => {
                             message: '"c" must be larger than or equal to 0',
                             path: 'b.c',
                             type: 'number.min',
-                            context: { limit: 0, value: -1.5, key: 'c' }
+                            context: { limit: 0, value: -1.5, key: 'c', label: 'c' }
                         },
                         {
                             message: '"c" must be an integer',
                             path: 'b.c',
                             type: 'number.integer',
-                            context: { value: -1.5, key: 'c' }
+                            context: { value: -1.5, key: 'c', label: 'c' }
                         }
                     ]);
                     done();
@@ -2083,13 +2083,13 @@ describe('any', () => {
                             message: '"c" must be larger than or equal to 0',
                             path: 'b.c',
                             type: 'number.min',
-                            context: { limit: 0, value: -1.5, key: 'c' }
+                            context: { limit: 0, value: -1.5, key: 'c', label: 'c' }
                         },
                         {
                             message: '"c" must be an integer',
                             path: 'b.c',
                             type: 'number.integer',
-                            context: { value: -1.5, key: 'c' }
+                            context: { value: -1.5, key: 'c', label: 'c' }
                         }
                     ]);
                     done();
@@ -2135,13 +2135,13 @@ describe('any', () => {
                             message: '"c" must be larger than or equal to 0',
                             path: 'b.c',
                             type: 'number.min',
-                            context: { limit: 0, value: -1.5, key: 'c' }
+                            context: { limit: 0, value: -1.5, key: 'c', label: 'c' }
                         },
                         {
                             message: '"c" must be an integer',
                             path: 'b.c',
                             type: 'number.integer',
-                            context: { value: -1.5, key: 'c' }
+                            context: { value: -1.5, key: 'c', label: 'c' }
                         }
                     ]);
                     done();
@@ -2235,7 +2235,7 @@ describe('any', () => {
                             message: '"c" oops, I received -1.5',
                             path: 'b.c',
                             type: 'override',
-                            context: { value: -1.5, key: 'c' }
+                            context: { value: -1.5, key: 'c', label: 'c' }
                         }
                     ]);
                     done();
@@ -2261,13 +2261,13 @@ describe('any', () => {
                             message: '"c" must be larger than or equal to 0',
                             path: 'b.c',
                             type: 'number.min',
-                            context: { limit: 0, value: -1.5, key: 'c' }
+                            context: { limit: 0, value: -1.5, key: 'c', label: 'c' }
                         },
                         {
                             message: '"c" must be an integer',
                             path: 'b.c',
                             type: 'number.integer',
-                            context: { value: -1.5, key: 'c' }
+                            context: { value: -1.5, key: 'c', label: 'c' }
                         }
                     ]);
                     done();

--- a/test/array.js
+++ b/test/array.js
@@ -581,7 +581,8 @@ describe('array', () => {
                     path: '1',
                     type: 'array.sparse',
                     context: {
-                        key: 'value'
+                        key: 'value',
+                        label: 'value'
                     }
                 }, {
                     message: '"value" at position 2 contains an excluded value',
@@ -590,7 +591,8 @@ describe('array', () => {
                     context: {
                         pos: 2,
                         key: 'value',
-                        value: true
+                        value: true,
+                        label: 'value'
                     }
                 }, {
                     message: '"value" at position 3 does not match any of the allowed types',
@@ -599,7 +601,8 @@ describe('array', () => {
                     context: {
                         pos: 3,
                         key: 'value',
-                        value: 'a'
+                        value: 'a',
+                        label: 'value'
                     }
                 }]);
                 done();
@@ -700,7 +703,8 @@ describe('array', () => {
                         pos: 3,
                         value: 1,
                         dupePos: 0,
-                        dupeValue: 1
+                        dupeValue: 1,
+                        label: 'value'
                     },
                     message: '"value" position 3 contains a duplicate value',
                     path: '3',
@@ -717,7 +721,8 @@ describe('array', () => {
                         pos: 3,
                         value: 1,
                         dupePos: 0,
-                        dupeValue: 1
+                        dupeValue: 1,
+                        label: 'value'
                     },
                     message: '"value" position 3 contains a duplicate value',
                     path: '3',
@@ -734,7 +739,8 @@ describe('array', () => {
                         pos: 3,
                         value: 1,
                         dupePos: 0,
-                        dupeValue: 1
+                        dupeValue: 1,
+                        label: 'a'
                     },
                     message: '"a" position 3 contains a duplicate value',
                     path: 'a.3',
@@ -751,7 +757,8 @@ describe('array', () => {
                         pos: 3,
                         value: 1,
                         dupePos: 0,
-                        dupeValue: 1
+                        dupeValue: 1,
+                        label: 'a'
                     },
                     message: '"a" position 3 contains a duplicate value',
                     path: 'a.3',
@@ -848,7 +855,8 @@ describe('array', () => {
                             key: 'value',
                             path: 'id',
                             pos: 2,
-                            value: { id: 1 }
+                            value: { id: 1 },
+                            label: 'value'
                         },
                         message: '"value" position 2 contains a duplicate value',
                         path: '2',
@@ -864,7 +872,8 @@ describe('array', () => {
                             key: 'value',
                             path: 'id',
                             pos: 4,
-                            value: {}
+                            value: {},
+                            label: 'value'
                         },
                         message: '"value" position 4 contains a duplicate value',
                         path: '4',
@@ -887,7 +896,8 @@ describe('array', () => {
                             key: 'value',
                             path: 'nested.id',
                             pos: 2,
-                            value: { nested: { id: 1 } }
+                            value: { nested: { id: 1 } },
+                            label: 'value'
                         },
                         message: '"value" position 2 contains a duplicate value',
                         path: '2',
@@ -903,7 +913,8 @@ describe('array', () => {
                             key: 'value',
                             path: 'nested.id',
                             pos: 4,
-                            value: {}
+                            value: {},
+                            label: 'value'
                         },
                         message: '"value" position 4 contains a duplicate value',
                         path: '4',
@@ -926,7 +937,8 @@ describe('array', () => {
                             key: 'value',
                             path: 'nested',
                             pos: 2,
-                            value: { nested: { id: 1 } }
+                            value: { nested: { id: 1 } },
+                            label: 'value'
                         },
                         message: '"value" position 2 contains a duplicate value',
                         path: '2',
@@ -942,7 +954,8 @@ describe('array', () => {
                             key: 'value',
                             path: 'nested',
                             pos: 4,
-                            value: {}
+                            value: {},
+                            label: 'value'
                         },
                         message: '"value" position 4 contains a duplicate value',
                         path: '4',

--- a/test/errors.js
+++ b/test/errors.js
@@ -238,7 +238,8 @@ describe('errors', () => {
                 context: {
                     limit: 3,
                     key: 'length',
-                    value: 1
+                    value: 1,
+                    label: 'length'
                 }
             }]);
             done();

--- a/test/errors.js
+++ b/test/errors.js
@@ -245,6 +245,23 @@ describe('errors', () => {
         });
     });
 
+    it('uses the original key name for context.key when the key has a label', (done) => {
+
+        Joi.object({ length: Joi.required().label('custom label') }).validate({}, (err) => {
+
+            expect(err.details).to.equal([{
+                message: '"custom label" is required',
+                path: 'length',
+                type: 'any.required',
+                context: {
+                    key: 'length',
+                    label: 'custom label'
+                }
+            }]);
+            done();
+        });
+    });
+
     it('has a name that is ValidationError', (done) => {
 
         const schema = Joi.number();

--- a/test/index.js
+++ b/test/index.js
@@ -1389,32 +1389,32 @@ describe('Joi', () => {
                 message: '"foo" length must be less than or equal to 3 characters long',
                 path: 'test.0.foo',
                 type: 'string.max',
-                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined }
+                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined, label: 'foo' }
             }, {
                 message: '"bar" length must be less than or equal to 5 characters long',
                 path: 'test.0.bar',
                 type: 'string.max',
-                context: { limit: 5, value: 'testfailed', key: 'bar', encoding: undefined }
+                context: { limit: 5, value: 'testfailed', key: 'bar', encoding: undefined, label: 'bar' }
             }, {
                 message: '"foo" length must be less than or equal to 3 characters long',
                 path: 'test2.test3.1.foo',
                 type: 'string.max',
-                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined }
+                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined, label: 'foo' }
             }, {
                 message: '"bar" length must be less than or equal to 5 characters long',
                 path: 'test2.test3.1.bar',
                 type: 'string.max',
-                context: { limit: 5, value: 'testfailed', key: 'bar', encoding: undefined }
+                context: { limit: 5, value: 'testfailed', key: 'bar', encoding: undefined, label: 'bar' }
             }, {
                 message: '"foo" length must be less than or equal to 3 characters long',
                 path: 'test2.test3.2.baz.test4.0.foo',
                 type: 'string.max',
-                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined }
+                context: { limit: 3, value: 'test1', key: 'foo', encoding: undefined, label: 'foo' }
             }, {
                 message: '"baz" is not allowed',
                 path: 'test2.test3.2.baz.test4.0.baz',
                 type: 'object.allowUnknown',
-                context: { key: 'baz', child: 'baz' }
+                context: { key: 'baz', child: 'baz', label: 'baz' }
             }]);
             done();
         });


### PR DESCRIPTION
This is a breaking change for those who relied on the buggy behavior of `err.context.key`.

The change itself is trivial, but I had to fixup a bunch of tests to include the `label` property.