### PR TITLE
fix object.type assertion to accept protoype objects without a constructor function

### DIFF
--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -670,7 +670,8 @@ internals.Object = class extends Any {
 
     type(constructor, name) {
 
-        Hoek.assert(typeof constructor === 'function', 'type must be a constructor function');
+        const ctorType = typeof constructor;
+        Hoek.assert(ctorType === 'function' || ctorType === 'object', 'type must be a constructor');
         const typeData = {
             name: name || constructor.name,
             ctor: constructor

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1495,7 +1495,7 @@ describe('object', () => {
             expect(() => {
 
                 Joi.object().type('');
-            }).to.throw('type must be a constructor function');
+            }).to.throw('type must be a constructor');
             done();
         });
 


### PR DESCRIPTION
Some prototype objects do not offer a default constructor function,  such as _Element_ and descendants in some browsers (i.e. IE/Edge; though likely other examples involving native code can be found). In this case the type of the prototype object is just 'object', not 'function', which currently triggers an assertion exception when passed into Joi.object().type().

This PR fixes the issue by allowing for objects of type 'object'. 