### PR TITLE
Allow passing an option to string().isoDate()

### DIFF
--- a/API.md
+++ b/API.md
@@ -1849,7 +1849,7 @@ const schema = Joi.string().trim();
 
 #### `string.isoDate()`
 
-Requires the string value to be in valid ISO 8601 date format.
+Requires the string value to be in valid ISO 8601 date format. If the validation `convert` option is on (enabled by default), the string will be forced to simplified extended ISO format (ISO 8601).
 
 ```js
 const schema = Joi.string().isoDate();

--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -315,7 +315,16 @@ internals.String = class extends Any {
         return this._test('isoDate', undefined, function (value, state, options) {
 
             if (JoiDate._isIsoDate(value)) {
-                return value;
+                if (!options.convert) {
+                    return value;
+                }
+
+                try {
+                    return new Date(value).toISOString();
+                }
+                catch (err) {
+                    return this.createError('string.isoDate', { value, reason: err, convert: options.convert }, state, options);
+                }
             }
 
             return this.createError('string.isoDate', { value }, state, options);

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -2745,7 +2745,7 @@ describe('string', () => {
 
         it('validates isoDate', (done) => {
 
-            Helper.validate(Joi.string().isoDate(), [
+            Helper.validateOptions(Joi.string().isoDate(), [
                 ['+002013-06-07T14:21:46.295Z', true],
                 ['-002013-06-07T14:21:46.295Z', true],
                 ['002013-06-07T14:21:46.295Z', false, null, '"value" must be a valid ISO 8601 date'],
@@ -2790,7 +2790,7 @@ describe('string', () => {
                 ['2013-W23-1T14:21:46-07:00', true],
                 ['2013-184', true],
                 ['2013-1841', false, null, '"value" must be a valid ISO 8601 date']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates isoDate with a friendly error message', (done) => {
@@ -2806,7 +2806,7 @@ describe('string', () => {
         it('validates combination of isoDate and min', (done) => {
 
             const rule = Joi.string().isoDate().min(23);
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', true],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', true],
@@ -2827,13 +2827,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', false, null, '"value" is not allowed to be empty'],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min and max', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23);
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', false, null, '"value" length must be less than or equal to 23 characters long'],
@@ -2854,13 +2854,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', false, null, '"value" is not allowed to be empty'],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max and invalid', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).invalid('2013-06-07T14:21+07:00');
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', false, null, '"value" length must be less than or equal to 23 characters long'],
@@ -2881,13 +2881,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', false, null, '"value" is not allowed to be empty'],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max and allow', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).allow('2013-06-07T14:21:46.295+07:00');
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', true],
@@ -2908,13 +2908,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', false, null, '"value" is not allowed to be empty'],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max, allow and invalid', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).allow('2013-06-07T14:21:46.295+07:00').invalid('2013-06-07T14:21+07:00');
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', true],
@@ -2935,13 +2935,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', false, null, '"value" is not allowed to be empty'],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max, allow, invalid and allow(\'\')', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).allow('2013-06-07T14:21:46.295+07:00').invalid('2013-06-07T14:21+07:00').allow('');
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', true],
@@ -2962,13 +2962,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', true],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max, allow, invalid and allow(\'\')', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).allow('2013-06-07T14:21:46.295+07:00').allow('');
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', true],
@@ -2989,13 +2989,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', true],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max, allow, invalid and regex', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).allow('2013-06-07T14:21:46.295+07:00').invalid('2013-06-07T14:21Z').regex(/Z$/);
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', true],
@@ -3016,13 +3016,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', false, null, '"value" is not allowed to be empty'],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max, allow, invalid, regex and allow(\'\')', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).allow('2013-06-07T14:21:46.295+07:00').invalid('2013-06-07T14:21Z').regex(/Z$/).allow('');
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', true],
@@ -3043,13 +3043,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', true],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max and allow(\'\')', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).allow('');
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', false, null, '"value" length must be less than or equal to 23 characters long'],
@@ -3070,13 +3070,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', true],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max and regex', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).regex(/Z$/);
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', false, null, '"value" length must be less than or equal to 23 characters long'],
@@ -3097,13 +3097,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', false, null, '"value" is not allowed to be empty'],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max, regex and allow(\'\')', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).regex(/Z$/).allow('');
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', false, null, '"value" length must be less than or equal to 23 characters long'],
@@ -3124,13 +3124,13 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', true],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
         });
 
         it('validates combination of isoDate, min, max, regex and required', (done) => {
 
             const rule = Joi.string().isoDate().min(17).max(23).regex(/Z$/).required();
-            Helper.validate(rule, [
+            Helper.validateOptions(rule, [
                 ['2013-06-07T14:21:46.295Z', false, null, '"value" length must be less than or equal to 23 characters long'],
                 ['2013-06-07T14:21:46.295Z0', false, null, '"value" must be a valid ISO 8601 date'],
                 ['2013-06-07T14:21:46.295+07:00', false, null, '"value" length must be less than or equal to 23 characters long'],
@@ -3151,7 +3151,28 @@ describe('string', () => {
                 ['1-1-2013', false, null, '"value" must be a valid ISO 8601 date'],
                 ['', false, null, '"value" is not allowed to be empty'],
                 [null, false, null, '"value" must be a string']
-            ], done);
+            ], { convert: false }, done);
+        });
+
+        it('validates and formats isoDate with convert set to true (default)', (done) => {
+
+            const rule = Joi.string().isoDate();
+            Helper.validateOptions(rule, [
+                ['+002013-06-07T14:21:46.295Z', true, null, '2013-06-07T14:21:46.295Z'],
+                ['-002013-06-07T14:21:46.295Z', true, null, '-002013-06-07T14:21:46.295Z'],
+                ['2013-06-07T14:21:46.295Z', true, null, '2013-06-07T14:21:46.295Z'],
+                ['2013-06-07T14:21:46.295+07:00', true, null, '2013-06-07T07:21:46.295Z'],
+                ['2013-06-07T14:21:46.295-07:00', true, null, '2013-06-07T21:21:46.295Z'],
+                ['2013-06-07T14:21:46Z', true, null, '2013-06-07T14:21:46.000Z'],
+                ['2013-06-07T14:21:46+07:00', true, null, '2013-06-07T07:21:46.000Z'],
+                ['2013-06-07T14:21:46-07:00', true, null, '2013-06-07T21:21:46.000Z'],
+                ['2013-06-07T14:21Z', true, null, '2013-06-07T14:21:00.000Z'],
+                ['2013-06-07T14:21+07:00', true, null, '2013-06-07T07:21:00.000Z'],
+                ['2013-06-07T14:21-07:00', true, null, '2013-06-07T21:21:00.000Z'],
+                ['2013-06-07', true, null, '2013-06-07T00:00:00.000Z'],
+                ['2013-06-07T14:21', true, null, '2013-06-07T14:21:00.000Z'],
+                ['2013-184', false, null, '"value" must be a valid ISO 8601 date']
+            ], { convert: true }, done);
         });
 
         it('validates an hexadecimal string', (done) => {


### PR DESCRIPTION
Allow passing an option to string().isoDate() which formats the string as the simplified extended ISO format

Mimics the formatting returned by date().iso(), and the default ensures backwards compatibility.

ideally would use convert option to toggle whether the conversion happens, but since convert defaults to true, this would be a breaking change.

Closes #1196