### PR TITLE
Make isemail an optional dependency

### DIFF
--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -4,7 +4,7 @@
 
 const Net = require('net');
 const Hoek = require('hoek');
-const Isemail = require('isemail');
+let Isemail;                            // Loaded on demand
 const Any = require('../any');
 const Ref = require('../../ref');
 const JoiDate = require('../date');
@@ -168,6 +168,8 @@ internals.String = class extends Any {
         }
 
         return this._test('email', isEmailOptions, function (value, state, options) {
+
+            Isemail = Isemail || require('isemail');
 
             try {
                 const result = Isemail.validate(value, isEmailOptions);


### PR DESCRIPTION
This will allow dropping isemail dependency in hapi core.