### PR TITLE
Allow calling root methods directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ const internals = {
 
 internals.applyDefaults = function (joi, schema) {
 
-    joi = joi || module.exports._currentJoi;
+    Hoek.assert(joi, 'Must be invoked on a Joi instance.');
 
     if (joi._defaults) {
         schema = joi._defaults(schema);

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,13 +23,15 @@ const internals = {
     string: require('./types/string')
 };
 
-internals.applyDefaults = function (schema) {
+internals.applyDefaults = function (joi, schema) {
 
-    if (this._defaults) {
-        schema = this._defaults(schema);
+    joi = joi || module.exports._currentJoi;
+
+    if (joi._defaults) {
+        schema = joi._defaults(schema);
     }
 
-    schema._currentJoi = this;
+    schema._currentJoi = joi;
 
     return schema;
 };
@@ -46,12 +48,12 @@ internals.root = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.any() does not allow arguments.');
 
-        return internals.applyDefaults.call(this, any);
+        return internals.applyDefaults(this, any);
     };
 
     root.alternatives = root.alt = function () {
 
-        const alternatives = internals.applyDefaults.call(this, internals.alternatives);
+        const alternatives = internals.applyDefaults(this, internals.alternatives);
         return arguments.length ? alternatives.try.apply(alternatives, arguments) : alternatives;
     };
 
@@ -59,47 +61,47 @@ internals.root = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.array() does not allow arguments.');
 
-        return internals.applyDefaults.call(this, internals.array);
+        return internals.applyDefaults(this, internals.array);
     };
 
     root.boolean = root.bool = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.boolean() does not allow arguments.');
 
-        return internals.applyDefaults.call(this, internals.boolean);
+        return internals.applyDefaults(this, internals.boolean);
     };
 
     root.binary = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.binary() does not allow arguments.');
 
-        return internals.applyDefaults.call(this, internals.binary);
+        return internals.applyDefaults(this, internals.binary);
     };
 
     root.date = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.date() does not allow arguments.');
 
-        return internals.applyDefaults.call(this, internals.date);
+        return internals.applyDefaults(this, internals.date);
     };
 
     root.func = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.func() does not allow arguments.');
 
-        return internals.applyDefaults.call(this, internals.object._func());
+        return internals.applyDefaults(this, internals.object._func());
     };
 
     root.number = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.number() does not allow arguments.');
 
-        return internals.applyDefaults.call(this, internals.number);
+        return internals.applyDefaults(this, internals.number);
     };
 
     root.object = function () {
 
-        const object = internals.applyDefaults.call(this, internals.object);
+        const object = internals.applyDefaults(this, internals.object);
         return arguments.length ? object.keys.apply(object, arguments) : object;
     };
 
@@ -107,7 +109,7 @@ internals.root = function () {
 
         Hoek.assert(arguments.length === 0, 'Joi.string() does not allow arguments.');
 
-        return internals.applyDefaults.call(this, internals.string);
+        return internals.applyDefaults(this, internals.string);
     };
 
     root.ref = function () {
@@ -216,6 +218,7 @@ internals.root = function () {
 
     root.defaults = function (fn) {
 
+        Hoek.assert(this instanceof module.exports.constructor, 'defaults() must be called on a Joi instance');
         Hoek.assert(typeof fn === 'function', 'Defaults must be a function');
 
         let joi = Object.create(this.any());
@@ -241,6 +244,8 @@ internals.root = function () {
     };
 
     root.extend = function () {
+
+        Hoek.assert(this instanceof module.exports.constructor, 'extend() must be called on a Joi instance');
 
         const extensions = Hoek.flatten(Array.prototype.slice.call(arguments));
         Hoek.assert(extensions.length > 0, 'You need to provide at least one extension');
@@ -394,7 +399,7 @@ internals.root = function () {
             const instance = new type();
             joi[extension.name] = function () {
 
-                return internals.applyDefaults.call(this, instance);
+                return internals.applyDefaults(this, instance);
             };
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -3091,6 +3091,16 @@ describe('Joi', () => {
 
     describe('extend()', () => {
 
+        it('should fail when called without object', (done) => {
+
+            expect(() => {
+
+                const extend = Joi.extend;
+                return extend();
+            }).to.throw('extend() must be called on a Joi instance');
+            done();
+        });
+
         describe('parameters', () => {
 
             it('must be an object or array of objects', (done) => {
@@ -4383,6 +4393,16 @@ describe('Joi', () => {
                     }
                 });
             }).to.throw('defaults() must return a schema');
+            done();
+        });
+
+        it('should fail when called without object', (done) => {
+
+            expect(() => {
+
+                const defaults = Joi.defaults;
+                return defaults((schema) => schema);
+            }).to.throw('defaults() must be called on a Joi instance');
             done();
         });
 

--- a/test/types/any.js
+++ b/test/types/any.js
@@ -31,6 +31,14 @@ describe('any', () => {
         done();
     });
 
+    it('handles being called on a null object.', (done) => {
+
+        const any = Joi.any;
+        expect(any()).to.be.instanceOf(Joi.constructor);
+
+        done();
+    });
+
     describe('equal()', () => {
 
         it('validates valid values', (done) => {

--- a/test/types/any.js
+++ b/test/types/any.js
@@ -31,10 +31,13 @@ describe('any', () => {
         done();
     });
 
-    it('handles being called on a null object.', (done) => {
+    it('throws an exception if called on a null object.', (done) => {
 
         const any = Joi.any;
-        expect(any()).to.be.instanceOf(Joi.constructor);
+
+        expect(
+            () => any()
+        ).to.throw('Must be invoked on a Joi instance.');
 
         done();
     });


### PR DESCRIPTION
Also throws an explicit message, if user tries to call `defaults()` or `extend()` without an object.