### PR TITLE
Fix Value Range for IPv6 CIDRs

### DIFF
--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -25,7 +25,8 @@ const internals = {
         uuidv3: '3',
         uuidv4: '4',
         uuidv5: '5'
-    }
+    },
+    cidrPresences: ['required', 'optional', 'forbidden']
 };
 
 internals.String = class extends Any {
@@ -212,7 +213,7 @@ internals.String = class extends Any {
             Hoek.assert(typeof ipOptions.cidr === 'string', 'cidr must be a string');
             ipOptions.cidr = ipOptions.cidr.toLowerCase();
 
-            Hoek.assert(ipOptions.cidr in Ip.cidrs, 'cidr must be one of ' + Object.keys(Ip.cidrs).join(', '));
+            Hoek.assert(Hoek.contain(internals.cidrPresences, ipOptions.cidr), 'cidr must be one of ' + internals.cidrPresences.join(', '));
 
             // If we only received a `cidr` setting, create a regex for it. But we don't need to create one if `cidr` is "optional" since that is the default
             if (!ipOptions.version && ipOptions.cidr !== 'optional') {

--- a/lib/types/string/ip.js
+++ b/lib/types/string/ip.js
@@ -10,9 +10,21 @@ const RFC3986 = require('./rfc3986');
 const internals = {
     Ip: {
         cidrs: {
-            required: '\\/(?:' + RFC3986.cidr + ')',
-            optional: '(?:\\/(?:' + RFC3986.cidr + '))?',
-            forbidden: ''
+            ipv4: {
+                required: '\\/(?:' + RFC3986.ipv4Cidr + ')',
+                optional: '(?:\\/(?:' + RFC3986.ipv4Cidr + '))?',
+                forbidden: ''
+            },
+            ipv6: {
+                required: '\\/' + RFC3986.ipv6Cidr,
+                optional: '(?:\\/' + RFC3986.ipv6Cidr + ')?',
+                forbidden: ''
+            },
+            ipvfuture: {
+                required: '\\/' + RFC3986.ipv6Cidr,
+                optional: '(?:\\/' + RFC3986.ipv6Cidr + ')?',
+                forbidden: ''
+            }
         },
         versions: {
             ipv4: RFC3986.IPv4address,
@@ -29,12 +41,14 @@ internals.Ip.createIpRegex = function (versions, cidr) {
     for (let i = 0; i < versions.length; ++i) {
         const version = versions[i];
         if (!regex) {
-            regex = '^(?:' + internals.Ip.versions[version];
+            regex = '^(?:' + internals.Ip.versions[version] + internals.Ip.cidrs[version][cidr];
         }
-        regex = regex + '|' + internals.Ip.versions[version];
+        else {
+            regex += '|' + internals.Ip.versions[version] + internals.Ip.cidrs[version][cidr];
+        }
     }
 
-    return new RegExp(regex + ')' + internals.Ip.cidrs[cidr] + '$');
+    return new RegExp(regex + ')$');
 };
 
 module.exports = internals.Ip;

--- a/lib/types/string/rfc3986.js
+++ b/lib/types/string/rfc3986.js
@@ -18,6 +18,11 @@ internals.generate = function () {
     const or = '|';
 
     /**
+     * Rule to support zero-padded addresses.
+     */
+    const zeroPad = '0?';
+
+    /**
      * DIGIT = %x30-39 ; 0-9
      */
     const digit = '0-9';
@@ -30,11 +35,21 @@ internals.generate = function () {
     const alphaOnly = '[' + alpha + ']';
 
     /**
+     * IPv4
      * cidr       = DIGIT                ; 0-9
      *            / %x31-32 DIGIT         ; 10-29
      *            / "3" %x30-32           ; 30-32
      */
-    internals.rfc3986.cidr = digitOnly + or + '[1-2]' + digitOnly + or + '3' + '[0-2]';
+    internals.rfc3986.ipv4Cidr = digitOnly + or + '[1-2]' + digitOnly + or + '3' + '[0-2]';
+
+    /**
+     * IPv6
+     * cidr       = DIGIT                 ; 0-9
+     *            / %x31-39 DIGIT         ; 10-99
+     *            / "1" %x0-1 DIGIT       ; 100-119
+     *            / "12" %x0-8            ; 120-128
+     */
+    internals.rfc3986.ipv6Cidr = '(?:' + zeroPad + zeroPad + digitOnly + or + zeroPad + '[1-9]' + digitOnly + or + '1' + '[01]' + digitOnly + or + '12[0-8])';
 
     /**
      * HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
@@ -62,11 +77,6 @@ internals.generate = function () {
      */
     const pchar = unreserved + pctEncoded + subDelims + ':@';
     const pcharOnly = '[' + pchar + ']';
-
-    /**
-     * Rule to support zero-padded addresses.
-     */
-    const zeroPad = '0?';
 
     /**
      * dec-octet   = DIGIT                 ; 0-9

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -958,6 +958,9 @@ describe('string', () => {
                 '0.0.0.0/33',
                 '256.0.0.0/0',
                 '255.255.255.256/32',
+                '255.255.255.255/64',
+                '255.255.255.255/128',
+                '255.255.255.255/255',
                 '256.0.0.0',
                 '255.255.255.256'
             ])(false, message);
@@ -966,16 +969,20 @@ describe('string', () => {
         const invalidIPv6s = function (message) {
 
             return prepareIps([
-                '2001:db8::7/33',
-                '1080:0:0:0:8:800:200C:417G'
+                '1080:0:0:0:8:800:200C:417G/33',
+                '1080:0:0:0:8:800:200C:417G',
+                'FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/129',
+                'FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/255'
             ])(false, message);
         };
 
         const invalidIPvFutures = function (message) {
 
             return prepareIps([
-                'v1.09azAZ-._~!$&\'()*+,;=:/33',
-                'v1.09#'
+                'v1.09#/33',
+                'v1.09#',
+                'v1.09azAZ-._~!$&\'()*+,;=:/129',
+                'v1.09azAZ-._~!$&\'()*+,;=:/255'
             ])(false, message);
         };
 
@@ -1016,8 +1023,10 @@ describe('string', () => {
         const validIPv6sWithCidr = prepareIps([
             '2001:db8::7/32',
             'a:b:c:d:e::1.2.3.4/13',
+            'a:b:c:d:e::1.2.3.4/64',
             'FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/0',
             'FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/32',
+            'FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/128',
             '1080:0:0:0:8:800:200C:417A/27'
         ]);
 
@@ -1065,7 +1074,7 @@ describe('string', () => {
             '7:6:5:4:3:2:1::'
         ]);
 
-        const validIPvFuturesWithCidr = prepareIps(['v1.09azAZ-._~!$&\'()*+,;=:/32']);
+        const validIPvFuturesWithCidr = prepareIps(['v1.09azAZ-._~!$&\'()*+,;=:/32','v1.09azAZ-._~!$&\'()*+,;=:/128']);
 
         const validIPvFuturesWithoutCidr = prepareIps(['v1.09azAZ-._~!$&\'()*+,;=:']);
 


### PR DESCRIPTION
Fix how we handle CIDRs for IPv6 so that we are allowing up to 128 for the CIDR.

Fixes #1232