### PR TITLE
Support ISO 8601 duration as a string validator

### DIFF
--- a/API.md
+++ b/API.md
@@ -138,6 +138,7 @@
     - [`string.uppercase()`](#stringuppercase)
     - [`string.trim([enabled])`](#stringtrimenabled)
     - [`string.isoDate()`](#stringisodate)
+    - [`string.isoDuration()`](#stringisoduration)
   - [`symbol` - inherits from `Any`](#symbol---inherits-from-any)
     - [`symbol.map(map)`](#symbolmapmap)
   - [`alternatives` - inherits from `Any`](#alternatives---inherits-from-any)
@@ -2183,6 +2184,21 @@ If the validation `convert` option is on (enabled by default), the string will b
 
 ```js
 const schema = Joi.string().isoDate();
+schema.validate('2018-11-28T18:25:32+00:00'); // No Error
+schema.validate('20181-11-28T18:25:32+00:00'); // ValidationError: must be a valid 8601 date
+schema.validate(''); // ValidationError: must be a valid 8601 date
+```
+
+#### `string.isoDuration()`
+
+Requires the string value to be in valid ISO 8601 duration format.
+
+```js
+const schema = Joi.string().isoDuration();
+schema.validate('P3Y6M4DT12H30M5S'); // No Error
+schema.validate('2018-11-28T18:25:32+00:00'); // ValidationError: must be a valid ISO 8601 duration
+schema.validate(''); // ValidationError: must be a valid ISO 8601 duration
+
 ```
 
 ### `symbol` - inherits from `Any`

--- a/lib/language.js
+++ b/lib/language.js
@@ -143,6 +143,7 @@ exports.errors = {
         uriRelativeOnly: 'must be a valid relative uri',
         uriCustomScheme: 'must be a valid uri with a scheme matching the {{scheme}} pattern',
         isoDate: 'must be a valid ISO 8601 date',
+        isoDuration: 'must be a valid ISO 8601 duration',
         guid: 'must be a valid GUID',
         hex: 'must only contain hexadecimal characters',
         hexAlign: 'hex decoded representation must be byte aligned',

--- a/lib/types/date/index.js
+++ b/lib/types/date/index.js
@@ -12,6 +12,7 @@ const Hoek = require('hoek');
 const internals = {};
 
 internals.isoDate = /^(?:[-+]\d{2})?(?:\d{4}(?!\d{2}\b))(?:(-?)(?:(?:0[1-9]|1[0-2])(?:\1(?:[12]\d|0[1-9]|3[01]))?|W(?:[0-4]\d|5[0-2])(?:-?[1-7])?|(?:00[1-9]|0[1-9]\d|[12]\d{2}|3(?:[0-5]\d|6[1-6])))(?![T]$|[T][\d]+Z$)(?:[T\s](?:(?:(?:[01]\d|2[0-3])(?:(:?)[0-5]\d)?|24\:?00)(?:[.,]\d+(?!:))?)(?:\2[0-5]\d(?:[.,]\d+)?)?(?:[Z]|(?:[+-])(?:[01]\d|2[0-3])(?::?[0-5]\d)?)?)?)?$/;
+internals.isoDuration = /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$/;
 internals.invalidDate = new Date('');
 internals.isIsoDate = (() => {
 
@@ -124,6 +125,11 @@ internals.Date = class extends Any {
     _isIsoDate(value) {
 
         return internals.isoDate.test(value);
+    }
+
+    _isIsoDuration(value) {
+
+        return internals.isoDuration.test(value);
     }
 
 };

--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -367,6 +367,18 @@ internals.String = class extends Any {
         });
     }
 
+    isoDuration() {
+
+        return this._test('isoDuration', undefined, function (value, state, options) {
+
+            if (JoiDate._isIsoDuration(value)) {
+                return value;
+            }
+
+            return this.createError('string.isoDuration', { value }, state, options);
+        });
+    }
+
     guid(guidOptions) {
 
         let versionNumbers = '';

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -9703,6 +9703,59 @@ describe('string', () => {
             ], { convert: true });
         });
 
+        it('validates isoDuration', () => {
+
+            Helper.validateOptions(Joi.string().isoDuration(), [
+                ['P3Y6M4DT12H30M5S', true],
+                ['P3Y6M4DT12H30M', true],
+                ['P3Y6M4DT12H5S', true],
+                ['P3Y6M4DT30M5S', true],
+                ['P3Y6MT12H30M5S', true],
+                ['P3Y4DT12H30M5S', true],
+                ['P6M4DT12H30M5S', true],
+                ['PT10H20M5S', true],
+                ['PT40S', true],
+                ['PT0S', true],
+                ['P0D', true],
+                ['P30S', false, null, {
+                    message: '"value" must be a valid ISO 8601 duration',
+                    details: [{
+                        message: '"value" must be a valid ISO 8601 duration',
+                        path: [],
+                        type: 'string.isoDuration',
+                        context: { value: 'P30S', label: 'value', key: undefined }
+                    }]
+                }],
+                ['P30', false, null, {
+                    message: '"value" must be a valid ISO 8601 duration',
+                    details: [{
+                        message: '"value" must be a valid ISO 8601 duration',
+                        path: [],
+                        type: 'string.isoDuration',
+                        context: { value: 'P30', label: 'value', key: undefined }
+                    }]
+                }],
+                ['', false, null, {
+                    message: '"value" is not allowed to be empty',
+                    details: [{
+                        message: '"value" is not allowed to be empty',
+                        path: [],
+                        type: 'any.empty',
+                        context: { value: '', invalids: [''], label: 'value', key: undefined }
+                    }]
+                }],
+                [null, false, null, {
+                    message: '"value" must be a string',
+                    details: [{
+                        message: '"value" must be a string',
+                        path: [],
+                        type: 'string.base',
+                        context: { value: null, label: 'value', key: undefined }
+                    }]
+                }]
+            ]);
+        });
+
         it('validates the hexadecimal options', () => {
 
             expect(() => {


### PR DESCRIPTION
This addresses https://github.com/hapijs/joi/issues/1612 by adding iso duration as a type of string validator. I'm not sure the best design to add it on the date validator (because it's not a date), so I didn't.

This also adds a reasonable amount of unit tests to cover it. Tests and linter pass