### PR TITLE
Allow validate options to be passed through assert/attempt #1722

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,8 +11,8 @@
   - [`validate(value, schema, [options], [callback])`](#validatevalue-schema-options-callback)
   - [`compile(schema)`](#compileschema)
   - [`describe(schema)`](#describeschema)
-  - [`assert(value, schema, [message])`](#assertvalue-schema-message)
-  - [`attempt(value, schema, [message])`](#attemptvalue-schema-message)
+  - [`assert(value, schema, [message], [options])`](#assertvalue-schema-message-options)
+  - [`attempt(value, schema, [message], [options])`](#attemptvalue-schema-message-options)
   - [`ref(key, [options])`](#refkey-options)
   - [`isRef(ref)`](#isrefref)
   - [`reach(schema, path)`](#reachschema-path)
@@ -371,23 +371,25 @@ Results in:
   valids: [ 'foo', 'bar' ] }
 ```
 
-### `assert(value, schema, [message])`
+### `assert(value, schema, [message], [options])`
 
 Validates a value against a schema and [throws](#errors) if validation fails where:
 - `value` - the value to validate.
 - `schema` - the validation schema. Can be a **joi** type object or a plain object where every key is assigned a **joi** type object using [`Joi.compile`](#compileschema) (be careful of the cost of compiling repeatedly the same schemas).
 - `message` - optional message string prefix added in front of the error message. may also be an Error object.
+- `options` - optional options object, passed in to [`Joi.validate`](##validatevalue-schema-options-callback)
 
 ```js
 Joi.assert('x', Joi.number());
 ```
 
-### `attempt(value, schema, [message])`
+### `attempt(value, schema, [message], [options])`
 
 Validates a value against a schema, returns valid object, and [throws](#errors) if validation fails where:
 - `value` - the value to validate.
 - `schema` - the validation schema. Can be a **joi** type object or a plain object where every key is assigned a **joi** type object using [`Joi.compile`](#compileschema) (be careful of the cost of compiling repeatedly the same schemas).
 - `message` - optional message string prefix added in front of the error message. may also be an Error object.
+- `options` - optional options object, passed in to [`Joi.validate`](##validatevalue-schema-options-callback)
 
 ```js
 Joi.attempt('x', Joi.number()); // throws error

--- a/lib/index.js
+++ b/lib/index.js
@@ -167,14 +167,21 @@ internals.root = function () {
         }
     };
 
-    root.assert = function (value, schema, message) {
+    root.assert = function (...args) {
 
-        this.attempt(value, schema, message);
+        this.attempt(...args);
     };
 
-    root.attempt = function (value, schema, message) {
+    root.attempt = function (value, schema, ...args/* [message], [options]*/) {
 
-        const result = this.validate(value, schema);
+        const first = args[0];
+        const message = (
+            first instanceof Error ||
+            typeof first === 'string'
+        ) ? first : null;
+
+        const options = message ? args[1] : args[0];
+        const result = this.validate(value, schema, options);
         const error = result.error;
         if (error) {
             if (!message) {

--- a/test/index.js
+++ b/test/index.js
@@ -2637,6 +2637,17 @@ describe('Joi', () => {
             }).to.not.throw();
             expect(result).to.not.exist();
         });
+
+        it('respects abortEarly option', () => {
+
+            try {
+                Joi.assert({}, Joi.object().keys({ a: Joi.required(), b: Joi.required() }), { abortEarly: false });
+                throw new Error('should not reach that');
+            }
+            catch (err) {
+                expect(err.details.length).to.equal(2);
+            }
+        });
     });
 
     describe('attempt()', () => {
@@ -2675,11 +2686,23 @@ describe('Joi', () => {
             }).to.throw('the reason is "value" must be a number');
         });
 
-        it('throws on invalid value with message as error', () => {
+        it('throws on invalid value with message and abortEarly: false', () => {
+
+            try {
+                Joi.attempt({}, Joi.object().keys({ a: Joi.required(), b: Joi.required() }), 'the reasons are', { abortEarly: false });
+                throw new Error('should not reach that');
+            }
+            catch (err) {
+                expect(err.message.match(/the reasons are/)).to.not.equal(null);
+                expect(err.details.length).to.equal(2);
+            }
+        });
+
+        it('throws on invalid value with message as error even with abortEarly: false', () => {
 
             expect(() => {
 
-                Joi.attempt('x', Joi.number(), new Error('invalid value'));
+                Joi.attempt({}, Joi.object().keys({ a: Joi.required(), b: Joi.required() }), new Error('invalid value'), { abortEarly: false });
             }).to.throw('invalid value');
         });
 


### PR DESCRIPTION
Per discussion in #1722 

One note is that since `attempt`/`assert` leverage `error.annotate()`, the error message is messier 
than I think @sarneeh was hoping for. This was already the case for `attempt`/`assert` on objects, though, and allowing `abortEarly` through does add the additional field annotations as well as the additional `error.details`.