### PR TITLE
Use isJoi and _currentJoi.version to determine schema compatiblity

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -190,7 +190,8 @@ internals.root = function () {
 
     root.reach = function (schema, path) {
 
-        Hoek.assert(schema && schema instanceof Any, 'you must provide a joi schema');
+        Hoek.assert(schema && schema.isJoi === true, 'you must provide a joi schema');
+        Hoek.assert(schema._currentJoi.version === root.version, `you must provide a joi schema with version ${root.version}`);
         Hoek.assert(typeof path === 'string', 'path must be a string');
 
         if (path === '') {


### PR DESCRIPTION
Closes #1261. 

We've had this same issue (in a monorepo with yarn workspaces, the nature of the issue is the same though). Joi schemas with the exact same version should be safely compatible, right?

This MR adds no tests and keeps coverage at 100%.

