### PR TITLE
Add `Joi.defaults()`

### DIFF
--- a/API.md
+++ b/API.md
@@ -285,6 +285,28 @@ const schema = Joi.object({ foo: Joi.object({ bar: Joi.number() }) });
 const number = Joi.reach(schema, 'foo.bar');
 ```
 
+### `defaults(fn)`
+
+Creates a new Joi instance that will apply defaults onto newly created schemas through the use of the `fn` function that takes exactly one argument, the schema being created.
+
+The function must always return a schema, even if untransformed.
+
+```js
+const defaultJoi = Joi.defaults((schema) => {
+
+    switch (schema._type) {
+        case 'string':
+            return schema.allow('');
+        case 'object':
+            return schema.min(1);
+        default:
+            return schema;
+    }
+});
+
+const schema = defaultJoi.object(); // Equivalent to a Joi.object().min(1)
+```
+
 ### `extend(extension)`
 
 Creates a new Joi instance customized with the extension(s) you provide included.

--- a/API.md
+++ b/API.md
@@ -294,7 +294,7 @@ The function must always return a schema, even if untransformed.
 ```js
 const defaultJoi = Joi.defaults((schema) => {
 
-    switch (schema._type) {
+    switch (schema.type) {
         case 'string':
             return schema.allow('');
         case 'object':
@@ -414,6 +414,16 @@ Generates a schema object that matches any data type.
 ```js
 const any = Joi.any();
 any.validate('a', (err, value) => { });
+```
+
+#### `type`
+
+Gets the type of the schema.
+
+```js
+const schema = Joi.string();
+
+schema.type === 'string';   // === true
 ```
 
 #### `any.validate(value, [options], [callback])`

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -10,22 +10,10 @@ const Ref = require('./ref');
 
 // Declare internals
 
-const internals = {
-    any: null,
-    date: require('./types/date'),
-    string: require('./types/string'),
-    number: require('./types/number'),
-    boolean: require('./types/boolean'),
-    alt: null,
-    object: null
-};
+const internals = {};
 
 
-exports.schema = function (config) {
-
-    internals.any = internals.any || new (require('./types/any'))();
-    internals.alt = internals.alt || require('./types/alternatives');
-    internals.object = internals.object || require('./types/object');
+exports.schema = function (Joi, config) {
 
     if (config !== undefined && config !== null && typeof config === 'object') {
 
@@ -34,39 +22,39 @@ exports.schema = function (config) {
         }
 
         if (Array.isArray(config)) {
-            return internals.alt.try(config);
+            return Joi.alternatives().try(config);
         }
 
         if (config instanceof RegExp) {
-            return internals.string.regex(config);
+            return Joi.string().regex(config);
         }
 
         if (config instanceof Date) {
-            return internals.date.valid(config);
+            return Joi.date().valid(config);
         }
 
-        return internals.object.keys(config);
+        return Joi.object().keys(config);
     }
 
     if (typeof config === 'string') {
-        return internals.string.valid(config);
+        return Joi.string().valid(config);
     }
 
     if (typeof config === 'number') {
-        return internals.number.valid(config);
+        return Joi.number().valid(config);
     }
 
     if (typeof config === 'boolean') {
-        return internals.boolean.valid(config);
+        return Joi.boolean().valid(config);
     }
 
     if (Ref.isRef(config)) {
-        return internals.any.valid(config);
+        return Joi.valid(config);
     }
 
     Hoek.assert(config === null, 'Invalid schema content:', config);
 
-    return internals.any.valid(null);
+    return Joi.valid(null);
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,76 +23,90 @@ const internals = {
     string: require('./types/string')
 };
 
+internals.applyDefaults = function (schema) {
+
+    if (this._defaults) {
+        schema = this._defaults(schema);
+    }
+
+    schema._currentJoi = this;
+
+    return schema;
+};
 
 internals.root = function () {
 
     const any = new Any();
 
     const root = any.clone();
+    Any.prototype._currentJoi = root;
+
     root.any = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.any() does not allow arguments.');
 
-        return any;
+        return internals.applyDefaults.call(this, any);
     };
 
     root.alternatives = root.alt = function () {
 
-        return arguments.length ? internals.alternatives.try.apply(internals.alternatives, arguments) : internals.alternatives;
+        const alternatives = internals.applyDefaults.call(this, internals.alternatives);
+        return arguments.length ? alternatives.try.apply(alternatives, arguments) : alternatives;
     };
 
     root.array = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.array() does not allow arguments.');
 
-        return internals.array;
+        return internals.applyDefaults.call(this, internals.array);
     };
 
     root.boolean = root.bool = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.boolean() does not allow arguments.');
 
-        return internals.boolean;
+        return internals.applyDefaults.call(this, internals.boolean);
     };
 
     root.binary = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.binary() does not allow arguments.');
 
-        return internals.binary;
+        return internals.applyDefaults.call(this, internals.binary);
     };
 
     root.date = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.date() does not allow arguments.');
 
-        return internals.date;
+        return internals.applyDefaults.call(this, internals.date);
     };
 
     root.func = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.func() does not allow arguments.');
 
-        return internals.object._func();
+        return internals.applyDefaults.call(this, internals.object._func());
     };
 
     root.number = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.number() does not allow arguments.');
 
-        return internals.number;
+        return internals.applyDefaults.call(this, internals.number);
     };
 
     root.object = function () {
 
-        return arguments.length ? internals.object.keys.apply(internals.object, arguments) : internals.object;
+        const object = internals.applyDefaults.call(this, internals.object);
+        return arguments.length ? object.keys.apply(object, arguments) : object;
     };
 
     root.string = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.string() does not allow arguments.');
 
