### PR TITLE
Update isemail from 2.x.x to 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "hoek": "4.x.x",
-    "isemail": "2.x.x",
+    "isemail": "3.x.x",
     "items": "2.x.x",
     "topo": "2.x.x"
   },

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -510,6 +510,7 @@ describe('string', () => {
             Helper.validate(schema, [
                 ['joe@example.com', true],
                 ['"joe"@example.com', true],
+                ['êjness@something.com', true],
                 ['@iaminvalid.com', false, null, '"value" must be a valid email'],
                 ['joe@[IPv6:2a00:1450:4001:c02::1b]', true],
                 ['12345678901234567890123456789012345678901234567890123456789012345@walmartlabs.com', false, null, '"value" must be a valid email'],
@@ -561,7 +562,8 @@ describe('string', () => {
             Helper.validate(schema, [
                 ['joe@example.com', true],
                 ['joe@www.example.com', true],
-                ['joe@localhost', false, null, '"value" must be a valid email'],
+                ['joe@localhost', true],
+                ['joe@', false, null, '"value" must be a valid email'],
                 ['joe', false, null, '"value" must be a valid email']
             ], done);
         });


### PR DESCRIPTION
`isemail` [v3.0.0](https://github.com/hapijs/isemail/releases/tag/v3.0.0) has been released, adding support for unicode emails and removing DNS lookups entirely.