### PR TITLE
Add ES6 class validation

### DIFF
--- a/API.md
+++ b/API.md
@@ -64,6 +64,7 @@
     - [`binary.min(limit)`](#binaryminlimit)
     - [`binary.max(limit)`](#binarymaxlimit)
     - [`binary.length(limit)`](#binarylengthlimit)
+  - [`class` - inherits from `Any`](#class---inherits-from-any)
   - [`date` - inherits from `Any`](#date---inherits-from-any)
     - [`date.min(date)`](#datemindate)
     - [`date.max(date)`](#datemaxdate)
@@ -1059,6 +1060,15 @@ Specifies the exact length of the buffer:
 
 ```js
 const schema = Joi.binary().length(5);
+```
+
+### `class` - inherits from `Any`
+
+Generates a schema object that matches an ES6 class type.
+
+```js
+const _class = Joi.class();
+_class.validate(class MyClass {}, (err, value) => { });
 ```
 
 ### `date` - inherits from `Any`

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -4,6 +4,7 @@
 
 const Hoek = require('hoek');
 const Language = require('./language');
+const IsClass = require('./is-class');
 
 
 // Declare internals
@@ -25,6 +26,7 @@ internals.stringify = function (value, wrapArrays) {
     }
 
     if (value instanceof exports.Err || type === 'function' || type === 'symbol') {
+
         return value.toString();
     }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -4,7 +4,6 @@
 
 const Hoek = require('hoek');
 const Language = require('./language');
-const IsClass = require('./is-class');
 
 
 // Declare internals

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -26,7 +26,6 @@ internals.stringify = function (value, wrapArrays) {
     }
 
     if (value instanceof exports.Err || type === 'function' || type === 'symbol') {
-
         return value.toString();
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,13 @@ internals.root = function () {
         return internals.applyDefaults.call(this, internals.object._func());
     };
 
+    root.class = function () {
+
+        Hoek.assert(arguments.length === 0, 'Joi.class() does not allow arguments.');
+
+        return internals.applyDefaults.call(this, internals.object._class());
+    };
+
     root.number = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.number() does not allow arguments.');

--- a/lib/is-class.js
+++ b/lib/is-class.js
@@ -1,2 +1,3 @@
+'use strict';
 
 module.exports = (func) => (/^\s*class\s/).test(func.toString());

--- a/lib/is-class.js
+++ b/lib/is-class.js
@@ -1,0 +1,2 @@
+
+module.exports = (func) => (/^\s*class\s/).test(func.toString());

--- a/lib/language.js
+++ b/lib/language.js
@@ -55,6 +55,10 @@ exports.errors = {
         max: 'must be less than or equal to {{limit}} bytes',
         length: 'must be {{limit}} bytes'
     },
+    class: {
+        base: 'must be an ES6 class',
+        ref: 'must be a Joi reference'
+    },
     date: {
         base: 'must be a number of milliseconds or valid date string',
         format: 'must be a string with one of the following formats {{format}}',

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -5,6 +5,7 @@
 const Hoek = require('hoek');
 const Ref = require('../../ref');
 const Errors = require('../../errors');
+const IsClass = require('../../is-class');
 let Alternatives = null;                // Delay-loaded to prevent circular dependencies
 let Cast = null;
 
@@ -361,8 +362,8 @@ module.exports = internals.Any = class {
                 value.description = description;
             }
 
-            if (!this._flags.func) {
-                Hoek.assert(typeof value.description === 'string' && value.description.length > 0, 'description must be provided when default value is a function');
+            if (!this._flags.func && !this._flags.class) {
+                Hoek.assert(typeof value.description === 'string' && value.description.length > 0, 'description must be provided when default value is a function or class');
             }
         }
 
@@ -487,7 +488,7 @@ module.exports = internals.Any = class {
                 finalValue = this._flags.default(state.parent, options);
             }
             else if (typeof this._flags.default === 'function' &&
-                !(this._flags.func && !this._flags.default.description)) {
+                !((this._flags.class || this._flags.func) && !this._flags.default.description)) {
 
                 let args;
 
@@ -839,7 +840,12 @@ internals._try = function (fn, args) {
     let result;
 
     try {
-        result = fn.apply(null, args);
+        if (IsClass(fn)) {
+            result = new fn(args);
+        }
+        else {
+            result = fn.apply(null, args);
+        }
     }
     catch (e) {
         err = e;

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -5,7 +5,6 @@
 const Hoek = require('hoek');
 const Ref = require('../../ref');
 const Errors = require('../../errors');
-const IsClass = require('../../is-class');
 let Alternatives = null;                // Delay-loaded to prevent circular dependencies
 let Cast = null;
 

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -840,12 +840,7 @@ internals._try = function (fn, args) {
     let result;
 
     try {
-        if (IsClass(fn)) {
-            result = new fn(args);
-        }
-        else {
-            result = fn.apply(null, args);
-        }
+        result = fn.apply(null, args);
     }
     catch (e) {
         err = e;

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -8,7 +8,7 @@ const Any = require('../any');
 const Errors = require('../../errors');
 const Cast = require('../../cast');
 const Ref = require('../../ref');
-
+const IsClass = require('../../is-class');
 
 // Declare internals
 
@@ -45,9 +45,24 @@ internals.Object = class extends Any {
             value = internals.safeParse(value);
         }
 
-        const type = this._flags.func ? 'function' : 'object';
+        let type;
+        let typeMatches;
+
+        if (this._flags.func) {
+            type = 'function';
+            typeMatches = typeof value === type && !IsClass(value);
+        }
+        else if (this._flags.class) {
+            type = 'class';
+            typeMatches = IsClass(value);
+        }
+        else {
+            type = 'object';
+            typeMatches = typeof value === type;
+        }
+
         if (!value ||
-            typeof value !== type ||
+            !typeMatches ||
             Array.isArray(value)) {
 
             errors.push(this.createError(type + '.base', null, state, options));
@@ -268,6 +283,13 @@ internals.Object = class extends Any {
 
         const obj = this.clone();
         obj._flags.func = true;
+        return obj;
+    }
+
+    _class() {
+
+        const obj = this.clone();
+        obj._flags.class = true;
         return obj;
     }
 

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2222,15 +2222,17 @@ describe('object', () => {
 
                 expect(value._class.constructor).to.equal(defaultClass.constructor);
 
+                const valueClassInstance = new value._class();
+
                 expect(valueClassInstance.constructor.name).to.equal(defaultClassInstance.constructor.name);
 
                 schema.validate({ _class: class NewClass {} }, (err, _value) => {
 
                     expect(err).to.not.exist();
 
-                    const valueClassInstance = new _value._class();
+                    const _valueClassInstance = new _value._class();
 
-                    expect(valueClassInstance.constructor.name).to.not.equal(defaultClassInstance.constructor.name);
+                    expect(_valueClassInstance.constructor.name).to.not.equal(defaultClassInstance.constructor.name);
 
                     done();
                 });

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2167,17 +2167,28 @@ describe('object', () => {
 
         it('should differentiate between ES6 classes and functions', (done) => {
 
-            const schema = Joi.object({
+            const classSchema = Joi.object({
                 _class: Joi.class()
             });
 
-            const testFunc = function() {};
+            const funcSchema = Joi.object({
+                _func: Joi.func()
+            });
 
-            schema.validate({ _class: testFunc }, (err, value) => {
+            const testFunc = function() {};
+            const testClass = class MyClass {};
+
+            classSchema.validate({ _class: testFunc }, (err, value) => {
 
                 expect(err).to.exist();
                 expect(err.message).to.equal('child "_class" fails because ["_class" must be an ES6 class]');
-                done();
+
+                funcSchema.validate({ _func: testClass }, (err, value) => {
+
+                    expect(err).to.exist();
+                    expect(err.message).to.equal('child "_func" fails because ["_func" must be a Function]');
+                    done();
+                });
             });
         });
 

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2206,6 +2206,38 @@ describe('object', () => {
                 done();
             });
         });
+
+        it('works with default', (done) => {
+
+            const defaultClass = class MyClass {};
+            const defaultClassInstance = new defaultClass();
+
+            const schema = Joi.object({
+                _class: Joi.class().default(defaultClass)
+            });
+
+            schema.validate({}, (err, value) => {
+
+                expect(err).to.not.exist();
+
+                expect(value._class.constructor).to.equal(defaultClass.constructor);
+
+                const valueClassInstance = new value._class();
+
+                expect(valueClassInstance.constructor.name).to.equal(defaultClassInstance.constructor.name);
+
+                schema.validate({ _class: class NewClass {} }, (err, value) => {
+
+                    expect(err).to.not.exist();
+
+                    const valueClassInstance = new value._class();
+
+                    expect(valueClassInstance.constructor.name).to.not.equal(defaultClassInstance.constructor.name);
+
+                    done();
+                });
+            });
+        });
     });
 
     describe('requiredKeys()', () => {

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2175,7 +2175,7 @@ describe('object', () => {
                 _func: Joi.func()
             });
 
-            const testFunc = function() {};
+            const testFunc = function () {};
             const testClass = class MyClass {};
 
             classSchema.validate({ _class: testFunc }, (err, value) => {
@@ -2222,15 +2222,13 @@ describe('object', () => {
 
                 expect(value._class.constructor).to.equal(defaultClass.constructor);
 
-                const valueClassInstance = new value._class();
-
                 expect(valueClassInstance.constructor.name).to.equal(defaultClassInstance.constructor.name);
 
-                schema.validate({ _class: class NewClass {} }, (err, value) => {
+                schema.validate({ _class: class NewClass {} }, (err, _value) => {
 
                     expect(err).to.not.exist();
 
-                    const valueClassInstance = new value._class();
+                    const valueClassInstance = new _value._class();
 
                     expect(valueClassInstance.constructor.name).to.not.equal(defaultClassInstance.constructor.name);
 

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2183,7 +2183,7 @@ describe('object', () => {
                 expect(err).to.exist();
                 expect(err.message).to.equal('child "_class" fails because ["_class" must be an ES6 class]');
 
-                funcSchema.validate({ _func: testClass }, (err, value) => {
+                funcSchema.validate({ _func: testClass }, (err, _value) => {
 
                     expect(err).to.exist();
                     expect(err.message).to.equal('child "_func" fails because ["_func" must be a Function]');

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2163,6 +2163,40 @@ describe('object', () => {
 
     });
 
+    describe('ES6 Classes', () => {
+
+        it('should differentiate between ES6 classes and functions', (done) => {
+
+            const schema = Joi.object({
+                _class: Joi.class()
+            });
+
+            const testFunc = function() {};
+
+            schema.validate({ _class: testFunc }, (err, value) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('child "_class" fails because ["_class" must be an ES6 class]');
+                done();
+            });
+        });
+
+        it('validates an ES6 class', (done) => {
+
+            const schema = Joi.object({
+                _class: Joi.class()
+            });
+
+            const testClass = class MyClass {};
+
+            schema.validate({ _class: testClass }, (err, value) => {
+
+                expect(err).to.not.exist();
+                done();
+            });
+        });
+    });
+
     describe('requiredKeys()', () => {
 
         it('should set keys as required', (done) => {
@@ -2223,7 +2257,7 @@ describe('object', () => {
 
         it('should work on types other than objects', (done) => {
 
-            const schemas = [Joi.array(), Joi.binary(), Joi.boolean(), Joi.date(), Joi.func(), Joi.number(), Joi.string()];
+            const schemas = [Joi.array(), Joi.binary(), Joi.boolean(), Joi.date(), Joi.func(), Joi.class(), Joi.number(), Joi.string()];
             schemas.forEach((schema) => {
 
                 expect(() => {


### PR DESCRIPTION
- Add Joi.class()
- Ensure regular functions are not valid as Joi.class()
- Ensure ES6 classes are not valid as Joi.func()
- Ensure ES6 classes validate correctly with Joi.class()

BREAKING CHANGE: `joi` users might have been passing in ES6 classes to `Joi.func()`, and this will cause a validation error now.