### PR TITLE
disable required by argument

### DIFF
--- a/API.md
+++ b/API.md
@@ -505,6 +505,11 @@ Marks a key as required which will not allow `undefined` as value. All keys are 
 const schema = Joi.any().required();
 ```
 
+It is also possible to use required dynamically. If you pass false as argument the key is optional. 
+```js
+const schema = Joi.any().required(false);
+```
+
 #### `any.optional()`
 
 Marks a key as optional which will allow `undefined` as values. Used to annotate the schema for readability as all keys are optional by default.

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -286,9 +286,13 @@ module.exports = internals.Any = class {
         return obj;
     }
 
-    required() {
+    required(isRequired) {
 
         if (this._flags.presence === 'required') {
+            return this;
+        }
+
+        if (isRequired === false){
             return this;
         }
 

--- a/test/types/any.js
+++ b/test/types/any.js
@@ -2255,6 +2255,20 @@ describe('any', () => {
                     done();
                 });
             });
+
+            it('should ignore a value defined with required(false)', (done) => {
+
+                const schema = Joi.object({
+                    a: Joi.any().required(false),
+                    b: Joi.any()
+                });
+
+                Joi.validate({ b: 'abc' }, schema, { abortEarly: false }, (err) => {
+
+                    expect(err).to.be.null();
+                    done();
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
I want to add a parameter to the required method to 'disable' it programatically.

The reason for that is that I want to use the same validation schema for POST and PATCH methods with hapi. With this approach I can do the following but it does not break any previous functionality:

    module.exports = (required) => Joi.object({
        a: Joi.string().required(required)
    });

And use it in my route definitions like this: 

    {
        method: 'POST',
        path: '/pets',
        config: {
            handler: (request, reply) => {},
            validate: {
                payload: ProjectType()
            }
        }
    }
    {
        method: 'PUT',
        path: '/pets/{id}',
        config: {
            handler: (request, reply) => {},
            validate: {
                payload: ProjectType(false)
            }
        }
    }

Is there another approach to handle this? I want to avoid to duplicate the validation schemas where the only difference is that for one the fields are required and for the other not.