### PR TITLE
Add array().assertItem(). Closes #1656

### DIFF
--- a/API.md
+++ b/API.md
@@ -57,6 +57,7 @@
     - [`array.max(limit)`](#arraymaxlimit)
     - [`array.length(limit)`](#arraylengthlimit)
     - [`array.unique([comparator], [options])`](#arrayuniquecomparator-options)
+    - [`array.assertItem(schema)`](#arrayassertitemschema)
   - [`boolean` - inherits from `Any`](#boolean---inherits-from-any)
     - [`boolean.truthy(value)`](#booleantruthyvalue)
     - [`boolean.falsy(value)`](#booleanfalsyvalue)
@@ -170,6 +171,8 @@
     - [`array.ref`](#arrayref)
     - [`array.sparse`](#arraysparse)
     - [`array.unique`](#arrayunique)
+    - [`array.assertItemKnown`](#arrayassertitemknown)
+    - [`array.assertItemUnknown`](#arrayassertitemunknown)
     - [`binary.base`](#binarybase)
     - [`binary.length`](#binarylength)
     - [`binary.max`](#binarymax)
@@ -1238,6 +1241,24 @@ schema.validate([{}, {}]);
 ```
 
 💥 Possible validation errors:[`array.unique`](#arrayunique)
+
+#### `array.assertItem(schema)`
+
+Verifies that an assertion passes for at least one item in the array, where:
+- `schema` - the validation rules required to satisfy the assertion. If the `schema` includes references, they are resolved against
+  the array item being tested, not the value of the `ref` target.
+
+```js
+const schema = Joi.array().items(
+  Joi.object({
+    a: Joi.string(),
+    b: Joi.number()
+  })
+).assertItem(Joi.object({ a: Joi.string().valid('a'), b: Joi.number() }))
+```
+
+💥 Possible validation errors:[`array.assertItemKnown`](#arrayassertitemknown), [`array.assertitemUnknown`](#arrayassertitemunknown)
+
 
 ### `boolean` - inherits from `Any`
 
@@ -3005,6 +3026,35 @@ A duplicate value was found in an array.
     value: any, // Value that is duplicated
     dupePos: number, // Index where the first appearance of the duplicate value was found in the array
     dupeValue: any // Value with which the duplicate was met
+}
+```
+
+#### `array.assertItemKnown`
+
+**Description**
+
+The schema on an [`array.assertItem()`](#arrayassertitem) failed to validate. This error happens when the schema is labelled.
+
+**Context**
+```ts
+{
+    key: string, // Last element of the path accessing the value, `undefined` if at the root
+    label: string, // Label if defined, otherwise it's the key
+    assertionLabel: string // Label of assertion schema
+}
+```
+
+#### `array.assertItemUnknown`
+
+**Description**
+
+The schema on an [`array.assertItem()`](#arrayassertitem) failed to validate. This error happens when the schema is unlabelled.
+
+**Context**
+```ts
+{
+    key: string, // Last element of the path accessing the value, `undefined` if at the root
+    label: string, // Label if defined, otherwise it's the key
 }
 ```
 

--- a/lib/language.js
+++ b/lib/language.js
@@ -37,6 +37,8 @@ exports.errors = {
         includesRequiredBoth: 'does not contain {{knownMisses}} and {{unknownMisses}} other required value(s)',
         excludes: 'at position {{pos}} contains an excluded value',
         excludesSingle: 'single value of "{{!label}}" contains an excluded value',
+        assertItemKnown: 'does not contain a match for type "{{!assertionLabel}}"',
+        assertItemUnknown: 'failed an assertion test',
         min: 'must contain at least {{limit}} items',
         max: 'must contain less than or equal to {{limit}} items',
         length: 'must contain {{limit}} items',

--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -483,6 +483,41 @@ internals.Array = class extends Any {
         });
     }
 
+    assertItem(schema) {
+
+        try {
+            schema = Cast.schema(this._currentJoi, schema);
+        }
+        catch (castErr) {
+            if (castErr.hasOwnProperty('path')) {
+                castErr.message = castErr.message + '(' + castErr.path + ')';
+            }
+
+            throw castErr;
+        }
+
+        return this._test('assertItem', schema, function (value, state, options) {
+
+            const isValid = value.some((item, idx) => {
+
+                const localState = new State(idx, [...state.path, idx], state.key, state.reference);
+                const result = schema._validate(item, localState, options);
+                return !result.errors;
+            });
+
+            if (isValid) {
+                return value;
+            }
+
+            const assertionLabel = schema._getLabel();
+            if (assertionLabel) {
+                return this.createError('array.assertItemKnown', { assertionLabel }, state, options);
+            }
+
+            return this.createError('array.assertItemUnknown', null, state, options);
+        });
+    }
+
     unique(comparator, configs) {
 
         Hoek.assert(comparator === undefined ||


### PR DESCRIPTION
See #1656 for use case.

@Marsup recommended creating an `array().includes()` method, but Joi already has an "includes" concept for arrays via `array().items()` and it's associated error messages. The target functionality more closely resembles `object().assert()`, except for array items, and as a supplement to `array().items()`.

`array().assertItem()` felt the most self explanatory. Feedback welcome.