### PR TITLE
Set baseType properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -302,6 +302,7 @@ internals.root = function () {
                     super();
                     if (extension.base) {
                         Object.assign(this, base);
+                        this._baseType = extension.base;
                     }
 
                     this._type = extension.name;

--- a/test/index.js
+++ b/test/index.js
@@ -2974,6 +2974,7 @@ describe('Joi', () => {
 
             const schema = customJoi.myType();
             expect(schema._type).to.equal('myType');
+            expect(schema._baseType).to.be.undefined();
             expect(schema.isJoi).to.be.true();
         });
 
@@ -2988,6 +2989,7 @@ describe('Joi', () => {
             expect(customJoi.myType).to.be.a.function();
 
             const schema = customJoi.myType();
+            expect(schema._baseType._type).to.equal('string');
             Helper.validate(schema, [
                 [123, false, null, {
                     message: '"value" must be a string',
@@ -3028,6 +3030,7 @@ describe('Joi', () => {
             expect(customJoi.myType).to.be.a.function();
 
             const schema = customJoi.myType({ a: customJoi.number() });
+            expect(schema._baseType._type).to.equal('object');
             Helper.validate(schema, [
                 [undefined, true],
                 [{}, true],
@@ -3074,6 +3077,7 @@ describe('Joi', () => {
             expect(original.bar).to.not.exist();
 
             const schema = customJoi.myType();
+            expect(schema._baseType).to.be.undefined();
             const valid = schema.foo().validate({});
             const invalid = schema.bar().validate({});
 
@@ -3633,6 +3637,11 @@ describe('Joi', () => {
 
                 const schema = customJoi.myType();
                 expect(schema.describe()).to.equal({
+                    base: {
+                        flags: { unsafe: false },
+                        invalids: [Infinity, -Infinity],
+                        type: 'number'
+                    },
                     type: 'myType',
                     invalids: [Infinity, -Infinity],
                     flags: { unsafe: false }


### PR DESCRIPTION
In the current implementation, the baseType property is not being set as it should when making an extension of Joi.
This PR enables that functionality, thus attaching the base object into that property.

It has been quite difficult to figure what's the purpose of the baseType. It is very likely that I might have confused concepts. But I understand it as the object assigned to the base property when extending.

```
var extendedJoi = joi.extend((_joi) => ({
	base: _joi.string().allow(null),
	name: 'nullableString', // edited, since it has to be a non-native name
}));
```
`extendedJoi()._baseType` should be `joi.string()`

Adding this functionality is key for other libraries that depend in Joi.