### PR TITLE
Added the ability to use a reference for Array min/max/length

### DIFF
--- a/API.md
+++ b/API.md
@@ -850,6 +850,15 @@ Specifies the minimum number of items in the array where:
 const schema = Joi.array().min(2);
 ```
 
+It can also be a reference to another field.
+
+```js
+const schema = Joi.object({
+  limit: Joi.number().integer().required(),
+  numbers: Joi.array().min(Joi.ref('limit')).required()
+});
+```
+
 #### `array.max(limit)`
 
 Specifies the maximum number of items in the array where:
@@ -859,6 +868,15 @@ Specifies the maximum number of items in the array where:
 const schema = Joi.array().max(10);
 ```
 
+It can also be a reference to another field.
+
+```js
+const schema = Joi.object({
+  limit: Joi.number().integer().required(),
+  numbers: Joi.array().max(Joi.ref('limit')).required()
+});
+```
+
 #### `array.length(limit)`
 
 Specifies the exact number of items in the array where:
@@ -866,6 +884,15 @@ Specifies the exact number of items in the array where:
 
 ```js
 const schema = Joi.array().length(5);
+```
+
+It can also be a reference to another field.
+
+```js
+const schema = Joi.object({
+  limit: Joi.number().integer().required(),
+  numbers: Joi.array().length(Joi.ref('limit')).required()
+});
 ```
 
 #### `array.unique([comparator])`

