### PR TITLE
Remove confusing paragraph for string modifiers

### DIFF
--- a/API.md
+++ b/API.md
@@ -1574,9 +1574,6 @@ be enabled with `allow('')`. However, if you want to specify a default value in 
 different pattern: `Joi.string().empty('').default('default value')`. This tells Joi that the empty string should be
 considered as an empty value (instead of invalid) and which value to use as default.
 
-If the validation `convert` option is on (enabled by default), a string will be converted using the specified modifiers
-for `string.lowercase()`, `string.uppercase()`, `string.trim()`, and each replacement specified with `string.replace()`.
-
 Supports the same methods of the [`any()`](#any) type.
 
 ```js


### PR DESCRIPTION
Addresses documentation concerns in #1191

> If the validation convert option is on (enabled by default), a string will be converted using the specified modifiers for string.lowercase(), string.uppercase(), string.trim(), and each replacement specified with string.replace()

and paired with

> string.insensitive()
> Allows the value to match any whitelist of blacklist item in a case insensitive comparison.

suggests that lowercase(), uppercase(), trim() and replace() are `convert` options only, and not validation directives.