### PR TITLE
[docs] typo in rename keys API example

### DIFF
--- a/API.md
+++ b/API.md
@@ -395,10 +395,13 @@ so that if one key validation depends on another, the dependent key is validated
 References support the following arguments:
 - `key` - the reference target. References cannot point up the object tree, only to sibling keys, but they can point to
   their siblings' children (e.g. 'a.b.c') using the `.` separator. If a `key` starts with `$` is signifies a context reference
-  which is looked up in the `context` option object.
+  which is looked up in the `context` option object. If the `key` starts with a separator character, it is the same as setting
+  `options.self` to `true`.
 - `options` - optional settings:
     - `separator` - overrides the default `.` hierarchy separator.
     - `contextPrefix` - overrides the default `$` context prefix signifier.
+    - `self` - if `true`, the reference is for a property of the value it operates on instead of a sibling of the value.
+      Defaults to `false`.
     - Other options can also be passed based on what [`Hoek.reach`](https://github.com/hapijs/hoek/blob/master/API.md#reachobj-chain-options) supports.
 
 Note that references can only be used where explicitly supported such as in `valid()` or `invalid()` rules. If upwards

--- a/API.md
+++ b/API.md
@@ -2013,7 +2013,7 @@ Keys are renamed before any other validation rules are applied.
 ```js
 const object = Joi.object().keys({
     a: Joi.number()
-}).rename('b', 'a');
+}).rename('a', 'b');
 
 object.validate({ b: 5 }, (err, value) => { });
 ```

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -14,16 +14,27 @@ exports.create = function (key, options) {
 
     Hoek.assert(typeof key === 'string', 'Invalid reference key:', key);
 
-    const settings = Hoek.clone(options);         // options can be reused and modified
+    const settings = options ? Hoek.clone(options) : {};        // options can be reused and modified
 
-    const ref = function (value, validationOptions) {
+    const ref = function (parent, value, validationOptions) {
 
-        return Hoek.reach(ref.isContext ? validationOptions.context : value, ref.key, settings);
+        const target = ref.isContext ? validationOptions.context : (settings.self ? value : parent);
+        return Hoek.reach(target, ref.key, settings);
     };
 
-    ref.isContext = (key[0] === ((settings && settings.contextPrefix) || '$'));
+    const contextPrefix = settings.contextPrefix || '$';
+    const separator = settings.separator || '.';
+
+    ref.isContext = (key[0] === contextPrefix);
+    if (!ref.isContext &&
+        key[0] === separator) {
+
+        key = key.slice(1);
+        settings.self = true;
+    }
+
     ref.key = (ref.isContext ? key.slice(1) : key);
-    ref.path = ref.key.split((settings && settings.separator) || '.');
+    ref.path = ref.key.split(separator);
     ref.depth = ref.path.length;
     ref.root = ref.path[0];
     ref.isJoi = true;

--- a/lib/set.js
+++ b/lib/set.js
@@ -104,7 +104,7 @@ module.exports = class InternalSet {
             if (state && this._hasRef) {
                 for (let item of this._set) {
                     if (Ref.isRef(item)) {
-                        item = [].concat(item(state.reference || state.parent, options));
+                        item = [].concat(item(state.reference || state.parent, value, options));
                         const found = item.indexOf(value);
                         if (found >= 0) {
                             return { value: item[found] };
@@ -134,7 +134,7 @@ module.exports = class InternalSet {
 
         for (let item of this._set) {
             if (checkRef && Ref.isRef(item)) { // Only resolve references if there is a state, otherwise it's a merge
-                item = item(state.reference || state.parent, options);
+                item = item(state.reference || state.parent, value, options);
 
                 if (Array.isArray(item)) {
                     const found = item.findIndex(isReallyEqual);

--- a/lib/types/alternatives/index.js
+++ b/lib/types/alternatives/index.js
@@ -38,7 +38,7 @@ internals.Alternatives = class extends Any {
             const item = this._inner.matches[i];
             if (!item.schema) {
                 const schema = item.peek || item.is;
-                const input = item.is ? item.ref(state.reference || state.parent, options) : value;
+                const input = item.is ? item.ref(state.reference || state.parent, value, options) : value;
                 const failed = schema._validate(input, null, options, state.parent).errors;
 
                 if (failed) {

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -693,7 +693,7 @@ module.exports = internals.Any = class {
             finalValue = value;
         }
         else if (Ref.isRef(this._flags.default)) {
-            finalValue = this._flags.default(state.parent, options);
+            finalValue = this._flags.default(state.parent, value, options);
         }
         else if (typeof this._flags.default === 'function' &&
             !(this._flags.func && !this._flags.default.description)) {

--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -409,7 +409,7 @@ internals.Array = class extends Any {
 
             let compareTo;
             if (isRef) {
-                compareTo = limit(state.reference || state.parent, options);
+                compareTo = limit(state.reference || state.parent, value, options);
 
                 if (!(Number.isSafeInteger(compareTo) && compareTo >= 0)) {
                     return this.createError('array.ref', { ref: limit, value: compareTo }, state, options);
@@ -437,7 +437,7 @@ internals.Array = class extends Any {
 
             let compareTo;
             if (isRef) {
-                compareTo = limit(state.reference || state.parent, options);
+                compareTo = limit(state.reference || state.parent, value, options);
 
                 if (!(Number.isSafeInteger(compareTo) && compareTo >= 0)) {
                     return this.createError('array.ref', { ref: limit.key }, state, options);
@@ -465,7 +465,7 @@ internals.Array = class extends Any {
 
             let compareTo;
             if (isRef) {
-                compareTo = limit(state.reference || state.parent, options);
+                compareTo = limit(state.reference || state.parent, value, options);
 
                 if (!(Number.isSafeInteger(compareTo) && compareTo >= 0)) {
                     return this.createError('array.ref', { ref: limit.key }, state, options);

--- a/lib/types/date/index.js
+++ b/lib/types/date/index.js
@@ -150,7 +150,7 @@ internals.compare = function (type, compare) {
                 compareTo = Date.now();
             }
             else if (isRef) {
-                const refValue = date(state.reference || state.parent, options);
+                const refValue = date(state.reference || state.parent, value, options);
                 compareTo = internals.Date.toDate(refValue);
 
                 if (!compareTo) {

--- a/lib/types/number/index.js
+++ b/lib/types/number/index.js
@@ -112,7 +112,7 @@ internals.Number = class extends Any {
 
         return this._test('multiple', base, function (value, state, options) {
 
-            const divisor = isRef ? base(state.reference || state.parent, options) : base;
+            const divisor = isRef ? base(state.reference || state.parent, value, options) : base;
 
             if (isRef && (typeof divisor !== 'number' || !isFinite(divisor))) {
                 return this.createError('number.ref', { ref: base.key }, state, options);
@@ -219,7 +219,7 @@ internals.compare = function (type, compare) {
 
             let compareTo;
             if (isRef) {
-                compareTo = limit(state.reference || state.parent, options);
+                compareTo = limit(state.reference || state.parent, value, options);
 
                 if (!(typeof compareTo === 'number' && !isNaN(compareTo))) {
                     return this.createError('number.ref', { ref: limit.key }, state, options);

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -96,96 +96,8 @@ internals.Object = class extends Any {
 
         // Rename keys
 
-        const renamed = {};
-        for (let i = 0; i < this._inner.renames.length; ++i) {
-            const rename = this._inner.renames[i];
-
-            if (rename.isRegExp) {
-                const targetKeys = Object.keys(target);
-                const matchedTargetKeys = [];
-
-                for (let j = 0; j < targetKeys.length; ++j) {
-                    if (rename.from.test(targetKeys[j])) {
-                        matchedTargetKeys.push(targetKeys[j]);
-                    }
-                }
-
-                const allUndefined = matchedTargetKeys.every((key) => target[key] === undefined);
-                if (rename.options.ignoreUndefined && allUndefined) {
-                    continue;
-                }
-
-                if (!rename.options.multiple &&
-                    renamed[rename.to]) {
-
-                    errors.push(this.createError('object.rename.regex.multiple', { from: matchedTargetKeys, to: rename.to }, state, options));
-                    if (options.abortEarly) {
-                        return finish();
-                    }
-                }
-
-                if (Object.prototype.hasOwnProperty.call(target, rename.to) &&
-                    !rename.options.override &&
-                    !renamed[rename.to]) {
-
-                    errors.push(this.createError('object.rename.regex.override', { from: matchedTargetKeys, to: rename.to }, state, options));
-                    if (options.abortEarly) {
-                        return finish();
-                    }
-                }
-
-                if (allUndefined) {
-                    delete target[rename.to];
-                }
-                else {
-                    target[rename.to] = target[matchedTargetKeys[matchedTargetKeys.length - 1]];
-                }
-
-                renamed[rename.to] = true;
-
-                if (!rename.options.alias) {
-                    for (let j = 0; j < matchedTargetKeys.length; ++j) {
-                        delete target[matchedTargetKeys[j]];
-                    }
-                }
-            }
-            else {
-                if (rename.options.ignoreUndefined && target[rename.from] === undefined) {
-                    continue;
-                }
-
-                if (!rename.options.multiple &&
-                    renamed[rename.to]) {
-
-                    errors.push(this.createError('object.rename.multiple', { from: rename.from, to: rename.to }, state, options));
-                    if (options.abortEarly) {
-                        return finish();
-                    }
-                }
-
-                if (Object.prototype.hasOwnProperty.call(target, rename.to) &&
-                    !rename.options.override &&
-                    !renamed[rename.to]) {
-
-                    errors.push(this.createError('object.rename.override', { from: rename.from, to: rename.to }, state, options));
-                    if (options.abortEarly) {
-                        return finish();
-                    }
-                }
-
-                if (target[rename.from] === undefined) {
-                    delete target[rename.to];
-                }
-                else {
-                    target[rename.to] = target[rename.from];
-                }
-
-                renamed[rename.to] = true;
-
-                if (!rename.options.alias) {
-                    delete target[rename.from];
-                }
-            }
+        if (!this._rename(target, state, options, errors)) {
+            return finish();
         }
 
         // Validate schema
@@ -318,6 +230,103 @@ internals.Object = class extends Any {
         }
 
         return finish();
+    }
+
+    _rename(target, state, options, errors) {
+
+        const renamed = {};
+        for (let i = 0; i < this._inner.renames.length; ++i) {
+            const rename = this._inner.renames[i];
+
+            if (rename.isRegExp) {
+                const targetKeys = Object.keys(target);
+                const matchedTargetKeys = [];
+
+                for (let j = 0; j < targetKeys.length; ++j) {
+                    if (rename.from.test(targetKeys[j])) {
+                        matchedTargetKeys.push(targetKeys[j]);
+                    }
+                }
+
+                const allUndefined = matchedTargetKeys.every((key) => target[key] === undefined);
+                if (rename.options.ignoreUndefined && allUndefined) {
+                    continue;
+                }
+
+                if (!rename.options.multiple &&
+                    renamed[rename.to]) {
+
+                    errors.push(this.createError('object.rename.regex.multiple', { from: matchedTargetKeys, to: rename.to }, state, options));
+                    if (options.abortEarly) {
+                        return false;
+                    }
+                }
+
+                if (Object.prototype.hasOwnProperty.call(target, rename.to) &&
+                    !rename.options.override &&
+                    !renamed[rename.to]) {
+
+                    errors.push(this.createError('object.rename.regex.override', { from: matchedTargetKeys, to: rename.to }, state, options));
+                    if (options.abortEarly) {
+                        return false;
+                    }
+                }
+
+                if (allUndefined) {
+                    delete target[rename.to];
+                }
+                else {
+                    target[rename.to] = target[matchedTargetKeys[matchedTargetKeys.length - 1]];
+                }
+
+                renamed[rename.to] = true;
+
+                if (!rename.options.alias) {
+                    for (let j = 0; j < matchedTargetKeys.length; ++j) {
+                        delete target[matchedTargetKeys[j]];
+                    }
+                }
+            }
+            else {
+                if (rename.options.ignoreUndefined && target[rename.from] === undefined) {
+                    continue;
+                }
+
+                if (!rename.options.multiple &&
+                    renamed[rename.to]) {
+
+                    errors.push(this.createError('object.rename.multiple', { from: rename.from, to: rename.to }, state, options));
+                    if (options.abortEarly) {
+                        return false;
+                    }
+                }
+
+                if (Object.prototype.hasOwnProperty.call(target, rename.to) &&
+                    !rename.options.override &&
+                    !renamed[rename.to]) {
+
+                    errors.push(this.createError('object.rename.override', { from: rename.from, to: rename.to }, state, options));
+                    if (options.abortEarly) {
+                        return false;
+                    }
+                }
+
+                if (target[rename.from] === undefined) {
+                    delete target[rename.to];
+                }
+                else {
+                    target[rename.to] = target[rename.from];
+                }
+
+                renamed[rename.to] = true;
+
+                if (!rename.options.alias) {
+                    delete target[rename.from];
+                }
+            }
+        }
+
+        return true;
     }
 
     keys(schema) {

--- a/lib/types/string/index.js
+++ b/lib/types/string/index.js
@@ -656,7 +656,7 @@ internals.compare = function (type, compare) {
 
             let compareTo;
             if (isRef) {
-                compareTo = limit(state.reference || state.parent, options);
+                compareTo = limit(state.reference || state.parent, value, options);
 
                 if (!Number.isSafeInteger(compareTo)) {
                     return this.createError('string.ref', { ref: limit, value: compareTo }, state, options);

--- a/test/types/alternatives.js
+++ b/test/types/alternatives.js
@@ -313,6 +313,194 @@ describe('alternatives', () => {
                 ]);
             });
 
+            it('validates conditional alternatives (self reference, explicit)', () => {
+
+                const schema = Joi.object({
+                    a: Joi.boolean().required()
+                })
+                    .when(Joi.ref('a', { self: true }), {
+                        is: true,
+                        then: {
+                            b: Joi.string().required()
+                        },
+                        otherwise: {
+                            c: Joi.string().required()
+                        }
+                    });
+
+                Helper.validate(schema, [
+                    [{ a: true, b: 'x' }, true],
+                    [{ a: true, b: 5 }, false, null, {
+                        message: 'child "b" fails because ["b" must be a string]',
+                        details: [{
+                            message: '"b" must be a string',
+                            path: ['b'],
+                            type: 'string.base',
+                            context: { value: 5, key: 'b', label: 'b' }
+                        }]
+                    }],
+                    [{ a: true }, false, null, {
+                        message: 'child "b" fails because ["b" is required]',
+                        details: [{
+                            message: '"b" is required',
+                            path: ['b'],
+                            type: 'any.required',
+                            context: { key: 'b', label: 'b' }
+                        }]
+                    }],
+                    [{ a: true, c: 5 }, false, null, {
+                        message: 'child "b" fails because ["b" is required]',
+                        details: [{
+                            message: '"b" is required',
+                            path: ['b'],
+                            type: 'any.required',
+                            context: { key: 'b', label: 'b' }
+                        }]
+                    }],
+                    [{ a: true, c: 'x' }, false, null, {
+                        message: 'child "b" fails because ["b" is required]',
+                        details: [{
+                            message: '"b" is required',
+                            path: ['b'],
+                            type: 'any.required',
+                            context: { key: 'b', label: 'b' }
+                        }]
+                    }],
+
+                    [{ a: false, b: 'x' }, false, null, {
+                        message: 'child "c" fails because ["c" is required]',
+                        details: [{
+                            message: '"c" is required',
+                            path: ['c'],
+                            type: 'any.required',
+                            context: { key: 'c', label: 'c' }
+                        }]
+                    }],
+                    [{ a: false, b: 5 }, false, null, {
+                        message: 'child "c" fails because ["c" is required]',
+                        details: [{
+                            message: '"c" is required',
+                            path: ['c'],
+                            type: 'any.required',
+                            context: { key: 'c', label: 'c' }
+                        }]
+                    }],
+                    [{ a: false }, false, null, {
+                        message: 'child "c" fails because ["c" is required]',
+                        details: [{
+                            message: '"c" is required',
+                            path: ['c'],
+                            type: 'any.required',
+                            context: { key: 'c', label: 'c' }
+                        }]
+                    }],
+                    [{ a: false, c: 5 }, false, null, {
+                        message: 'child "c" fails because ["c" must be a string]',
+                        details: [{
+                            message: '"c" must be a string',
+                            path: ['c'],
+                            type: 'string.base',
+                            context: { value: 5, key: 'c', label: 'c' }
+                        }]
+                    }],
+                    [{ a: false, c: 'x' }, true]
+                ]);
+            });
+
+            it('validates conditional alternatives (self reference, implicit)', () => {
+
+                const schema = Joi.object({
+                    a: Joi.boolean().required()
+                })
+                    .when('.a', {
+                        is: true,
+                        then: {
+                            b: Joi.string().required()
+                        },
+                        otherwise: {
+                            c: Joi.string().required()
+                        }
+                    });
+
+                Helper.validate(schema, [
+                    [{ a: true, b: 'x' }, true],
+                    [{ a: true, b: 5 }, false, null, {
+                        message: 'child "b" fails because ["b" must be a string]',
+                        details: [{
+                            message: '"b" must be a string',
+                            path: ['b'],
+                            type: 'string.base',
+                            context: { value: 5, key: 'b', label: 'b' }
+                        }]
+                    }],
+                    [{ a: true }, false, null, {
+                        message: 'child "b" fails because ["b" is required]',
+                        details: [{
+                            message: '"b" is required',
+                            path: ['b'],
+                            type: 'any.required',
+                            context: { key: 'b', label: 'b' }
+                        }]
+                    }],
+                    [{ a: true, c: 5 }, false, null, {
+                        message: 'child "b" fails because ["b" is required]',
+                        details: [{
+                            message: '"b" is required',
+                            path: ['b'],
+                            type: 'any.required',
+                            context: { key: 'b', label: 'b' }
+                        }]
+                    }],
+                    [{ a: true, c: 'x' }, false, null, {
+                        message: 'child "b" fails because ["b" is required]',
+                        details: [{
+                            message: '"b" is required',
+                            path: ['b'],
+                            type: 'any.required',
+                            context: { key: 'b', label: 'b' }
+                        }]
+                    }],
+
+                    [{ a: false, b: 'x' }, false, null, {
+                        message: 'child "c" fails because ["c" is required]',
+                        details: [{
+                            message: '"c" is required',
+                            path: ['c'],
+                            type: 'any.required',
+                            context: { key: 'c', label: 'c' }
+                        }]
+                    }],
+                    [{ a: false, b: 5 }, false, null, {
+                        message: 'child "c" fails because ["c" is required]',
+                        details: [{
+                            message: '"c" is required',
+                            path: ['c'],
+                            type: 'any.required',
+                            context: { key: 'c', label: 'c' }
+                        }]
+                    }],
+                    [{ a: false }, false, null, {
+                        message: 'child "c" fails because ["c" is required]',
+                        details: [{
+                            message: '"c" is required',
+                            path: ['c'],
+                            type: 'any.required',
+                            context: { key: 'c', label: 'c' }
+                        }]
+                    }],
+                    [{ a: false, c: 5 }, false, null, {
+                        message: 'child "c" fails because ["c" must be a string]',
+                        details: [{
+                            message: '"c" must be a string',
+                            path: ['c'],
+                            type: 'string.base',
+                            context: { value: 5, key: 'c', label: 'c' }
+                        }]
+                    }],
+                    [{ a: false, c: 'x' }, true]
+                ]);
+            });
+
             it('validates conditional alternatives (empty key)', () => {
 
                 const schema = {

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -10223,7 +10223,7 @@ describe('string', () => {
                 }],
                 ['data:image/png;base64,YW55IGNhcm5hbCBwbGVhc3VyZS4=', true],
                 ['data:image/png;charset=utf-8,=YW55IGNhcm5hbCBwbGVhc3VyZS', true],
-                ['data:text/x-script.phyton;charset=utf-8,=YW55IGNhcm5hbCBwbGVhc3VyZS', true]
+                ['data:text/x-script.python;charset=utf-8,=YW55IGNhcm5hbCBwbGVhc3VyZS', true]
             ]);
         });
 


### PR DESCRIPTION
typo in the example for renaming keys, arguments were not in the right order.