### PR TITLE
Fixes [#1239]

### DIFF
--- a/API.md
+++ b/API.md
@@ -1529,7 +1529,7 @@ object.validate({ b: 5 }, (err, value) => { });
 It can also rename keys using a regex
 
 ```js
-const regex = /foobar/i;
+const regex = /^foobar$/i;
 
 const schema = Joi.object().keys({
   fooBar: Joi.string()

--- a/API.md
+++ b/API.md
@@ -1526,6 +1526,18 @@ const object = Joi.object().keys({
 object.validate({ b: 5 }, (err, value) => { });
 ```
 
+It can also rename keys using a regex
+
+```js
+const regex = /foobar/i;
+
+const schema = Joi.object().keys({
+  fooBar: Joi.string()
+}).rename(regex, 'fooBar');
+
+schema.validate({ FooBar: 'a'}, (err, value) => {});
+```
+
 #### `object.assert(ref, schema, [message])`
 
 Verifies an assertion where:

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -119,48 +119,53 @@ internals.Object = class extends Any {
                 }
             }
 
+            if (rename.isRegExp) {
+                const targetKeys = Object.keys(target);
+                const matchedTargetKeys = [];
 
-            const isRegExRename = rename.from instanceof RegExp;
-
-            if (target[rename.from] === undefined && !isRegExRename) {
-                delete target[rename.to];
-            }
-            else if (isRegExRename) {
-                const objectKeys = Object.keys(target);
-
-                if (rename.options.override && target[rename.from] === undefined) {
-                    delete target[rename.to];
+                for (let j = 0; j < targetKeys.length; ++j) {
+                    if (rename.from.test(targetKeys[j])) {
+                        matchedTargetKeys.push(targetKeys[j]);
+                    }
                 }
 
-                for (let j = objectKeys.length; j--;) {
-                    if (rename.from.test(objectKeys[j])) {
-                        target[rename.to] = target[objectKeys[j]];
-                        delete target[objectKeys[j]];
+                if (matchedTargetKeys.length === 0) {
+                    delete target[rename.to];
+                }
+                else {
+                    if (!rename.options.multiple &&
+                        matchedTargetKeys.length > 1) {
 
-                        let offendingKey;
-
-                        for (let k = this._inner.children.length; k--;) {
-                            if (rename.from.test(this._inner.children[k].key)) {
-                                offendingKey = this._inner.children[k].key;
-                                target[offendingKey] = target[rename.to];
-                            }
+                        errors.push(this.createError('object.rename.multiple', { from: matchedTargetKeys, to: rename.to }, state, options));
+                        if (options.abortEarly) {
+                            return finish();
                         }
+                    }
 
-                        if (!rename.options.alias && !rename.options.override) {
-                            delete target[offendingKey];
-                        }
+                    target[rename.to] = target[matchedTargetKeys[matchedTargetKeys.length - 1]];
+                }
+
+                if (!rename.options.alias) {
+
+                    for (let j = 0; j < matchedTargetKeys.length; ++j) {
+                        delete target[matchedTargetKeys[j]];
                     }
                 }
             }
             else {
-                target[rename.to] = target[rename.from];
+                if (target[rename.from] === undefined) {
+                    delete target[rename.to];
+                }
+                else {
+                    target[rename.to] = target[rename.from];
+                }
+
+                if (!rename.options.alias) {
+                    delete target[rename.from];
+                }
             }
 
             renamed[rename.to] = true;
-
-            if (!rename.options.alias && !isRegExRename) {
-                delete target[rename.from];
-            }
         }
 
         // Validate schema
@@ -556,7 +561,8 @@ internals.Object = class extends Any {
         obj._inner.renames.push({
             from,
             to,
-            options: Hoek.applyToDefaults(internals.renameDefaults, options || {})
+            options: Hoek.applyToDefaults(internals.renameDefaults, options || {}),
+            isRegExp: from instanceof RegExp
         });
 
         return obj;

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -95,8 +95,22 @@ internals.Object = class extends Any {
         const renamed = {};
         for (let i = 0; i < this._inner.renames.length; ++i) {
             const rename = this._inner.renames[i];
+            const matchedTargetKeys = [];
 
-            if (rename.options.ignoreUndefined && target[rename.from] === undefined) {
+            const fromIsUndefined = rename.isRegExp ?
+                Object.keys(target).filter((targetKey) => {
+
+                    const keyMatchesRegexp = rename.from.test(targetKey);
+
+                    if (keyMatchesRegexp) {
+                        matchedTargetKeys.push(targetKey);
+                    }
+
+                    return keyMatchesRegexp;
+                }).length === 0 :
+                target[rename.from] === undefined;
+
+            if (rename.options.ignoreUndefined && fromIsUndefined) {
                 continue;
             }
 
@@ -120,15 +134,6 @@ internals.Object = class extends Any {
             }
 
             if (rename.isRegExp) {
-                const targetKeys = Object.keys(target);
-                const matchedTargetKeys = [];
-
-                for (let j = 0; j < targetKeys.length; ++j) {
-                    if (rename.from.test(targetKeys[j])) {
-                        matchedTargetKeys.push(targetKeys[j]);
-                    }
-                }
-
                 if (matchedTargetKeys.length === 0) {
                     delete target[rename.to];
                 }

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -128,22 +128,26 @@ internals.Object = class extends Any {
             else if (isRegExRename) {
                 const objectKeys = Object.keys(target);
 
+                if (rename.options.override && target[rename.from] === undefined) {
+                    delete target[rename.to];
+                }
+
                 for (let j = objectKeys.length; j--;) {
                     if (rename.from.test(objectKeys[j])) {
                         target[rename.to] = target[objectKeys[j]];
+                        delete target[objectKeys[j]];
 
-                        // Using regex: Key needs to be normalized to proper case
+                        let offendingKey;
 
                         for (let k = this._inner.children.length; k--;) {
-                            if (rename.from.test(this._inner.children[k].key) || rename.options.override) {
-                                target[this._inner.children[k].key] = target[objectKeys[j]];
-
-                                delete target[objectKeys[j]];
-
-                                if (!rename.options.alias && !rename.options.override) {
-                                    delete target[this._inner.children[k].key];
-                                }
+                            if (rename.from.test(this._inner.children[k].key)) {
+                                offendingKey = this._inner.children[k].key;
+                                target[offendingKey] = target[rename.to];
                             }
+                        }
+
+                        if (!rename.options.alias && !rename.options.override) {
+                            delete target[offendingKey];
                         }
                     }
                 }

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -123,14 +123,18 @@ internals.Object = class extends Any {
             if (target[rename.from] === undefined && typeof rename.from !== 'object') {
                 delete target[rename.to];
             }
-            else if (typeof rename.from === 'object') {
+            else if (rename.from instanceof RegExp) {
                 const fromKey = Object.keys(target).find((key) => {
 
                     return rename.from.test(key);
                 });
 
                 target[rename.to] = target[fromKey];
-                delete target[fromKey];
+
+                if (!rename.options.override) {
+                    delete target[fromKey];
+                }
+
             }
             else {
                 target[rename.to] = target[rename.from];
@@ -138,7 +142,7 @@ internals.Object = class extends Any {
 
             renamed[rename.to] = true;
 
-            if (!rename.options.alias && typeof rename.from !== 'object') {
+            if (!rename.options.alias && !(rename.from instanceof RegExp)) {
                 delete target[rename.from];
             }
         }

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -93,7 +93,7 @@ internals.Object = class extends Any {
         // Rename keys
 
         const renamed = {};
-        for (let i = 0; i < this._inner.renames.length;  ++i) {
+        for (let i = 0; i < this._inner.renames.length; ++i) {
             const rename = this._inner.renames[i];
 
             if (rename.options.ignoreUndefined && target[rename.from] === undefined) {

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -120,7 +120,7 @@ internals.Object = class extends Any {
 
 
 
-            if (target[rename.from] === undefined && typeof rename.from !== 'object') {
+            if (target[rename.from] === undefined && !(rename.from instanceof RegExp)) {
                 delete target[rename.to];
             }
             else if (rename.from instanceof RegExp) {

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -95,58 +95,44 @@ internals.Object = class extends Any {
         const renamed = {};
         for (let i = 0; i < this._inner.renames.length; ++i) {
             const rename = this._inner.renames[i];
-            const matchedTargetKeys = [];
-
-            const fromIsUndefined = rename.isRegExp ?
-                Object.keys(target).filter((targetKey) => {
-
-                    const keyMatchesRegexp = rename.from.test(targetKey);
-
-                    if (keyMatchesRegexp) {
-                        matchedTargetKeys.push(targetKey);
-                    }
-
-                    return keyMatchesRegexp;
-                }).length === 0 :
-                target[rename.from] === undefined;
-
-            if (rename.options.ignoreUndefined && fromIsUndefined) {
-                continue;
-            }
-
-            if (!rename.options.multiple &&
-                renamed[rename.to]) {
-
-                errors.push(this.createError('object.rename.multiple', { from: rename.from, to: rename.to }, state, options));
-                if (options.abortEarly) {
-                    return finish();
-                }
-            }
-
-            if (Object.prototype.hasOwnProperty.call(target, rename.to) &&
-                !rename.options.override &&
-                !renamed[rename.to]) {
-
-                errors.push(this.createError('object.rename.override', { from: rename.from, to: rename.to }, state, options));
-                if (options.abortEarly) {
-                    return finish();
-                }
-            }
 
             if (rename.isRegExp) {
+                const targetKeys = Object.keys(target);
+                const matchedTargetKeys = [];
+
+                for (let j = 0; j < targetKeys.length; ++j) {
+                    if (rename.from.test(targetKeys[j])) {
+                        matchedTargetKeys.push(targetKeys[j]);
+                    }
+                }
+
+                if (rename.options.ignoreUndefined && matchedTargetKeys.length === 0) {
+                    continue;
+                }
+
+                if (!rename.options.multiple &&
+                    renamed[rename.to]) {
+
+                    errors.push(this.createError('object.rename.multiple', { from: matchedTargetKeys, to: rename.to }, state, options));
+                    if (options.abortEarly) {
+                        return finish();
+                    }
+                }
+
+                if (Object.prototype.hasOwnProperty.call(target, rename.to) &&
+                    !rename.options.override &&
+                    !renamed[rename.to]) {
+
+                    errors.push(this.createError('object.rename.override', { from: rename.from, to: rename.to }, state, options));
+                    if (options.abortEarly) {
+                        return finish();
+                    }
+                }
+
                 if (matchedTargetKeys.length === 0) {
                     delete target[rename.to];
                 }
                 else {
-                    if (!rename.options.multiple &&
-                        matchedTargetKeys.length > 1) {
-
-                        errors.push(this.createError('object.rename.multiple', { from: matchedTargetKeys, to: rename.to }, state, options));
-                        if (options.abortEarly) {
-                            return finish();
-                        }
-                    }
-
                     target[rename.to] = target[matchedTargetKeys[matchedTargetKeys.length - 1]];
                 }
 
@@ -156,8 +142,33 @@ internals.Object = class extends Any {
                         delete target[matchedTargetKeys[j]];
                     }
                 }
+
+                renamed[rename.to] = true;
             }
             else {
+                if (rename.options.ignoreUndefined && target[rename.from] === undefined) {
+                    continue;
+                }
+
+                if (!rename.options.multiple &&
+                    renamed[rename.to]) {
+
+                    errors.push(this.createError('object.rename.multiple', { from: rename.from, to: rename.to }, state, options));
+                    if (options.abortEarly) {
+                        return finish();
+                    }
+                }
+
+                if (Object.prototype.hasOwnProperty.call(target, rename.to) &&
+                    !rename.options.override &&
+                    !renamed[rename.to]) {
+
+                    errors.push(this.createError('object.rename.override', { from: rename.from, to: rename.to }, state, options));
+                    if (options.abortEarly) {
+                        return finish();
+                    }
+                }
+
                 if (target[rename.from] === undefined) {
                     delete target[rename.to];
                 }
@@ -165,12 +176,12 @@ internals.Object = class extends Any {
                     target[rename.to] = target[rename.from];
                 }
 
+                renamed[rename.to] = true;
+
                 if (!rename.options.alias) {
                     delete target[rename.from];
                 }
             }
-
-            renamed[rename.to] = true;
         }
 
         // Validate schema

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -119,11 +119,12 @@ internals.Object = class extends Any {
             }
 
 
+            const isRegExRename = rename.from instanceof RegExp;
 
-            if (target[rename.from] === undefined && !(rename.from instanceof RegExp)) {
+            if (target[rename.from] === undefined && !isRegExRename) {
                 delete target[rename.to];
             }
-            else if (rename.from instanceof RegExp) {
+            else if (isRegExRename) {
                 const fromKey = Object.keys(target).find((key) => {
 
                     return rename.from.test(key);
@@ -142,7 +143,7 @@ internals.Object = class extends Any {
 
             renamed[rename.to] = true;
 
-            if (!rename.options.alias && !(rename.from instanceof RegExp)) {
+            if (!rename.options.alias && !isRegExRename) {
                 delete target[rename.from];
             }
         }

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -127,12 +127,12 @@ internals.Object = class extends Any {
             else if (isRegExRename) {
                 const objectKeys = Object.keys(target);
 
-                for ( let i = 0; i < objectKeys.length; ++i) {
-                    if (rename.from.test(objectKeys[i])) {
-                        target[rename.to] = target[objectKeys[i]];
+                for (let j = 0; j < objectKeys.length; ++j) {
+                    if (rename.from.test(objectKeys[j])) {
+                        target[rename.to] = target[objectKeys[j]];
 
                         if (!rename.options.override) {
-                            delete target[objectKeys[i]];
+                            delete target[objectKeys[j]];
                         }
                     }
                 }

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -84,6 +84,7 @@ internals.Object = class extends Any {
             for (let i = 0; i < valueKeys.length; ++i) {
                 target[valueKeys[i]] = value[valueKeys[i]];
             }
+
         }
         else {
             target = value;
@@ -92,7 +93,7 @@ internals.Object = class extends Any {
         // Rename keys
 
         const renamed = {};
-        for (let i = 0; i < this._inner.renames.length; ++i) {
+        for (let i = 0; i < this._inner.renames.length;  ++i) {
             const rename = this._inner.renames[i];
 
             if (rename.options.ignoreUndefined && target[rename.from] === undefined) {
@@ -127,12 +128,22 @@ internals.Object = class extends Any {
             else if (isRegExRename) {
                 const objectKeys = Object.keys(target);
 
-                for (let j = 0; j < objectKeys.length; ++j) {
+                for (let j = objectKeys.length; j--;) {
                     if (rename.from.test(objectKeys[j])) {
                         target[rename.to] = target[objectKeys[j]];
 
-                        if (!rename.options.override) {
-                            delete target[objectKeys[j]];
+                        // Using regex: Key needs to be normalized to proper case
+
+                        for (let k = this._inner.children.length; k--;) {
+                            if (rename.from.test(this._inner.children[k].key) || rename.options.override) {
+                                target[this._inner.children[k].key] = target[objectKeys[j]];
+
+                                delete target[objectKeys[j]];
+
+                                if (!rename.options.alias && !rename.options.override) {
+                                    delete target[this._inner.children[k].key];
+                                }
+                            }
                         }
                     }
                 }

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -118,8 +118,19 @@ internals.Object = class extends Any {
                 }
             }
 
-            if (target[rename.from] === undefined) {
+
+
+            if (target[rename.from] === undefined && typeof rename.from !== 'object') {
                 delete target[rename.to];
+            }
+            else if (typeof rename.from === 'object') {
+                const fromKey = Object.keys(target).find((key) => {
+
+                    return rename.from.test(key);
+                });
+
+                target[rename.to] = target[fromKey];
+                delete target[fromKey];
             }
             else {
                 target[rename.to] = target[rename.from];
@@ -127,7 +138,7 @@ internals.Object = class extends Any {
 
             renamed[rename.to] = true;
 
-            if (!rename.options.alias) {
+            if (!rename.options.alias && typeof rename.from !== 'object') {
                 delete target[rename.from];
             }
         }
@@ -512,7 +523,7 @@ internals.Object = class extends Any {
 
     rename(from, to, options) {
 
-        Hoek.assert(typeof from === 'string', 'Rename missing the from argument');
+        Hoek.assert(typeof from === 'string' || typeof from === 'object', 'Rename missing the from argument');
         Hoek.assert(typeof to === 'string', 'Rename missing the to argument');
         Hoek.assert(to !== from, 'Cannot rename key to same name:', from);
 

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -125,17 +125,17 @@ internals.Object = class extends Any {
                 delete target[rename.to];
             }
             else if (isRegExRename) {
-                const fromKey = Object.keys(target).find((key) => {
+                const objectKeys = Object.keys(target);
 
-                    return rename.from.test(key);
-                });
+                for ( let i = 0; i < objectKeys.length; ++i) {
+                    if (rename.from.test(objectKeys[i])) {
+                        target[rename.to] = target[objectKeys[i]];
 
-                target[rename.to] = target[fromKey];
-
-                if (!rename.options.override) {
-                    delete target[fromKey];
+                        if (!rename.options.override) {
+                            delete target[objectKeys[i]];
+                        }
+                    }
                 }
-
             }
             else {
                 target[rename.to] = target[rename.from];

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -527,7 +527,7 @@ internals.Object = class extends Any {
 
     rename(from, to, options) {
 
-        Hoek.assert(typeof from === 'string' || typeof from === 'object', 'Rename missing the from argument');
+        Hoek.assert(typeof from === 'string' || from instanceof RegExp, 'Rename missing the from argument');
         Hoek.assert(typeof to === 'string', 'Rename missing the to argument');
         Hoek.assert(to !== from, 'Cannot rename key to same name:', from);
 

--- a/test/index.js
+++ b/test/index.js
@@ -1653,6 +1653,7 @@ describe('Joi', () => {
                 {
                     from: 'renamed',
                     to: 'required',
+                    isRegExp: false,
                     options: {
                         alias: false,
                         multiple: false,

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -812,6 +812,43 @@ describe('object', () => {
                 });
             });
 
+            it('should ignore a key with ignoredUndefined if from does not exist', (done) => {
+
+                const regex = /^b$/i;
+
+                const schema = Joi.object().rename(regex, 'a', { ignoreUndefined: true });
+
+                const input = {
+                    a: 'something'
+                };
+
+                schema.validate(input, (err, value) => {
+
+                    expect(err).to.not.exist();
+                    expect(value).to.equal({ a: 'something' });
+                    done();
+                });
+            });
+
+            it('should rename a key with ignoredUndefined if from does exist', (done) => {
+
+                const regex = /^b$/i;
+
+                const schema = Joi.object().rename(regex, 'a', { ignoreUndefined: true });
+
+                const input = {
+                    c: 'something else',
+                    b: 'something'
+                };
+
+                schema.validate(input, (err, value) => {
+
+                    expect(err).to.not.exist();
+                    expect(value).to.equal({ a: 'something', c: 'something else' });
+                    done();
+                });
+            });
+
             it('shouldn\'t delete a key with override and ignoredUndefined if from does not exist', (done) => {
 
                 const regex = /^b$/i;
@@ -952,7 +989,6 @@ describe('object', () => {
                 done();
             });
         });
-
 
         it('errors multiple times when abortEarly is false', (done) => {
 
@@ -1124,24 +1160,6 @@ describe('object', () => {
         it('should ignore a key with ignoredUndefined if from does not exist', (done) => {
 
             const schema = Joi.object().rename('b', 'a', { ignoreUndefined: true });
-
-            const input = {
-                a: 'something'
-            };
-
-            schema.validate(input, (err, value) => {
-
-                expect(err).to.not.exist();
-                expect(value).to.equal({ a: 'something' });
-                done();
-            });
-        });
-
-        it('using regex it should ignore a key with ignoredUndefined if from does not exist', (done) => {
-
-            const regex = /^b$/i;
-
-            const schema = Joi.object().rename(regex, 'a', { ignoreUndefined: true });
 
             const input = {
                 a: 'something'

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -673,6 +673,21 @@ describe('object', () => {
             });
         });
 
+        it('renames using a regular expression', (done) => {
+
+            const regex = /foobar/i;
+
+            const schema = Joi.object({
+                fooBar: Joi.string()
+            }).rename(regex, 'fooBar');
+
+            Joi.compile(schema).validate({ FOOBAR: 'a' }, (err, value) => {
+
+                expect(err).to.not.exist();
+                done();
+            });
+        });
+
         it('aliases a key', (done) => {
 
             const schema = Joi.object({

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -693,10 +693,11 @@ describe('object', () => {
             const regex = /foobar/i;
 
             const schema = Joi.object({
-                fooBar: Joi.string()
+                fooBar: Joi.string(),
+                fooBaz: Joi.string()
             }).rename(regex, 'fooBar', { override: true });
 
-            Joi.compile(schema).validate({ fooBar: 'a' }, (err, value) => {
+            Joi.compile(schema).validate({ fooBar: 'a', fooBaz: 'b' }, (err, value) => {
 
                 expect(err).to.not.exist();
                 expect(value.fooBar).to.equal('a');

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -812,43 +812,6 @@ describe('object', () => {
                 });
             });
 
-            it('should ignore a key with ignoredUndefined if from does not exist', (done) => {
-
-                const regex = /^b$/i;
-
-                const schema = Joi.object().rename(regex, 'a', { ignoreUndefined: true });
-
-                const input = {
-                    a: 'something'
-                };
-
-                schema.validate(input, (err, value) => {
-
-                    expect(err).to.not.exist();
-                    expect(value).to.equal({ a: 'something' });
-                    done();
-                });
-            });
-
-            it('should rename a key with ignoredUndefined if from does exist', (done) => {
-
-                const regex = /^b$/i;
-
-                const schema = Joi.object().rename(regex, 'a', { ignoreUndefined: true });
-
-                const input = {
-                    c: 'something else',
-                    b: 'something'
-                };
-
-                schema.validate(input, (err, value) => {
-
-                    expect(err).to.not.exist();
-                    expect(value).to.equal({ a: 'something', c: 'something else' });
-                    done();
-                });
-            });
-
             it('shouldn\'t delete a key with override and ignoredUndefined if from does not exist', (done) => {
 
                 const regex = /^b$/i;
@@ -938,27 +901,21 @@ describe('object', () => {
 
                 const schema = Joi.object({
                     fooBar: Joi.string()
-                }).rename(regex, 'fooBar');
+                }).rename(regex, 'fooBar').rename(/foobar/i, 'fooBar');
 
                 Joi.compile(schema).validate({ FOOBAR: 'a', FooBar: 'b' }, (err, value) => {
 
-                    expect(err.message).to.equal('"value" cannot rename child "[FOOBAR, FooBar]" because multiple renames are disabled and another key was already renamed to "fooBar"');
+                    expect(err.message).to.equal('"value" cannot rename child "[fooBar]" because multiple renames are disabled and another key was already renamed to "fooBar"');
                     done();
                 });
             });
 
             it('errors multiple times when abortEarly is false', (done) => {
 
-                const regex = /foobar/i;
-
-                const schema = Joi.object({
-                    fooBar: Joi.string()
-                }).options({ abortEarly: false }).rename(regex, 'fooBar').rename('FooBar', 'fooBar');
-
-                Joi.compile(schema).validate({ FOOBAR: 'a', FooBar: 'b' }, (err, value) => {
+                Joi.object().keys({ z: Joi.string() }).rename(/a/i, 'b').rename(/c/i, 'b').rename(/z/i, 'z').options({ abortEarly: false }).validate({ a: 1, c: 1, d: 1, z: 1 }, (err, value) => {
 
                     expect(err).to.exist();
-                    expect(err.message).to.equal('"value" cannot rename child "[FOOBAR, FooBar]" because multiple renames are disabled and another key was already renamed to "fooBar". "value" cannot rename child "FooBar" because multiple renames are disabled and another key was already renamed to "fooBar"');
+                    expect(err.message).to.equal('"value" cannot rename child "[c]" because multiple renames are disabled and another key was already renamed to "b". "value" cannot rename child "/z/i" because override is disabled and target "z" exists. "d" is not allowed. "b" is not allowed');
                     done();
                 });
             });
@@ -1160,6 +1117,24 @@ describe('object', () => {
         it('should ignore a key with ignoredUndefined if from does not exist', (done) => {
 
             const schema = Joi.object().rename('b', 'a', { ignoreUndefined: true });
+
+            const input = {
+                a: 'something'
+            };
+
+            schema.validate(input, (err, value) => {
+
+                expect(err).to.not.exist();
+                expect(value).to.equal({ a: 'something' });
+                done();
+            });
+        });
+
+        it('using regex it should ignore a key with ignoredUndefined if from does not exist', (done) => {
+
+            const regex = /^b$/i;
+
+            const schema = Joi.object().rename(regex, 'a', { ignoreUndefined: true });
 
             const input = {
                 a: 'something'

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -688,6 +688,22 @@ describe('object', () => {
             });
         });
 
+        it('using regex and override enabled it should allow overwriting existing value', (done) => {
+
+            const regex = /foobar/i;
+
+            const schema = Joi.object({
+                fooBar: Joi.string()
+            }).rename(regex, 'fooBar', { override: true });
+
+            Joi.compile(schema).validate({ fooBar: 'a' }, (err, value) => {
+
+                expect(err).to.not.exist();
+                expect(value.fooBar).to.equal('a');
+                done();
+            });
+        });
+
         it('aliases a key', (done) => {
 
             const schema = Joi.object({

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -688,23 +688,6 @@ describe('object', () => {
             });
         });
 
-        it('using regex and override enabled it should allow overwriting existing value', (done) => {
-
-            const regex = /foobar/i;
-
-            const schema = Joi.object({
-                fooBar: Joi.string(),
-                fooBaz: Joi.string()
-            }).rename(regex, 'fooBar', { override: true });
-
-            Joi.compile(schema).validate({ fooBar: 'a', fooBaz: 'b' }, (err, value) => {
-
-                expect(err).to.not.exist();
-                expect(value.fooBar).to.equal('a');
-                done();
-            });
-        });
-
         it('aliases a key', (done) => {
 
             const schema = Joi.object({
@@ -723,6 +706,24 @@ describe('object', () => {
             });
         });
 
+        it('using regex it aliases a key', (done) => {
+
+            const regex = /^a$/i;
+
+            const schema = Joi.object({
+                a: Joi.number(),
+                b: Joi.number()
+            }).rename(regex, 'b', { alias: true });
+
+            Joi.compile(schema).validate({ A: 100 }, (err, value) => {
+
+                expect(err).to.not.exist();
+                expect(value.a).to.equal(100);
+                expect(value.b).to.equal(100);
+                done();
+            });
+        });
+
         it('with override disabled should not allow overwriting existing value', (done) => {
 
             const schema = Joi.object({
@@ -736,6 +737,20 @@ describe('object', () => {
             });
         });
 
+        it('using regex with override disabled it should not allow overwriting existing value', (done) => {
+
+            const regex = /^test1$/i;
+            const schema = Joi.object({
+                test1: Joi.string()
+            }).rename(regex, 'test1');
+
+            Joi.compile(schema).validate({ test: 'b', test1: 'a' }, (err, value) => {
+
+                expect(err.message).to.equal('"value" cannot rename child "/^test1$/i" because override is disabled and target "test1" exists');
+                done();
+            });
+        });
+
         it('with override enabled should allow overwriting existing value', (done) => {
 
             const schema = Joi.object({
@@ -743,6 +758,21 @@ describe('object', () => {
             }).rename('test', 'test1', { override: true });
 
             schema.validate({ test: 'b', test1: 'a' }, (err, value) => {
+
+                expect(err).to.not.exist();
+                done();
+            });
+        });
+
+        it('using regex with override enabled it should allow overwriting existing value', (done) => {
+
+            const regex = /^test$/i;
+
+            const schema = Joi.object({
+                test1: Joi.string()
+            }).rename(regex, 'test1', { override: true });
+
+            Joi.compile(schema).validate({ test: 'b', test1: 'a' }, (err, value) => {
 
                 expect(err).to.not.exist();
                 done();


### PR DESCRIPTION
This PR extends `Joi.object.rename()` to allow the renaming of key properties via regex. The necessity arose from needing to validate against url query parameters and being case insensitive, while still being able to refer to the param in question in my src code in it's default, expected format.

**Use case:**
client requests...
`base_url/resource?marketCode=191` - camel cased
`base_url/resource?marketcode=191` - lower cased
`base_url/resource?MarketCode=191` - pascal cased

```js
/*...assuming your use case is for api development with hapi, in your handler func you'd be able to reference marketcode in it's format specified in your validation schema */

const marketCodeRegExp = /^marketcode$/i;

config: {
  validate: Joi.object().keys({
    marketCode: Joi.string()
  }).rename(marketCodeRegExp, 'marketCode')
}

//...handler.js
request.query.marketCode /*  would always evaluate to => 191 regardless of what format the parameter sent in */
```