--- a/lib/language.js
+++ b/lib/language.js
@@ -43,7 +43,8 @@ exports.errors = {
         ordered: 'at position {{pos}} fails because {{reason}}',
         orderedLength: 'at position {{pos}} fails because array must contain at most {{limit}} items',
         sparse: 'must not be a sparse array',
-        unique: 'position {{pos}} contains a duplicate value'
+        unique: 'position {{pos}} contains a duplicate value',
+        numberRef: 'references "{{ref}}" which is not a number'
     },
     boolean: {
         base: 'must be a boolean'

--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -4,6 +4,7 @@
 
 const Any = require('../any');
 const Cast = require('../../cast');
+const Ref = require('../../ref');
 const Hoek = require('hoek');
 
 
@@ -390,11 +391,25 @@ internals.Array = class extends Any {
 
     min(limit) {
 
-        Hoek.assert(Number.isSafeInteger(limit) && limit >= 0, 'limit must be a positive integer');
+        const isRef = Ref.isRef(limit);
+
+        Hoek.assert((Number.isSafeInteger(limit) && limit >= 0) || isRef, 'limit must be a positive integer or reference');
 
         return this._test('min', limit, function (value, state, options) {
 
-            if (value.length >= limit) {
+            let compareTo;
+            if (isRef) {
+                compareTo = limit(state.reference || state.parent, options);
+
+                if (!Number.isSafeInteger(compareTo)) {
+                    return this.createError('array.numberRef', { ref: limit.key }, state, options);
+                }
+            }
+            else {
+                compareTo = limit;
+            }
+
+            if (value.length >= compareTo) {
                 return value;
             }
 
@@ -404,11 +419,25 @@ internals.Array = class extends Any {
 
     max(limit) {
 
-        Hoek.assert(Number.isSafeInteger(limit) && limit >= 0, 'limit must be a positive integer');
+        const isRef = Ref.isRef(limit);
+
+        Hoek.assert((Number.isSafeInteger(limit) && limit >= 0) || isRef, 'limit must be a positive integer or reference');
 
         return this._test('max', limit, function (value, state, options) {
 
-            if (value.length <= limit) {
+            let compareTo;
+            if (isRef) {
+                compareTo = limit(state.reference || state.parent, options);
+
+                if (!Number.isSafeInteger(compareTo)) {
+                    return this.createError('array.numberRef', { ref: limit.key }, state, options);
+                }
+            }
+            else {
+                compareTo = limit;
+            }
+
+            if (value.length <= compareTo) {
                 return value;
             }
 
@@ -418,11 +447,25 @@ internals.Array = class extends Any {
 
     length(limit) {
 
-        Hoek.assert(Number.isSafeInteger(limit) && limit >= 0, 'limit must be a positive integer');
+        const isRef = Ref.isRef(limit);
+
+        Hoek.assert((Number.isSafeInteger(limit) && limit >= 0) || isRef, 'limit must be a positive integer or reference');
 
         return this._test('length', limit, function (value, state, options) {
 
-            if (value.length === limit) {
+            let compareTo;
+            if (isRef) {
+                compareTo = limit(state.reference || state.parent, options);
+
+                if (!Number.isSafeInteger(compareTo)) {
+                    return this.createError('array.numberRef', { ref: limit.key }, state, options);
+                }
+            }
+            else {
+                compareTo = limit;
+            }
+
+            if (value.length === compareTo) {
                 return value;
             }
 

--- a/test/types/array.js
+++ b/test/types/array.js
@@ -362,7 +362,7 @@ describe('array', () => {
             expect(() => {
 
                 Joi.array().min('a');
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -371,9 +371,75 @@ describe('array', () => {
             expect(() => {
 
                 Joi.array().min(1.2);
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
+
+        it('throws when limit is negative', (done) => {
+
+            expect(() => {
+
+                Joi.array().min(-1);
+            }).to.throw('limit must be a positive integer or reference');
+            done();
+        });
+
+        it('validates array size when a reference', (done) => {
+
+            const schema = Joi.object().keys({
+                limit: Joi.any(),
+                arr: Joi.array().min(Joi.ref('limit'))
+            });
+            Helper.validate(schema, [
+                [{
+                    limit: 2,
+                    arr: [1, 2]
+                }, true],
+                [{
+                    limit: 2,
+                    arr: [1]
+                }, false, null, 'child "arr" fails because ["arr" must contain at least ref:limit items]']
+            ], done);
+        });
+
+        it('handles references within a when', (done) => {
+
+            const schema = Joi.object({
+                limit: Joi.any(),
+                arr: Joi.array(),
+                arr2: Joi.when('arr', {
+                    is: Joi.array().min(Joi.ref('limit')),
+                    then: Joi.array()
+                })
+            });
+
+            Helper.validate(schema, [
+                [{
+                    limit: 2,
+                    arr: [1, 2],
+                    arr2: [1, 2]
+                }, true]
+            ], done);
+        });
+
+        it('validates reference is a safe integer', (done) => {
+
+            const schema = Joi.object().keys({
+                limit: Joi.any(),
+                arr: Joi.array().min(Joi.ref('limit'))
+            });
+            Helper.validate(schema, [
+                [{
+                    limit: Math.pow(2, 53),
+                    arr: [1, 2]
+                }, false, null, 'child "arr" fails because ["arr" references "limit" which is not a number]'],
+                [{
+                    limit: 'I like turtles',
+                    arr: [1]
+                }, false, null, 'child "arr" fails because ["arr" references "limit" which is not a number]']
+            ], done);
+        });
+
     });
 
     describe('max()', () => {
@@ -392,7 +458,7 @@ describe('array', () => {
             expect(() => {
 
                 Joi.array().max('a');
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -401,9 +467,75 @@ describe('array', () => {
             expect(() => {
 
                 Joi.array().max(1.2);
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
+
+        it('throws when limit is negative', (done) => {
+
+            expect(() => {
+
+                Joi.array().max(-1);
+            }).to.throw('limit must be a positive integer or reference');
+            done();
+        });
+
+        it('validates array size when a reference', (done) => {
+
+            const schema = Joi.object().keys({
+                limit: Joi.any(),
+                arr: Joi.array().max(Joi.ref('limit'))
+            });
+            Helper.validate(schema, [
+                [{
+                    limit: 2,
+                    arr: [1, 2]
+                }, true],
+                [{
+                    limit: 2,
+                    arr: [1, 2, 3]
+                }, false, null, 'child "arr" fails because ["arr" must contain less than or equal to ref:limit items]']
+            ], done);
+        });
+
+        it('handles references within a when', (done) => {
+
+            const schema = Joi.object({
+                limit: Joi.any(),
+                arr: Joi.array(),
+                arr2: Joi.when('arr', {
+                    is: Joi.array().max(Joi.ref('limit')),
+                    then: Joi.array()
+                })
+            });
+
+            Helper.validate(schema, [
+                [{
+                    limit: 2,
+                    arr: [1, 2],
+                    arr2: [1, 2]
+                }, true]
+            ], done);
+        });
+
+        it('validates reference is a safe integer', (done) => {
+
+            const schema = Joi.object().keys({
+                limit: Joi.any(),
+                arr: Joi.array().max(Joi.ref('limit'))
+            });
+            Helper.validate(schema, [
+                [{
+                    limit: Math.pow(2, 53),
+                    arr: [1, 2]
+                }, false, null, 'child "arr" fails because ["arr" references "limit" which is not a number]'],
+                [{
+                    limit: 'I like turtles',
+                    arr: [1]
+                }, false, null, 'child "arr" fails because ["arr" references "limit" which is not a number]']
+            ], done);
+        });
+
     });
 
     describe('length()', () => {
@@ -422,7 +554,7 @@ describe('array', () => {
             expect(() => {
 
                 Joi.array().length('a');
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
         });
 
@@ -431,8 +563,73 @@ describe('array', () => {
             expect(() => {
 
                 Joi.array().length(1.2);
-            }).to.throw('limit must be a positive integer');
+            }).to.throw('limit must be a positive integer or reference');
             done();
+        });
+
+        it('throws when limit is negative', (done) => {
+
+            expect(() => {
+
+                Joi.array().length(-1);
+            }).to.throw('limit must be a positive integer or reference');
+            done();
+        });
+
+        it('validates array size when a reference', (done) => {
+
+            const schema = Joi.object().keys({
+                limit: Joi.any(),
+                arr: Joi.array().length(Joi.ref('limit'))
+            });
+            Helper.validate(schema, [
+                [{
+                    limit: 2,
+                    arr: [1, 2]
+                }, true],
+                [{
+                    limit: 2,
+                    arr: [1]
+                }, false, null, 'child "arr" fails because ["arr" must contain ref:limit items]']
+            ], done);
+        });
+
+        it('handles references within a when', (done) => {
+
+            const schema = Joi.object({
+                limit: Joi.any(),
+                arr: Joi.array(),
+                arr2: Joi.when('arr', {
+                    is: Joi.array().length(Joi.ref('limit')),
+                    then: Joi.array()
+                })
+            });
+
+            Helper.validate(schema, [
+                [{
+                    limit: 2,
+                    arr: [1, 2],
+                    arr2: [1, 2]
+                }, true]
+            ], done);
+        });
+
+        it('validates reference is a safe integer', (done) => {
+
+            const schema = Joi.object().keys({
+                limit: Joi.any(),
+                arr: Joi.array().length(Joi.ref('limit'))
+            });
+            Helper.validate(schema, [
+                [{
+                    limit: Math.pow(2, 53),
+                    arr: [1, 2]
+                }, false, null, 'child "arr" fails because ["arr" references "limit" which is not a number]'],
+                [{
+                    limit: 'I like turtles',
+                    arr: [1]
+                }, false, null, 'child "arr" fails because ["arr" references "limit" which is not a number]']
+            ], done);
         });
     });
 


### PR DESCRIPTION
This PR adds the ability for a user to use a reference for `array().length()`, `array().min()` and `array().max()` as well as adding test cases and documentation around the functionality.

Fixes #1017 