### PR TITLE
Asserts that two arguments are provided to object.with() and object.without()

### DIFF
--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -459,10 +459,14 @@ internals.Object = class extends Any {
 
     with(key, peers) {
 
+        Hoek.assert(arguments.length === 2, 'Invalid number of arguments, expected 2.');
+
         return this._dependency('with', key, peers);
     }
 
     without(key, peers) {
+
+        Hoek.assert(arguments.length === 2, 'Invalid number of arguments, expected 2.');
 
         return this._dependency('without', key, peers);
     }

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1706,6 +1706,37 @@ describe('object', () => {
             expect(error).to.equal(true);
         });
 
+        it('should throw an error unless 2 parameters are passed', () => {
+
+            let error;
+            try {
+                Joi.object().with();
+                error = false;
+            }
+            catch (e) {
+                error = true;
+            }
+            expect(error).to.equal(true);
+
+            try {
+                Joi.object().with('a');
+                error = false;
+            }
+            catch (e) {
+                error = true;
+            }
+            expect(error).to.equal(true);
+
+            try {
+                Joi.object().with('a', 'b', 'c');
+                error = false;
+            }
+            catch (e) {
+                error = true;
+            }
+            expect(error).to.equal(true);
+        });
+
         it('should validate correctly when key is an empty string', () => {
 
             const schema = Joi.object().with('', 'b');
@@ -1762,6 +1793,37 @@ describe('object', () => {
             expect(error).to.equal(true);
 
 
+        });
+
+        it('should throw an error unless 2 parameters are passed', () => {
+
+            let error;
+            try {
+                Joi.object().with();
+                error = false;
+            }
+            catch (e) {
+                error = true;
+            }
+            expect(error).to.equal(true);
+
+            try {
+                Joi.object().with('a');
+                error = false;
+            }
+            catch (e) {
+                error = true;
+            }
+            expect(error).to.equal(true);
+
+            try {
+                Joi.object().with('a', 'b', 'c');
+                error = false;
+            }
+            catch (e) {
+                error = true;
+            }
+            expect(error).to.equal(true);
         });
 
         it('should validate correctly when key is an empty string', () => {

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1708,33 +1708,13 @@ describe('object', () => {
 
         it('should throw an error unless 2 parameters are passed', () => {
 
-            let error;
-            try {
-                Joi.object().with();
-                error = false;
-            }
-            catch (e) {
-                error = true;
-            }
-            expect(error).to.equal(true);
+            const message = 'Invalid number of arguments, expected 2.';
 
-            try {
-                Joi.object().with('a');
-                error = false;
-            }
-            catch (e) {
-                error = true;
-            }
-            expect(error).to.equal(true);
+            expect(() => Joi.object().with()).to.throw(message);
+            expect(() => Joi.object().with('a')).to.throw(message);
+            expect(() => Joi.object().with('a', 'b', 'c')).to.throw(message);
 
-            try {
-                Joi.object().with('a', 'b', 'c');
-                error = false;
-            }
-            catch (e) {
-                error = true;
-            }
-            expect(error).to.equal(true);
+            expect(Joi.object().with('a', 'b')).to.be.an.object().and.contain({ isJoi: true });
         });
 
         it('should validate correctly when key is an empty string', () => {
@@ -1797,33 +1777,13 @@ describe('object', () => {
 
         it('should throw an error unless 2 parameters are passed', () => {
 
-            let error;
-            try {
-                Joi.object().with();
-                error = false;
-            }
-            catch (e) {
-                error = true;
-            }
-            expect(error).to.equal(true);
+            const message = 'Invalid number of arguments, expected 2.';
 
-            try {
-                Joi.object().with('a');
-                error = false;
-            }
-            catch (e) {
-                error = true;
-            }
-            expect(error).to.equal(true);
+            expect(() => Joi.object().without()).to.throw(message);
+            expect(() => Joi.object().without('a')).to.throw(message);
+            expect(() => Joi.object().without('a', 'b', 'c')).to.throw(message);
 
-            try {
-                Joi.object().with('a', 'b', 'c');
-                error = false;
-            }
-            catch (e) {
-                error = true;
-            }
-            expect(error).to.equal(true);
+            expect(Joi.object().without('a', 'b')).to.be.an.object().and.contain({ isJoi: true });
         });
 
         it('should validate correctly when key is an empty string', () => {


### PR DESCRIPTION
How does this look?

The assertion is for arguments.length === 2 rather than arguments.length <= 2 like you suggested ([extra arguments](https://github.com/hapijs/joi/pull/1394#issuecomment-356991804)).