### PR TITLE
add boolean type trueValue & falseValue convert

### DIFF
--- a/lib/types/boolean/index.js
+++ b/lib/types/boolean/index.js
@@ -19,6 +19,8 @@ internals.Boolean = class extends Any {
         super();
         this._type = 'boolean';
         this._flags.insensitive = true;
+        this._flags.trueValue = true;
+        this._flags.falseValue = false;
         this._inner.truthySet = new internals.Set();
         this._inner.falsySet = new internals.Set();
     }
@@ -43,6 +45,7 @@ internals.Boolean = class extends Any {
         }
 
         result.errors = (typeof result.value === 'boolean') ? null : this.createError('boolean.base', null, state, options);
+        result.value = (typeof result.value === 'boolean') ? (result.value ? this._flags.trueValue : this._flags.falseValue) : result.value;
         return result;
     }
 
@@ -91,6 +94,26 @@ internals.Boolean = class extends Any {
         description.truthy = [true].concat(this._inner.truthySet.values());
         description.falsy = [false].concat(this._inner.falsySet.values());
         return description;
+    }
+
+    trueValue(value) {
+
+        if (this._flags.trueValue === value) {
+            return this;
+        }
+        const obj = this.clone();
+        obj._flags.trueValue = value;
+        return obj;
+    }
+
+    falseValue(value) {
+
+        if (this._flags.falseValue === value) {
+            return this;
+        }
+        const obj = this.clone();
+        obj._flags.falseValue = value;
+        return obj;
     }
 };
 

--- a/test/types/alternatives.js
+++ b/test/types/alternatives.js
@@ -1023,7 +1023,7 @@ describe('alternatives', () => {
                     },
                     otherwise: {
                         type: 'boolean',
-                        flags: { insensitive: true },
+                        flags: { insensitive: true, trueValue: true, falseValue: false },
                         truthy: [true],
                         falsy: [false]
                     }

--- a/test/types/array.js
+++ b/test/types/array.js
@@ -1111,7 +1111,7 @@ describe('array', () => {
                 items: [
                     { type: 'number', invalids: [Infinity, -Infinity] },
                     { type: 'string', invalids: [''] },
-                    { type: 'boolean', flags: { presence: 'forbidden', insensitive: true }, truthy: [true], falsy: [false] }
+                    { type: 'boolean', flags: { presence: 'forbidden', insensitive: true, trueValue: true, falseValue: false }, truthy: [true], falsy: [false] }
                 ]
             });
 

--- a/test/types/boolean.js
+++ b/test/types/boolean.js
@@ -644,12 +644,49 @@ describe('boolean', () => {
                 type: 'boolean',
                 flags: {
                     presence: 'required',
-                    insensitive: true
+                    insensitive: true,
+                    trueValue: true,
+                    falseValue: false
                 },
                 truthy: [true, 'yes'],
                 falsy: [false, 'no']
             });
             done();
+        });
+
+        it('should convert to trueValue & falseValue', (done) => {
+
+            const noTrueFalseValue = Joi.boolean().trueValue(true).falseValue(false);
+            const setTrueFalseValueToTinyInt = Joi.boolean().truthy('yes').falsy('no').trueValue(1).falseValue(0);
+            const setTrueFalseValueToString = Joi.boolean().trueValue('yeap').falseValue('none');
+            expect(setTrueFalseValueToString.describe()).to.equal({
+                type: 'boolean',
+                flags: {
+                    insensitive: true,
+                    trueValue: 'yeap',
+                    falseValue: 'none'
+                },
+                truthy: [true],
+                falsy: [false]
+            });
+            Helper.validate(noTrueFalseValue, [
+                ['true', true, null, true],
+                ['false', true, null, false],
+                [true, true, null, true],
+                [false, true, null, false]
+            ]);
+            Helper.validate(setTrueFalseValueToTinyInt, [
+                ['yes', true, null, 1],
+                ['no', true, null, 0],
+                [true, true, null, 1],
+                [false, true, null, 0]
+            ]);
+            Helper.validate(setTrueFalseValueToString, [
+                ['true', true, null, 'yeap'],
+                ['false', true, null, 'none'],
+                [true, true, null, 'yeap'],
+                [false, true, null, 'none']
+            ], done);
         });
     });
 });

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1730,7 +1730,9 @@ describe('object', () => {
                             truthy: [true],
                             falsy: [false],
                             flags: {
-                                insensitive: true
+                                insensitive: true,
+                                trueValue: true,
+                                falseValue: false
                             }
                         }
                     }


### PR DESCRIPTION
sometimes we need to convert boolean to special value. for example, convert true/false to 1/0 to store in SQLite database.

this pull request add `boolean.trueValue(trueValue)` and `boolean.falseValue(falseValue)` api.

example usage:

````js
const schema = Joi.boolean().truthy('yes').falsy('no').trueValue(1).falseValue(0);
const result = Joi.validate('true', schema);
assert(result.value === 1 && result.error === null);
````