### PR TITLE
Pass options to pattern validation to support refs

### DIFF
--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2022,6 +2022,14 @@ describe('object', () => {
 
             expect(error).to.equal(true);
         });
+
+        it('allows using refs in .valid() schema pattern', async () => {
+
+            const schema = Joi.object().pattern(Joi.string().valid(Joi.ref('$keys')), Joi.any());
+
+            const value = await Joi.validate({ a: 'test' }, schema, { context: { keys: ['a'] } });
+            expect(value).to.equal({ a: 'test' });
+        });
     });
 
     describe('with()', () => {


### PR DESCRIPTION
Re: #1748 Passes validation options through to pattern validation to support context refs.