### PR TITLE
Fix cloned valid() / invalid() object values

### DIFF
--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -106,8 +106,8 @@ module.exports = internals.Any = class {
         obj._type = this._type;
         obj._settings = internals.concatSettings(this._settings);
         obj._baseType = this._baseType;
-        obj._valids = Hoek.clone(this._valids);
-        obj._invalids = Hoek.clone(this._invalids);
+        obj._valids = this._valids.slice();
+        obj._invalids = this._invalids.slice();
         obj._tests = this._tests.slice();
         obj._refs = this._refs.slice();
         obj._flags = Hoek.clone(this._flags);

--- a/test/types/any.js
+++ b/test/types/any.js
@@ -2493,6 +2493,13 @@ describe('any', () => {
             }]);
 
         });
+
+        it('preserves passed value when cloned', () => {
+
+            const o = {};
+            expect(Joi.valid(o).clone().validate(o).error).to.be.null();
+            expect(Joi.valid(o).clone().validate({}).error).to.be.an.error('"value" must be one of [[object Object]]');
+        });
     });
 
     describe('invalid()', () => {
@@ -2511,6 +2518,13 @@ describe('any', () => {
 
                 Joi.any().invalid(undefined);
             }).to.throw('Cannot call allow/valid/invalid with undefined');
+        });
+
+        it('preserves passed value when cloned', () => {
+
+            const o = {};
+            expect(Joi.object().invalid(o).clone().validate(o).error).to.be.an.error('"value" contains an invalid value');
+            expect(Joi.object().invalid(o).clone().validate({}).error).to.be.null();
         });
     });
 


### PR DESCRIPTION
This fixes `any.valid()` and `any.invalid()` for `typeof === 'object'` values when used through a method that clones the schema.