### PR TITLE
undefined in the array with label returns "correct  missing value"  message 

### DIFF
--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -123,7 +123,7 @@ internals.Array = class extends Any {
                     return errors;
                 }
 
-                continue;
+                // continue;
             }
 
             // Exclusions
@@ -132,7 +132,18 @@ internals.Array = class extends Any {
                 res = this._inner.exclusions[j]._validate(item, localState, {});                // Not passing options to use defaults
 
                 if (!res.errors) {
-                    errors.push(this.createError(wasArray ? 'array.excludes' : 'array.excludesSingle', { pos: i, value: item }, { key: state.key, path: localState.path }, options));
+                    let isAlreadyRecorded;
+                    for (let k = 0; k < errors.length; ++k) {
+                        if (errors[k].context.key === i) {
+                            isAlreadyRecorded = true;
+                            break;
+                        }
+                    }
+
+                    if (!isAlreadyRecorded) {
+                        errors.push(this.createError(wasArray ? 'array.excludes' : 'array.excludesSingle', { pos: i, value: item }, { key: state.key, path: localState.path }, options));
+                    }
+
                     errored = true;
 
                     if (options.abortEarly) {


### PR DESCRIPTION
Closes  #1392

If you give undefined in the array with the label earlier it ignores undefine it will just add the sparse array error and it will skip loop but  now it also records missing value error for that label and then it will skip loop

### Code 
```javascript


var schema = Joi.object().keys({location: Joi.array().ordered(Joi.number().min(-180).max(180).label('longitude').required(), Joi.number().min(-90).max(90).label('latitude').required()).label('location').required()});

var input = {location: [10, undefined]};


Joi.validate(input,schema, {abortEarly: false}));

```

### output
![screen shot 2018-01-18 at 12 34 54 pm](https://user-images.githubusercontent.com/17177346/35084871-08f9b91c-fc4c-11e7-8fe6-567b21aee376.png)
