### PR TITLE
Bump to 10.7.0 to accomodate isemail v3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joi",
   "description": "Object schema validation",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "homepage": "https://github.com/hapijs/joi",
   "repository": "git://github.com/hapijs/joi",
   "main": "lib/index.js",


### PR DESCRIPTION
The change in ismemail from `v2.x.x` to `v3.x.x` was a siginificant change in that it deprecated the requirement for the `dns` module: https://github.com/hapijs/isemail/pull/153 Therefore `joi` requires a minor version increment.