### PR TITLE
Fix object pattern in combination with empty

### DIFF
--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -254,9 +254,7 @@ internals.Object = class extends Any {
                             }
                         }
 
-                        if (result.value !== undefined) {
-                            target[key] = result.value;
-                        }
+                        target[key] = result.value;
                     }
                 }
             }

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1672,6 +1672,14 @@ describe('object', () => {
             const schema = Joi.object().pattern(/a/g, Joi.number());
             await Joi.validate({ a1: 5, a2: 6 }, schema);
         });
+
+        it('allows using empty() on values', async () => {
+
+            const schema = Joi.object().pattern(/a/g, Joi.any().empty(null));
+
+            const value = await Joi.validate({ a1: undefined, a2: null, a3: 'test' }, schema);
+            expect(value).to.equal({ a1: undefined, a2: undefined, a3: 'test' });
+        });
     });
 
     describe('with()', () => {


### PR DESCRIPTION
When using `Joi.object().pattern(...)` it is currently not possible to convert values to `undefined`.

I guess the provided test case is self explaining. If not, I am happy to provide a more detailed explanation.