### PR TITLE
Highlight the minDomainAtoms option for the email validation method in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const schema = Joi.object().keys({
     password: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/),
     access_token: [Joi.string(), Joi.number()],
     birthyear: Joi.number().integer().min(1900).max(2013),
-    email: Joi.string().email()
+    email: Joi.string().email({ minDomainAtoms: 2 })
 }).with('username', 'birthyear').without('password', 'access_token');
 
 // Return result.
@@ -56,6 +56,7 @@ The above schema defines the following constraints:
     * an integer between 1900 and 2013
 * `email`
     * a valid email address string
+    * must have two domain parts e.g. `example.com`
 
 # Usage
 


### PR DESCRIPTION
Following discussion in the issue #1366 I thought it might be helpful to alter the README.md example that uses the `email` validation method to include `minDomainAtoms` as a way to signpost that the default RFC compliant options might not be what most are after.

Appreciate the maintainers may not agree with this in which case feel free to close.

Also thanks for the code, great library 👍 