### PR TITLE
removing faulty code and adding test cases

### DIFF
--- a/lib/types/number/index.js
+++ b/lib/types/number/index.js
@@ -40,13 +40,6 @@ internals.Number = class extends Any {
 
         const isNumber = typeof result.value === 'number' && !isNaN(result.value);
 
-        if (options.convert && 'precision' in this._flags && isNumber) {
-
-            // This is conceptually equivalent to using toFixed but it should be much faster
-            const precision = Math.pow(10, this._flags.precision);
-            result.value = Math.round(result.value * precision) / precision;
-        }
-
         result.errors = isNumber ? null : this.createError('number.base', null, state, options);
         return result;
     }

--- a/test/types/number.js
+++ b/test/types/number.js
@@ -1884,15 +1884,42 @@ describe('number', () => {
 
     describe('precision()', () => {
 
-        it.only('converts numbers', () => {
+        it('converts numbers', () => {
 
             const rule = Joi.number().precision(4);
             Helper.validate(rule, [
                 [1.5, true, null, 1.5],
-                [0.12345, true, null, 0.1235],
+                [0.1235, true, null, 0.1235],
                 [123456, true, null, 123456],
-                [123456.123456, true, null, 123456.123456],
-                ['123456.123456', true, null, 123456.123456],
+                ['123456', true, null, 123456],
+                ['123456.1234', true, null, 123456.1234],
+                [0.12345, false, null, {
+                    message: '"value" must have no more than 4 decimal places',
+                    details: [{
+                        message: '"value" must have no more than 4 decimal places',
+                        path: [],
+                        type: 'number.precision',
+                        context: { limit: 4, value: 0.12345, key: undefined, label: 'value' }
+                    }]
+                }],
+                [123456.123456, false, null, {
+                    message: '"value" must have no more than 4 decimal places',
+                    details: [{
+                        message: '"value" must have no more than 4 decimal places',
+                        path: [],
+                        type: 'number.precision',
+                        context: { limit: 4, value: 123456.123456, key: undefined, label: 'value' }
+                    }]
+                }],
+                ['123456.123456', false, null, {
+                    message: '"value" must have no more than 4 decimal places',
+                    details: [{
+                        message: '"value" must have no more than 4 decimal places',
+                        path: [],
+                        type: 'number.precision',
+                        context: { limit: 4, value: 123456.123456, key: undefined, label: 'value' }
+                    }]
+                }],
                 ['abc', false, null, {
                     message: '"value" must be a number',
                     details: [{
@@ -1913,8 +1940,6 @@ describe('number', () => {
                 }]
             ]);
         });
-
-
     });
 
     describe('describe()', () => {

--- a/test/types/number.js
+++ b/test/types/number.js
@@ -1884,15 +1884,15 @@ describe('number', () => {
 
     describe('precision()', () => {
 
-        it('converts numbers', () => {
+        it.only('converts numbers', () => {
 
             const rule = Joi.number().precision(4);
             Helper.validate(rule, [
                 [1.5, true, null, 1.5],
                 [0.12345, true, null, 0.1235],
                 [123456, true, null, 123456],
-                [123456.123456, true, null, 123456.1235],
-                ['123456.123456', true, null, 123456.1235],
+                [123456.123456, true, null, 123456.123456],
+                ['123456.123456', true, null, 123456.123456],
                 ['abc', false, null, {
                     message: '"value" must be a number',
                     details: [{
@@ -1913,6 +1913,8 @@ describe('number', () => {
                 }]
             ]);
         });
+
+
     });
 
     describe('describe()', () => {


### PR DESCRIPTION
The documentation states, and the validation errors confirm, `precision` "Specifies the maximum number of decimal places where: limit - the maximum number of decimal places allowed."

This was not happening if convert: true because we were rounding to `limit` before checking precision, then returning the original non-rounded value.  The precision test has been modified to include the intent of the original, flawed, test cases (to accurately convert strings to numbers) and add expected failures for when the decimals submitted exceed the precision indicated.
