### PR TITLE
Fix "Must be invoked on a Joi instance" breaking change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,68 +50,68 @@ internals.root = function () {
         Hoek.assert(args.length === 0, 'Joi.any() does not allow arguments.');
 
         return internals.applyDefaults.call(this, any);
-    };
+    }.bind(root);
 
     root.alternatives = root.alt = function (...args) {
 
         const alternatives = internals.applyDefaults.call(this, internals.alternatives);
         return args.length ? alternatives.try.apply(alternatives, args) : alternatives;
-    };
+    }.bind(root);
 
     root.array = function (...args) {
 
         Hoek.assert(args.length === 0, 'Joi.array() does not allow arguments.');
 
         return internals.applyDefaults.call(this, internals.array);
-    };
+    }.bind(root);
 
     root.boolean = root.bool = function (...args) {
 
         Hoek.assert(args.length === 0, 'Joi.boolean() does not allow arguments.');
 
         return internals.applyDefaults.call(this, internals.boolean);
-    };
+    }.bind(root);
 
     root.binary = function (...args) {
 
         Hoek.assert(args.length === 0, 'Joi.binary() does not allow arguments.');
 
         return internals.applyDefaults.call(this, internals.binary);
-    };
+    }.bind(root);
 
     root.date = function (...args) {
 
         Hoek.assert(args.length === 0, 'Joi.date() does not allow arguments.');
 
         return internals.applyDefaults.call(this, internals.date);
-    };
+    }.bind(root);
 
     root.func = function (...args) {
 
         Hoek.assert(args.length === 0, 'Joi.func() does not allow arguments.');
 
         return internals.applyDefaults.call(this, internals.func);
-    };
+    }.bind(root);
 
     root.number = function (...args) {
 
         Hoek.assert(args.length === 0, 'Joi.number() does not allow arguments.');
 
         return internals.applyDefaults.call(this, internals.number);
-    };
+    }.bind(root);
 
     root.object = function (...args) {
 
         const object = internals.applyDefaults.call(this, internals.object);
         return args.length ? object.keys(...args) : object;
-    };
+    }.bind(root);
 
     root.string = function (...args) {
 
         Hoek.assert(args.length === 0, 'Joi.string() does not allow arguments.');
 
         return internals.applyDefaults.call(this, internals.string);
-    };
+    }.bind(root);
 
     root.ref = function (...args) {
 
@@ -156,7 +156,7 @@ internals.root = function () {
             }
             throw err;
         }
-    };
+    }.bind(root);
 
     root.assert = function (value, schema, message) {
 
@@ -210,7 +210,7 @@ internals.root = function () {
                 return this.reach(child.schema, path.substr(key.length + 1));
             }
         }
-    };
+    }.bind(root);
 
     root.lazy = function (fn) {
 
@@ -241,7 +241,7 @@ internals.root = function () {
         };
 
         return joi;
-    };
+    }.bind(root);
 
     root.extend = function (...args) {
 
@@ -401,7 +401,7 @@ internals.root = function () {
         }
 
         return joi;
-    };
+    }.bind(root);
 
     root.extensionSchema = internals.object.keys({
         base: internals.object.type(Any, 'Joi object'),


### PR DESCRIPTION
Allow to use code like
```javascript
import { string, object } from 'joi'
```
