### PR TITLE
Add byteAligned option to hex string

### DIFF
--- a/lib/language.js
+++ b/lib/language.js
@@ -142,6 +142,7 @@ exports.errors = {
         isoDate: 'must be a valid ISO 8601 date',
         guid: 'must be a valid GUID',
         hex: 'must only contain hexadecimal characters',
+        hexAlign: 'hex decoded representation must be byte aligned',
         base64: 'must be a valid base64 string',
         hostname: 'must be a valid hostname',
         normalize: 'must be unicode normalized in the {{form}} form',

--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -399,13 +399,21 @@ internals.String = class extends Any {
         });
     }
 
-    hex() {
+    hex(hexOptions = {}) {
 
+        Hoek.assert(typeof hexOptions === 'object', 'hex options must be an object');
+        Hoek.assert(typeof hexOptions.byteAligned === 'undefined' || typeof hexOptions.byteAligned === 'boolean',
+            'byteAligned must be boolean');
+
+        const byteAligned = hexOptions.byteAligned === true;
         const regex = /^[a-f0-9]+$/i;
 
         return this._test('hex', regex, function (value, state, options) {
 
             if (regex.test(value)) {
+                if (byteAligned && value.length % 2 !== 0) {
+                    return this.createError('string.hexAlign', { value }, state, options);
+                }
                 return value;
             }
 

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -9638,7 +9638,20 @@ describe('string', () => {
             ], { convert: true });
         });
 
-        it('validates an hexadecimal string', () => {
+        it('validates the hexadecimal options', () => {
+
+            expect(() => {
+
+                Joi.string().hex('a');
+            }).to.throw('hex options must be an object');
+
+            expect(() => {
+
+                Joi.string().hex({ byteAligned: 'a' });
+            }).to.throw('byteAligned must be boolean');
+        });
+
+        it('validates an hexadecimal string with no options', () => {
 
             const rule = Joi.string().hex();
             Helper.validate(rule, [
@@ -9651,6 +9664,32 @@ describe('string', () => {
                         path: [],
                         type: 'string.hex',
                         context: { value: '123afg', label: 'value', key: undefined }
+                    }]
+                }]
+            ]);
+        });
+
+        it('validates an hexadecimal string with byte align explicitly required', () => {
+
+            const rule = Joi.string().hex({ byteAligned: true });
+            Helper.validate(rule, [
+                ['0123456789abcdef', true],
+                ['123456789abcdef', false, null, {
+                    message: '"value" hex decoded representation must be byte aligned',
+                    details: [{
+                        message: '"value" hex decoded representation must be byte aligned',
+                        path: [],
+                        type: 'string.hexAlign',
+                        context: { value: '123456789abcdef', label: 'value', key: undefined }
+                    }]
+                }],
+                ['0123afg', false, null, {
+                    message: '"value" must only contain hexadecimal characters',
+                    details: [{
+                        message: '"value" must only contain hexadecimal characters',
+                        path: [],
+                        type: 'string.hex',
+                        context: { value: '0123afg', label: 'value', key: undefined }
                     }]
                 }]
             ]);


### PR DESCRIPTION
In most cases you probably want to create a byte-based representation from the hex string.

This PR adds a new `byteAligned` option, which will fail the validation when eg. `new Buffer(value, 'hex')` would fail due to bad alignment.

Due to semver, the option is considered `false` by default, preserving the existing behavior in all cases. I would probably switch this to `true` by default, when possible.