### PR TITLE
Build Joi with Lyo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 npm-debug.log
 dump.rdb
 node_modules
+dist
 results.tap
 results.xml
 config.json

--- a/README.md
+++ b/README.md
@@ -119,7 +119,21 @@ When validating a schema:
 
 # Browsers
 
-Joi doesn't directly support browsers, but you could use [joi-browser](https://github.com/jeffbski/joi-browser) for an ES5 build of Joi that works in browsers, or as a source of inspiration for your own builds.
+Joi works well in browsers too. You can find the latest ES5 build of Joi on [jsDelivr](https://cdn.jsdelivr.net/npm/joi@13/dist/joi.min.js).
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/joi@13/dist/joi.min.js"></script>
+
+<script>
+var schema = Joi.object().keys({
+  //...
+});
+
+var result = Joi.validate({ username: 'abc', birthyear: 1994 }, schema);
+</script>
+```
+
+You could also use [joi-browser](https://github.com/jeffbski/joi-browser) as a source of inspiration for your own builds.
 
 ## Acknowledgements
 

--- a/package.json
+++ b/package.json
@@ -21,14 +21,19 @@
   "devDependencies": {
     "code": "5.x.x",
     "hapitoc": "1.x.x",
-    "lab": "15.x.x"
+    "lab": "15.x.x",
+    "lyo": "1.x"
   },
   "scripts": {
     "test": "lab -t 100 -a code -L",
     "test-debug": "lab -a code",
     "test-cov-html": "lab -r html -o coverage.html -a code",
     "toc": "hapitoc",
-    "version": "npm run toc && git add API.md README.md"
+    "version": "npm run toc && git add API.md README.md",
+    "prepublishOnly": "lyo"
   },
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "lyo": {
+    "name": "Joi"
+  }
 }


### PR DESCRIPTION
Instead of saying that Joi doesn't support browsers, you can use [Lyo](https://github.com/bokub/lyo) to build it painlessly as an ES5-compatible library, without any complex configuration.

As you can see, I've added `dist` in the `.gitignore` so the bundle is not versioned, but that can be changed according to your preferences.

I've uploaded the build on [pastebin](https://pastebin.com/raw/1tcSrxuB) and tested Joi in [this jsFiddle](https://jsfiddle.net/bokub/uk13br8y/), and it works flawlessly.

On the next `npm publish` you run, Lyo will compile Joi and push it to npm with the rest of the package, making it available on jsDelivr at https://cdn.jsdelivr.net/npm/joi@13/dist/joi.min.js