### PR TITLE
Performance Improvements for string().guid()

### DIFF
--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -338,12 +338,10 @@ internals.String = class extends Any {
             'uuidv5': '5'
         };
 
-        let versionNumbers = [];
+        let versionNumbers = '';
         const versions = {};
-        let checkVersion = false;
 
         if (guidOptions && guidOptions.version) {
-            checkVersion = true;
             if (!Array.isArray(guidOptions.version)) {
                 guidOptions.version = [guidOptions.version];
             }
@@ -358,14 +356,12 @@ internals.String = class extends Any {
                 Hoek.assert(versionNumber, 'version at position ' + i + ' must be one of ' + Object.keys(uuids).join(', '));
                 Hoek.assert(!(versionNumber in versions), 'version at position ' + i + ' must not be a duplicate.');
 
-                versionNumbers.push(versionNumber);
+                versionNumbers += versionNumber;
                 versions[versionNumber] = '';
             }
-
-            versionNumbers = versionNumbers.join('');
         }
 
-        const guidRegex = new RegExp(`^([\\[{\\(]?)[0-9A-F]{8}([:-]?)[0-9A-F]{4}\\2?[${checkVersion ? versionNumbers : '0-9A-F'}][0-9A-F]{3}\\2?[${checkVersion ? '89AB' : '0-9A-F'}][0-9A-F]{3}\\2?[0-9A-F]{12}([\\]}\\)]?)$`, 'i');
+        const guidRegex = new RegExp(`^([\\[{\\(]?)[0-9A-F]{8}([:-]?)[0-9A-F]{4}\\2?[${versionNumbers || '0-9A-F'}][0-9A-F]{3}\\2?[${versionNumbers ? '89AB' : '0-9A-F'}][0-9A-F]{3}\\2?[0-9A-F]{12}([\\]}\\)]?)$`, 'i');
 
         return this._test('guid', guidOptions, function (value, state, options) {
 

--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -338,9 +338,12 @@ internals.String = class extends Any {
             'uuidv5': '5'
         };
 
-        const versions = [];
+        let versionNumbers = [];
+        const versions = {};
+        let checkVersion = false;
 
         if (guidOptions && guidOptions.version) {
+            checkVersion = true;
             if (!Array.isArray(guidOptions.version)) {
                 guidOptions.version = [guidOptions.version];
             }
@@ -351,43 +354,30 @@ internals.String = class extends Any {
                 let version = guidOptions.version[i];
                 Hoek.assert(typeof version === 'string', 'version at position ' + i + ' must be a string');
                 version = version.toLowerCase();
-                Hoek.assert(uuids[version], 'version at position ' + i + ' must be one of ' + Object.keys(uuids).join(', '));
-                Hoek.assert(versions.indexOf(version) === -1, 'version at position ' + i + ' must not be a duplicate.');
-                versions.push(version);
+                const versionNumber = uuids[version];
+                Hoek.assert(versionNumber, 'version at position ' + i + ' must be one of ' + Object.keys(uuids).join(', '));
+                Hoek.assert(!(versionNumber in versions), 'version at position ' + i + ' must not be a duplicate.');
+
+                versionNumbers.push(versionNumber);
+                versions[versionNumber] = '';
             }
+
+            versionNumbers = versionNumbers.join('');
         }
 
-        const regex = /^([\[{\(]?)([0-9A-F]{8})([:-]?)([0-9A-F]{4})([:-]?)([0-9A-F]{4})([:-]?)([0-9A-F]{4})([:-]?)([0-9A-F]{12})([\]}\)]?)$/i;
+        const guidRegex = new RegExp(`^([\\[{\\(]?)[0-9A-F]{8}([:-]?)[0-9A-F]{4}\\2?[${checkVersion ? versionNumbers : '0-9A-F'}][0-9A-F]{3}\\2?[${checkVersion ? '89AB' : '0-9A-F'}][0-9A-F]{3}\\2?[0-9A-F]{12}([\\]}\\)]?)$`, 'i');
 
         return this._test('guid', guidOptions, function (value, state, options) {
 
-            const results = regex.exec(value);
+            const results = guidRegex.exec(value);
 
             if (!results) {
                 return this.createError('string.guid', { value }, state, options);
             }
 
             // Matching braces
-            if (brackets[results[1]] !== results[11]) {
+            if (brackets[results[1]] !== results[results.length - 1]) {
                 return this.createError('string.guid', { value }, state, options);
-            }
-
-            // Matching separators
-            if (results[3] !== results[5] || results[3] !== results[7] || results[3] !== results[9]) {
-                return this.createError('string.guid', { value }, state, options);
-            }
-
-            // Specific UUID versions
-            if (versions.length) {
-                const validVersions = versions.some((uuidVersion) => {
-
-                    return results[6][0] === uuids[uuidVersion];
-                });
-
-                // Valid version and 89AB check
-                if (!(validVersions && /[89AB]/i.test(results[8][0]))) {
-                    return this.createError('string.guid', { value }, state, options);
-                }
             }
 
             return value;

--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -15,7 +15,17 @@ const Ip = require('./ip');
 
 const internals = {
     uriRegex: Uri.createUriRegex(),
-    ipRegex: Ip.createIpRegex(['ipv4', 'ipv6', 'ipvfuture'], 'optional')
+    ipRegex: Ip.createIpRegex(['ipv4', 'ipv6', 'ipvfuture'], 'optional'),
+    guidBrackets: {
+        '{': '}', '[': ']', '(': ')', '': ''
+    },
+    guidVersions: {
+        uuidv1: '1',
+        uuidv2: '2',
+        uuidv3: '3',
+        uuidv4: '4',
+        uuidv5: '5'
+    }
 };
 
 internals.String = class extends Any {
@@ -326,20 +336,7 @@ internals.String = class extends Any {
 
     guid(guidOptions) {
 
-        const brackets = {
-            '{': '}', '[': ']', '(': ')', '': ''
-        };
-
-        const uuids = {
-            'uuidv1': '1',
-            'uuidv2': '2',
-            'uuidv3': '3',
-            'uuidv4': '4',
-            'uuidv5': '5'
-        };
-
         let versionNumbers = '';
-        const versions = {};
 
         if (guidOptions && guidOptions.version) {
             if (!Array.isArray(guidOptions.version)) {
@@ -347,17 +344,18 @@ internals.String = class extends Any {
             }
 
             Hoek.assert(guidOptions.version.length >= 1, 'version must have at least 1 valid version specified');
+            const versions = new Set();
 
             for (let i = 0; i < guidOptions.version.length; ++i) {
                 let version = guidOptions.version[i];
                 Hoek.assert(typeof version === 'string', 'version at position ' + i + ' must be a string');
                 version = version.toLowerCase();
-                const versionNumber = uuids[version];
-                Hoek.assert(versionNumber, 'version at position ' + i + ' must be one of ' + Object.keys(uuids).join(', '));
-                Hoek.assert(!(versionNumber in versions), 'version at position ' + i + ' must not be a duplicate.');
+                const versionNumber = internals.guidVersions[version];
+                Hoek.assert(versionNumber, 'version at position ' + i + ' must be one of ' + Object.keys(internals.guidVersions).join(', '));
+                Hoek.assert(!(versions.has(versionNumber)), 'version at position ' + i + ' must not be a duplicate.');
 
                 versionNumbers += versionNumber;
-                versions[versionNumber] = '';
+                versions.add(versionNumber);
             }
         }
 
@@ -372,7 +370,7 @@ internals.String = class extends Any {
             }
 
             // Matching braces
-            if (brackets[results[1]] !== results[results.length - 1]) {
+            if (internals.guidBrackets[results[1]] !== results[results.length - 1]) {
                 return this.createError('string.guid', { value }, state, options);
             }
 


### PR DESCRIPTION
This PR includes some performance improvements to the run-time validation of the `string().guid()` validation type. 

#### How Was This Determined?
I ran a [series of benchmarks](https://github.com/DavidTPate/joi-bench/blob/dabe172db0e2aa81f43ea86b0381a2d4f11e7e02/benchmarks/string.js#L135-L158) for some common cases of GUID/UUIDs and then made tweaks to improve the performance.

**Schemas**
```js
const guidSchema = stringSchema.guid();
const guidVersionsSchema = stringSchema.guid({
   version: ['uuidv1', 'uuidv2', 'uuidv3', 'uuidv4']
});
```

**Benchmarks**
```js
// validate-schema#guid
guidSchema.validate('D1A5279D-B27D-4CD4-A05E-EFDD53D08E8D');

// validate-schema#guid-wrapped
guidSchema.validate('{D1A5279D-B27D-4CD4-A05E-EFDD53D08E8D}');

// validate-schema#guid-versions
guidVersionsSchema.validate('D1A5279D-B27D-4CD4-A05E-EFDD53D08E8D');

// validate-schema#guid-versions-wrapped
guidVersionsSchema.validate('{D1A5279D-B27D-4CD4-A05E-EFDD53D08E8D}');
```

#### Original Benchmarks
Unmodified I received the following benchmarks:

```
string
  validate-schema#guid-versions         x 353,757 ops/sec
  validate-schema#guid-versions-wrapped x 370,182 ops/sec
  validate-schema#guid                  x 406,565 ops/sec
  validate-schema#guid-wrapped          x 423,820 ops/sec
```

From there I deferred more of the work to the Regular Expression but kept the version check within an `if` statement, which brought me the following results:

```
string
  validate-schema#guid                  x 428,658 ops/sec
  validate-schema#guid-versions         x 439,570 ops/sec
  validate-schema#guid-versions-wrapped x 451,946 ops/sec
  validate-schema#guid-wrapped          x 458,762 ops/sec
```

From there I went and pulled the version & `89AB` checks along with utilizing back references within the Regular Expression for divider checks. Additionally, I simplified the Regular Expression to eliminate capture & non-capture groups where possible. This lead to the follow (current) benchmarks:

```
string
  validate-schema#guid-versions         x 449,913 ops/sec
  validate-schema#guid                  x 458,897 ops/sec
  validate-schema#guid-versions-wrapped x 472,751 ops/sec
  validate-schema#guid-wrapped          x 473,101 ops/sec
```

> **Note**: These benchmarks were run on my machine, so if you run them expect the numbers themselves to vary (also by Node version & platform), but they should stay around the same magnitude of difference.