### PR TITLE
Changed a separator for path parameter to pre-split array approach for Joi.reach

### DIFF
--- a/API.md
+++ b/API.md
@@ -291,11 +291,11 @@ Joi.isRef(ref); // returns true
 
 ### `reach(schema, path)`
 
-Get a sub-schema of an existing schema based on a path. Path separator is a dot (`.`).
+Get a sub-schema of an existing schema based on a path.
 
 ```js
 const schema = Joi.object({ foo: Joi.object({ bar: Joi.number() }) });
-const number = Joi.reach(schema, 'foo.bar');
+const number = Joi.reach(schema, ['foo', 'bar']);
 ```
 
 ### `defaults(fn)`

--- a/API.md
+++ b/API.md
@@ -291,11 +291,14 @@ Joi.isRef(ref); // returns true
 
 ### `reach(schema, path)`
 
-Get a sub-schema of an existing schema based on a path.
+Get a sub-schema of an existing schema based on a `path` that can be either a string or an array of strings For string values path separator is a dot (`.`).
 
 ```js
 const schema = Joi.object({ foo: Joi.object({ bar: Joi.number() }) });
-const number = Joi.reach(schema, ['foo', 'bar']);
+const number = Joi.reach(schema, 'foo.bar');
+
+//or
+const result = Joi.reach(schema, ['foo', 'bar']); //same as number
 ```
 
 ### `defaults(fn)`