-        return internals.string;
+        return internals.applyDefaults.call(this, internals.string);
     };
 
     root.ref = function () {
@@ -130,7 +144,7 @@ internals.root = function () {
     root.compile = function (schema) {
 
         try {
-            return Cast.schema(schema);
+            return Cast.schema(this, schema);
         }
         catch (err) {
             if (err.hasOwnProperty('path')) {
@@ -197,6 +211,32 @@ internals.root = function () {
     root.lazy = function (fn) {
 
         return Lazy.set(fn);
+    };
+
+    root.defaults = function (fn) {
+
+        Hoek.assert(typeof fn === 'function', 'Defaults must be a function');
+
+        let joi = Object.create(this.any());
+        joi = fn(joi);
+
+        Hoek.assert(joi && joi instanceof this.constructor, 'defaults() must return a schema');
+
+        Object.assign(joi, this, joi.clone()); // Re-add the types from `this` but also keep the settings from joi's potential new defaults
+
+        joi._defaults = (schema) => {
+
+            if (this._defaults) {
+                schema = this._defaults(schema);
+                Hoek.assert(schema instanceof this.constructor, 'defaults() must return a schema');
+            }
+
+            schema = fn(schema);
+            Hoek.assert(schema instanceof this.constructor, 'defaults() must return a schema');
+            return schema;
+        };
+
+        return joi;
     };
 
     root.extend = function () {
@@ -290,7 +330,7 @@ internals.root = function () {
                     const ruleArgs = rule.params ?
                         (rule.params instanceof Any ? rule.params._inner.children.map((k) => k.key) : Object.keys(rule.params)) :
                         [];
-                    const validateArgs = rule.params ? Cast.schema(rule.params) : null;
+                    const validateArgs = rule.params ? Cast.schema(this, rule.params) : null;
 
                     type.prototype[rule.name] = function () { // eslint-disable-line no-loop-func
 
@@ -353,7 +393,7 @@ internals.root = function () {
             const instance = new type();
             joi[extension.name] = function () {
 
-                return instance;
+                return internals.applyDefaults.call(this, instance);
             };
         }
 

--- a/lib/types/alternatives/index.js
+++ b/lib/types/alternatives/index.js
@@ -74,7 +74,7 @@ internals.Alternatives = class extends Any {
         const obj = this.clone();
 
         for (let i = 0; i < schemas.length; ++i) {
-            const cast = Cast.schema(schemas[i]);
+            const cast = Cast.schema(this._currentJoi, schemas[i]);
             if (cast._refs.length) {
                 obj._refs = obj._refs.concat(cast._refs);
             }
@@ -93,7 +93,7 @@ internals.Alternatives = class extends Any {
         Hoek.assert(options.then !== undefined || options.otherwise !== undefined, 'options must have at least one of "then" or "otherwise"');
 
         const obj = this.clone();
-        let is = Cast.schema(options.is);
+        let is = Cast.schema(this._currentJoi, options.is);
 
         if (options.is === null || !(Ref.isRef(options.is) || options.is instanceof Any)) {
 
@@ -104,8 +104,8 @@ internals.Alternatives = class extends Any {
         const item = {
             ref: Cast.ref(ref),
             is,
-            then: options.then !== undefined ? Cast.schema(options.then) : undefined,
-            otherwise: options.otherwise !== undefined ? Cast.schema(options.otherwise) : undefined
+            then: options.then !== undefined ? Cast.schema(this._currentJoi, options.then) : undefined,
+            otherwise: options.otherwise !== undefined ? Cast.schema(this._currentJoi, options.otherwise) : undefined
         };
 
         if (obj._baseType) {

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -95,6 +95,7 @@ module.exports = internals.Any = class {
         const obj = Object.create(Object.getPrototypeOf(this));
 
         obj.isJoi = true;
+        obj._currentJoi = this._currentJoi;
         obj._type = this._type;
         obj._settings = internals.concatSettings(this._settings);
         obj._baseType = this._baseType;
@@ -369,7 +370,7 @@ module.exports = internals.Any = class {
     empty(schema) {
 
         const obj = this.clone();
-        obj._flags.empty = schema === undefined ? undefined : Cast.schema(schema);
+        obj._flags.empty = schema === undefined ? undefined : Cast.schema(this._currentJoi, schema);
         return obj;
     }
 
@@ -378,8 +379,8 @@ module.exports = internals.Any = class {
         Hoek.assert(options && typeof options === 'object', 'Invalid options');
         Hoek.assert(options.then !== undefined || options.otherwise !== undefined, 'options must have at least one of "then" or "otherwise"');
 
-        const then = options.hasOwnProperty('then') ? this.concat(Cast.schema(options.then)) : undefined;
-        const otherwise = options.hasOwnProperty('otherwise') ? this.concat(Cast.schema(options.otherwise)) : undefined;
+        const then = options.hasOwnProperty('then') ? this.concat(Cast.schema(this._currentJoi, options.then)) : undefined;
+        const otherwise = options.hasOwnProperty('otherwise') ? this.concat(Cast.schema(this._currentJoi, options.otherwise)) : undefined;
 
         Alternatives = Alternatives || require('../alternatives');
         const obj = Alternatives.when(ref, { is: options.is, then, otherwise });

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -71,6 +71,11 @@ module.exports = internals.Any = class {
         this._inner = {};                           // Hash of arrays of immutable objects
     }
 
+    get type() {
+
+        return this._type;
+    }
+
     createError(type, context, state, options) {
 
         return Errors.create(type, context, state, options, this._flags);

--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -335,7 +335,7 @@ internals.Array = class extends Any {
         Hoek.flatten(Array.prototype.slice.call(arguments)).forEach((type, index) => {
 
             try {
-                type = Cast.schema(type);
+                type = Cast.schema(this._currentJoi, type);
             }
             catch (castErr) {
                 if (castErr.hasOwnProperty('path')) {
@@ -371,7 +371,7 @@ internals.Array = class extends Any {
         Hoek.flatten(Array.prototype.slice.call(arguments)).forEach((type, index) => {
 
             try {
-                type = Cast.schema(type);
+                type = Cast.schema(this._currentJoi, type);
             }
             catch (castErr) {
                 if (castErr.hasOwnProperty('path')) {

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -306,7 +306,7 @@ internals.Object = class extends Any {
             const key = children[i];
             const child = schema[key];
             try {
-                const cast = Cast.schema(child);
+                const cast = Cast.schema(this._currentJoi, child);
                 topo.add({ key, schema: cast }, { after: cast._refs, group: key });
             }
             catch (castErr) {
@@ -430,7 +430,7 @@ internals.Object = class extends Any {
         pattern = new RegExp(pattern.source, pattern.ignoreCase ? 'i' : undefined);         // Future version should break this and forbid unsupported regex flags
 
         try {
-            schema = Cast.schema(schema);
+            schema = Cast.schema(this._currentJoi, schema);
         }
         catch (castErr) {
             if (castErr.hasOwnProperty('path')) {
@@ -641,7 +641,7 @@ internals.Object = class extends Any {
         message = message || 'pass the assertion test';
 
         try {
-            schema = Cast.schema(schema);
+            schema = Cast.schema(this._currentJoi, schema);
         }
         catch (castErr) {
             if (castErr.hasOwnProperty('path')) {

--- a/test/index.js
+++ b/test/index.js
@@ -1878,7 +1878,7 @@ describe('Joi', () => {
 
             const a = Joi.number();
             const schema = Joi.object().keys({ a });
-            expect(Joi.reach(schema, 'a')).to.equal(a);
+            expect(Joi.reach(schema, 'a')).to.shallow.equal(a);
             done();
         });
 
@@ -1893,7 +1893,7 @@ describe('Joi', () => {
 
             const bar = Joi.number();
             const schema = Joi.object({ foo: Joi.object({ bar }) });
-            expect(Joi.reach(schema, 'foo.bar')).to.equal(bar);
+            expect(Joi.reach(schema, 'foo.bar')).to.shallow.equal(bar);
             done();
         });
 
@@ -2992,5 +2992,219 @@ describe('Joi', () => {
             done();
         });
 
+    });
+
+    describe('defaults()', () => {
+
+        it('should apply defaults to joi itself', (done) => {
+
+            const defaultJoi = Joi.defaults((schema) => schema.required().description('defaulted'));
+            const schema = defaultJoi.optional();
+            expect(schema.describe()).to.equal({
+                type: 'any',
+                description: 'defaulted',
+                flags: {
+                    presence: 'optional'
+                }
+            });
+            done();
+        });
+
+        it('should apply defaults to standard types', (done) => {
+
+            const defaultJoi = Joi.defaults((schema) => schema.required().description('defaulted'));
+            const schema = defaultJoi.string();
+            expect(schema.describe()).to.equal({
+                type: 'string',
+                invalids: [''],
+                description: 'defaulted',
+                flags: {
+                    presence: 'required'
+                }
+            });
+            done();
+        });
+
+        it('should apply defaults to types with arguments', (done) => {
+
+            const defaultJoi = Joi.defaults((schema) => schema.required().description('defaulted'));
+            const schema = defaultJoi.object({ foo: 'bar' });
+            expect(schema.describe()).to.equal({
+                type: 'object',
+                description: 'defaulted',
+                flags: {
+                    presence: 'required'
+                },
+                children: {
+                    foo: {
+                        type: 'string',
+                        description: 'defaulted',
+                        flags: {
+                            presence: 'required',
+                            allowOnly: true
+                        },
+                        invalids: [''],
+                        valids: ['bar']
+                    }
+                }
+            });
+            done();
+        });
+
+        it('should keep several defaults separated', (done) => {
+
+            const defaultJoi = Joi.defaults((schema) => schema.required().description('defaulted'));
+            const defaultJoi2 = Joi.defaults((schema) => schema.required().description('defaulted2'));
+            const schema = defaultJoi.object({
+                foo: 'bar',
+                baz: defaultJoi2.object().keys({
+                    qux: 'zorg'
+                })
+            });
+            expect(schema.describe()).to.equal({
+                type: 'object',
+                description: 'defaulted',
+                flags: {
+                    presence: 'required'
+                },
+                children: {
+                    foo: {
+                        type: 'string',
+                        description: 'defaulted',
+                        flags: {
+                            presence: 'required',
+                            allowOnly: true
+                        },
+                        invalids: [''],
+                        valids: ['bar']
+                    },
+                    baz: {
+                        children: {
+                            qux: {
+                                description: 'defaulted2',
+                                flags: {
+                                    allowOnly: true,
+                                    presence: 'required'
+                                },
+                                invalids: [''],
+                                type: 'string',
+                                valids: ['zorg']
+                            }
+                        },
+                        description: 'defaulted2',
+                        flags: {
+                            presence: 'required'
+                        },
+                        type: 'object'
+                    }
+
+                }
+            });
+            done();
+        });
+
+        it('should deal with inherited defaults', (done) => {
+
+            const defaultJoi = Joi
+                .defaults((schema) => schema.required().description('defaulted'))
+                .defaults((schema) => schema.raw());
+            const schema = defaultJoi.object({
+                foo: 'bar'
+            });
+            expect(schema.describe()).to.equal({
+                type: 'object',
+                description: 'defaulted',
+                flags: {
+                    presence: 'required',
+                    raw: true
+                },
+                children: {
+                    foo: {
+                        type: 'string',
+                        description: 'defaulted',
+                        flags: {
+                            presence: 'required',
+                            allowOnly: true,
+                            raw: true
+                        },
+                        invalids: [''],
+                        valids: ['bar']
+                    }
+                }
+            });
+            done();
+        });
+
+        it('should keep defaults on an extended joi', (done) => {
+
+            const defaultJoi = Joi.defaults((schema) => schema.required().description('defaulted'));
+            const extendedJoi = defaultJoi.extend({ name: 'foobar' });
+            const schema = extendedJoi.foobar();
+            expect(schema.describe()).to.equal({
+                type: 'foobar',
+                description: 'defaulted',
+                flags: {
+                    presence: 'required'
+                }
+            });
+            done();
+        });
+
+        it('should apply defaults on an extended joi', (done) => {
+
+            const extendedJoi = Joi.extend({ name: 'foobar' });
+            const defaultJoi = extendedJoi.defaults((schema) => schema.required().description('defaulted'));
+            const schema = defaultJoi.foobar();
+            expect(schema.describe()).to.equal({
+                type: 'foobar',
+                description: 'defaulted',
+                flags: {
+                    presence: 'required'
+                }
+            });
+            done();
+        });
+
+        it('should fail on missing return for any', (done) => {
+
+            expect(() => {
+
+                return Joi.defaults((schema) => {
+
+                    switch (schema._type) {
+                        case 'bool':
+                            return schema.required();
+                    }
+                });
+            }).to.throw('defaults() must return a schema');
+            done();
+        });
+
+        it('should fail on missing return for a standard type', (done) => {
+
+            const defaultJoi = Joi.defaults((schema) => {
+
+                switch (schema._type) {
+                    case 'any':
+                        return schema.required();
+                }
+            });
+            expect(() => defaultJoi.string()).to.throw('defaults() must return a schema');
+            done();
+        });
+
+        it('should fail on missing return for a standard type on an inherited default', (done) => {
+
+            const defaultJoi = Joi.defaults((schema) => {
+
+                switch (schema._type) {
+                    case 'any':
+                        return schema.required();
+                }
+            });
+            const defaultJoi2 = defaultJoi.defaults((schema) => schema.required());
+            expect(() => defaultJoi2.string()).to.throw('defaults() must return a schema');
+            done();
+        });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -3171,7 +3171,7 @@ describe('Joi', () => {
 
                 return Joi.defaults((schema) => {
 
-                    switch (schema._type) {
+                    switch (schema.type) {
                         case 'bool':
                             return schema.required();
                     }
@@ -3184,7 +3184,7 @@ describe('Joi', () => {
 
             const defaultJoi = Joi.defaults((schema) => {
 
-                switch (schema._type) {
+                switch (schema.type) {
                     case 'any':
                         return schema.required();
                 }
@@ -3197,7 +3197,7 @@ describe('Joi', () => {
 
             const defaultJoi = Joi.defaults((schema) => {
 
-                switch (schema._type) {
+                switch (schema.type) {
                     case 'any':
                         return schema.required();
                 }


### PR DESCRIPTION
Here's a feature that has been requested previously (sorry can't find the issues) and I've been thinking about how to expose it, so this PR is my proposal. Let me know what you think.

~I know accessing the `_type` is meh, but I doubt it will change and doing `schema instanceof Joi.object().constructor` is a bit tedious. Maybe type could be exposed through a getter...~