### PR TITLE
Avoid redundant copies of settings

### DIFF
--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -104,7 +104,7 @@ module.exports = internals.Any = class {
         obj.isJoi = true;
         obj._currentJoi = this._currentJoi;
         obj._type = this._type;
-        obj._settings = internals.concatSettings(this._settings);
+        obj._settings = this._settings;
         obj._baseType = this._baseType;
         obj._valids = Hoek.clone(this._valids);
         obj._invalids = Hoek.clone(this._invalids);
@@ -225,8 +225,9 @@ module.exports = internals.Any = class {
     strict(isStrict) {
 
         const obj = this.clone();
-        obj._settings = obj._settings || {};
-        obj._settings.convert = isStrict === undefined ? false : !isStrict;
+
+        const convert = isStrict === undefined ? false : !isStrict;
+        obj._settings = internals.concatSettings(obj._settings, { convert });
         return obj;
     }
 
@@ -883,28 +884,22 @@ internals._try = function (fn, args) {
 
 internals.concatSettings = function (target, source) {
 
-    // Used to avoid cloning context
-
-    if (!target &&
-        !source) {
-
-        return null;
+    if (!source) {
+        return target;
     }
 
     const obj = Object.assign({}, target);
 
-    if (source) {
-        const sKeys = Object.keys(source);
-        for (let i = 0; i < sKeys.length; ++i) {
-            const key = sKeys[i];
-            if (key !== 'language' ||
-                !obj.hasOwnProperty(key)) {
+    const sKeys = Object.keys(source);
+    for (let i = 0; i < sKeys.length; ++i) {
+        const key = sKeys[i];
+        if (key !== 'language' ||
+            !obj.hasOwnProperty(key)) {
 
-                obj[key] = source[key];
-            }
-            else {
-                obj[key] = Hoek.applyToDefaults(obj[key], source[key]);
-            }
+            obj[key] = source[key];
+        }
+        else {
+            obj[key] = Hoek.applyToDefaults(obj[key], source[key]);
         }
     }
 


### PR DESCRIPTION
This speeds of validation of simple schemas by ~10x.