--- a/lib/index.js
+++ b/lib/index.js
@@ -195,7 +195,7 @@ internals.root = function () {
 
         const reach = (sourceSchema, schemaPath) => {
 
-            if (!path.length) {
+            if (!schemaPath.length) {
                 return sourceSchema;
             }
 
@@ -208,7 +208,7 @@ internals.root = function () {
             for (let i = 0; i < children.length; ++i) {
                 const child = children[i];
                 if (child.key === key) {
-                    return this.reach(child.schema, schemaPath);
+                    return reach(child.schema, schemaPath);
                 }
             }
         };

--- a/lib/index.js
+++ b/lib/index.js
@@ -213,7 +213,7 @@ internals.root = function () {
             }
         };
 
-        const schemaPath = typeof path === 'string' ? path.split('.') : path;
+        const schemaPath = typeof path === 'string' ? path.split('.') : path.slice();
 
         return reach(schema, schemaPath);
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,23 +191,22 @@ internals.root = function () {
     root.reach = function (schema, path) {
 
         Hoek.assert(schema && schema instanceof Any, 'you must provide a joi schema');
-        Hoek.assert(typeof path === 'string', 'path must be a string');
+        Hoek.assert(Array.isArray(path), 'path must be an array');
 
-        if (path === '') {
+        if (!path.length) {
             return schema;
         }
 
-        const parts = path.split('.');
         const children = schema._inner.children;
         if (!children) {
             return;
         }
 
-        const key = parts[0];
+        const key = path.shift();
         for (let i = 0; i < children.length; ++i) {
             const child = children[i];
             if (child.key === key) {
-                return this.reach(child.schema, path.substr(key.length + 1));
+                return this.reach(child.schema, path);
             }
         }
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,24 +191,31 @@ internals.root = function () {
     root.reach = function (schema, path) {
 
         Hoek.assert(schema && schema instanceof Any, 'you must provide a joi schema');
-        Hoek.assert(Array.isArray(path), 'path must be an array');
+        Hoek.assert(Array.isArray(path) || typeof path === 'string', 'path must be a string or an array of strings');
 
-        if (!path.length) {
-            return schema;
-        }
+        const reach = (sourceSchema, schemaPath) => {
 
-        const children = schema._inner.children;
-        if (!children) {
-            return;
-        }
-
-        const key = path.shift();
-        for (let i = 0; i < children.length; ++i) {
-            const child = children[i];
-            if (child.key === key) {
-                return this.reach(child.schema, path);
+            if (!path.length) {
+                return sourceSchema;
             }
-        }
+
+            const children = sourceSchema._inner.children;
+            if (!children) {
+                return;
+            }
+
+            const key = schemaPath.shift();
+            for (let i = 0; i < children.length; ++i) {
+                const child = children[i];
+                if (child.key === key) {
+                    return this.reach(child.schema, schemaPath);
+                }
+            }
+        };
+
+        const schemaPath = typeof path === 'string' ? path.split('.') : path;
+
+        return reach(schema, schemaPath);
     };
 
     root.lazy = function (fn) {

--- a/test/index.js
+++ b/test/index.js
@@ -2747,29 +2747,36 @@ describe('Joi', () => {
 
         it('should fail when schema is not a joi object', () => {
 
-            expect(() => Joi.reach({ foo: 'bar' }, ['foo'])).to.throw('you must provide a joi schema');
+            expect(() => Joi.reach({ foo: 'bar' }, 'foo')).to.throw('you must provide a joi schema');
         });
 
         it('should fail without a proper path', () => {
 
             const schema = Joi.object();
-            expect(() => Joi.reach(schema)).to.throw('path must be an array');
-            expect(() => Joi.reach(schema, true)).to.throw('path must be an array');
+            expect(() => Joi.reach(schema)).to.throw('path must be a string or an array of strings');
+            expect(() => Joi.reach(schema, true)).to.throw('path must be a string or an array of strings');
         });
 
         it('should return undefined when no keys are defined', () => {
 
             const schema = Joi.object();
-            expect(Joi.reach(schema, ['a'])).to.be.undefined();
+            expect(Joi.reach(schema, 'a')).to.be.undefined();
         });
 
         it('should return undefined when key is not found', () => {
 
             const schema = Joi.object().keys({ a: Joi.number() });
-            expect(Joi.reach(schema, ['foo'])).to.be.undefined();
+            expect(Joi.reach(schema, 'foo')).to.be.undefined();
         });
 
         it('should return a schema when key is found', () => {
+
+            const a = Joi.number();
+            const schema = Joi.object().keys({ a });
+            expect(Joi.reach(schema, 'a')).to.shallow.equal(a);
+        });
+
+        it('should return a schema when key as array is found', () => {
 
             const a = Joi.number();
             const schema = Joi.object().keys({ a });
@@ -2779,20 +2786,27 @@ describe('Joi', () => {
         it('should return undefined on a schema that does not support reach', () => {
 
             const schema = Joi.number();
-            expect(Joi.reach(schema, ['a'])).to.be.undefined();
+            expect(Joi.reach(schema, 'a')).to.be.undefined();
         });
 
         it('should return a schema when deep key is found', () => {
 
             const bar = Joi.number();
             const schema = Joi.object({ foo: Joi.object({ bar }) });
-            expect(Joi.reach(schema, ['foo', 'bar'])).to.shallow.equal(bar);
+            expect(Joi.reach(schema, 'foo.bar')).to.shallow.equal(bar);
+        });
+
+        it('should return a schema when deep key is found', () => {
+
+            const bar = Joi.number();
+            const schema = Joi.object({ foo: Joi.object({ bar }) });
+            expect(Joi.reach(schema, ['foo','bar'])).to.shallow.equal(bar);
         });
 
         it('should return undefined when deep key is not found', () => {
 
             const schema = Joi.object({ foo: Joi.object({ bar: Joi.number() }) });
-            expect(Joi.reach(schema, ['foo', 'baz'])).to.be.undefined();
+            expect(Joi.reach(schema, 'foo.baz')).to.be.undefined();
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -2747,52 +2747,52 @@ describe('Joi', () => {
 
         it('should fail when schema is not a joi object', () => {
 
-            expect(() => Joi.reach({ foo: 'bar' }, 'foo')).to.throw('you must provide a joi schema');
+            expect(() => Joi.reach({ foo: 'bar' }, ['foo'])).to.throw('you must provide a joi schema');
         });
 
         it('should fail without a proper path', () => {
 
             const schema = Joi.object();
-            expect(() => Joi.reach(schema)).to.throw('path must be a string');
-            expect(() => Joi.reach(schema, true)).to.throw('path must be a string');
+            expect(() => Joi.reach(schema)).to.throw('path must be an array');
+            expect(() => Joi.reach(schema, true)).to.throw('path must be an array');
         });
 
         it('should return undefined when no keys are defined', () => {
 
             const schema = Joi.object();
-            expect(Joi.reach(schema, 'a')).to.be.undefined();
+            expect(Joi.reach(schema, ['a'])).to.be.undefined();
         });
 
         it('should return undefined when key is not found', () => {
 
             const schema = Joi.object().keys({ a: Joi.number() });
-            expect(Joi.reach(schema, 'foo')).to.be.undefined();
+            expect(Joi.reach(schema, ['foo'])).to.be.undefined();
         });
 
         it('should return a schema when key is found', () => {
 
             const a = Joi.number();
             const schema = Joi.object().keys({ a });
-            expect(Joi.reach(schema, 'a')).to.shallow.equal(a);
+            expect(Joi.reach(schema, ['a'])).to.shallow.equal(a);
         });
 
         it('should return undefined on a schema that does not support reach', () => {
 
             const schema = Joi.number();
-            expect(Joi.reach(schema, 'a')).to.be.undefined();
+            expect(Joi.reach(schema, ['a'])).to.be.undefined();
         });
 
         it('should return a schema when deep key is found', () => {
 
             const bar = Joi.number();
             const schema = Joi.object({ foo: Joi.object({ bar }) });
-            expect(Joi.reach(schema, 'foo.bar')).to.shallow.equal(bar);
+            expect(Joi.reach(schema, ['foo', 'bar'])).to.shallow.equal(bar);
         });
 
         it('should return undefined when deep key is not found', () => {
 
             const schema = Joi.object({ foo: Joi.object({ bar: Joi.number() }) });
-            expect(Joi.reach(schema, 'foo.baz')).to.be.undefined();
+            expect(Joi.reach(schema, ['foo', 'baz'])).to.be.undefined();
         });
     });
 


### PR DESCRIPTION
Fixed the issue: #1383

This changed the path parameter of `Joi.reach` from string to array of strings