### PR TITLE
Allow square braces in URL validation

### DIFF
--- a/lib/types/string/rfc3986.js
+++ b/lib/types/string/rfc3986.js
@@ -79,6 +79,11 @@ internals.generate = function () {
     const pcharOnly = '[' + pchar + ']';
 
     /**
+     * squareBraces example: []
+     */
+    const squareBraces = '\\[\\]';
+
+    /**
      * dec-octet   = DIGIT                 ; 0-9
      *            / %x31-39 DIGIT         ; 10-99
      *            / "1" 2DIGIT            ; 100-199
@@ -195,7 +200,7 @@ internals.generate = function () {
     /**
      * query = *( pchar / "/" / "?" )
      */
-    internals.rfc3986.query = '[' + pchar + '\\/\\?]*(?=#|$)'; //Finish matching either at the fragment part or end of the line.
+    internals.rfc3986.query = '[' + pchar + squareBraces + '\\/\\?]*(?=#|$)'; //Finish matching either at the fragment part or end of the line.
 
     /**
      * fragment = *( pchar / "/" / "?" )

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -2523,6 +2523,7 @@ describe('string', () => {
 
             Helper.validate(schema, [
                 ['foo://example.com:8042/over/there?name=ferret#nose', true],
+                ['https://example.com?abc[]=123&abc[]=456', true],
                 ['urn:example:animal:ferret:nose', true],
                 ['ftp://ftp.is.co.za/rfc/rfc1808.txt', true],
                 ['http://www.ietf.org/rfc/rfc2396.txt', true],


### PR DESCRIPTION
#### What does this PR do
Allow square braces in URL validation

#### Description of Task to be completed
Update regex to accept square braces

#### How should this be manually tested
```
const Joi = require('./');

const schema = Joi.object().keys({
    url: Joi.string().uri()
});

const resOne = Joi.validate({url: 'https://example.com?abc[]=123&abc[]=456'}, schema);
```
the snippet above wouldn't result in error because it's a valid URL with query.

#### Any background context you want to add
Fixes [Issue: 1461](https://github.com/hapijs/joi/issues/1461)

#### Screenshots