### PR TITLE
Don't delete object key when it equals the rename.to in a rename with regex

### DIFF
--- a/API.md
+++ b/API.md
@@ -294,6 +294,7 @@ Validates a value using the given schema and options where:
     `validate()` and not using `any.options()`.
   - `noDefaults` - when `true`, do not apply default values. Defaults to `false`.
   - `escapeHtml` - when `true`, error message templates will escape special characters to HTML entities, for security purposes. Defaults to `false`.
+  - `keysToLowerCase` - when `true` all of the value's object keys will be lower cased. Defaults to `false`.
 - `callback` - the optional synchronous callback method using the signature `function(err, value)` where:
   - `err` - if validation failed, the [error](#errors) reason, otherwise `null`.
   - `value` - the validated value with any type conversions and other modifiers applied (the input is left unchanged). `value` can be
@@ -1621,7 +1622,7 @@ const schema = Joi.func().ref();
 
 ### `number` - inherits from `Any`
 
-Generates a schema object that matches a number data type (as well as strings that can be converted to numbers). 
+Generates a schema object that matches a number data type (as well as strings that can be converted to numbers).
 
 By default, it only allows safe numbers, see [`number.unsafe()`](#numberunsafeenabled).
 
@@ -2389,7 +2390,7 @@ Requires the string value to be a valid email address.
     - `errorLevel` - Numerical threshold at which an email address is considered invalid.
     - `tldWhitelist` - Specifies a list of acceptable TLDs.
     - `minDomainAtoms` - Number of atoms required for the domain. Be careful since some domains, such as `io`, directly allow email.
-    
+
 Have a look at [`isemail`’s documentation](https://github.com/hapijs/isemail) for a detailed description of the options.
 
 ```js
@@ -2591,7 +2592,7 @@ const schema = Joi.string().isoDate();
 
 Generates a schema object that matches a `Symbol` data type.
 
-If the validation `convert` option is on (enabled by default), the mappings declared in `map()` will be tried for an eventual match. 
+If the validation `convert` option is on (enabled by default), the mappings declared in `map()` will be tried for an eventual match.
 
 Supports the same methods of the [`any()`](#any) type.
 
@@ -2608,7 +2609,7 @@ Allows values to be transformed into `Symbol`s, where:
 - `map` - mapping declaration that can be:
   - an object, where keys are strings, and values are `Symbol`s
   - an array of arrays of length 2, where for each sub-array, the 1st element must be anything but an object, a function or a `Symbol`, and the 2nd element must be a Symbol
-  - a `Map`, following the same principles as the array above 
+  - a `Map`, following the same principles as the array above
 
 ```js
 const schema = Joi.symbol().map([
@@ -3593,7 +3594,7 @@ The number didn't look like a port number.
 {
     key: string, // Last element of the path accessing the value, `undefined` if at the root
     label: string, // Label if defined, otherwise it's the key
-    value: number // The number itself 
+    value: number // The number itself
 }
 ```
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -21,5 +21,6 @@ exports.options = Joi.object({
     context: Joi.object(),
     strip: Joi.boolean(),
     noDefaults: Joi.boolean(),
-    escapeHtml: Joi.boolean()
+    escapeHtml: Joi.boolean(),
+    keysToLowerCase: Joi.boolean()
 }).strict();

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -32,7 +32,8 @@ internals.defaults = {
     presence: 'optional',
     strip: false,
     noDefaults: false,
-    escapeHtml: false
+    escapeHtml: false,
+    keysToLowerCase: false
 
     // context: null
 };
@@ -757,6 +758,20 @@ module.exports = internals.Any = class {
 
         if (options) {
             this.checkOptions(options);
+        }
+
+         // Normalize Keys
+         if (options && options.keysToLowerCase) {
+            const keys = Object.keys(value);
+            for (let i = 0; i < keys.length; ++i) {
+                const key =  keys[i];
+                var k = key.toLowerCase();
+
+                if (k !== key) {
+                    value[k] = value[key];
+                    delete value[key];
+                }
+            }
         }
 
         const settings = Settings.concat(internals.defaults, options);

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -760,12 +760,12 @@ module.exports = internals.Any = class {
             this.checkOptions(options);
         }
 
-         // Normalize Keys
-         if (options && options.keysToLowerCase) {
+        // Normalize Keys
+        if (options && options.keysToLowerCase) {
             const keys = Object.keys(value);
             for (let i = 0; i < keys.length; ++i) {
                 const key =  keys[i];
-                var k = key.toLowerCase();
+                const k = key.toLowerCase();
 
                 if (k !== key) {
                     value[k] = value[key];

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -145,7 +145,9 @@ internals.Object = class extends Any {
 
                 if (!rename.options.alias) {
                     for (let j = 0; j < matchedTargetKeys.length; ++j) {
-                        delete target[matchedTargetKeys[j]];
+                        if (rename.to !== matchedTargetKeys[j]) {
+                            delete target[matchedTargetKeys[j]];
+                        }
                     }
                 }
             }

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1292,31 +1292,37 @@ describe('object', () => {
 
                 const schema = Joi.object().keys({ z: Joi.string() }).rename(/a/i, 'b').rename(/c/i, 'b').rename(/z/i, 'z').options({ abortEarly: false });
                 const err = await expect(schema.validate({ a: 1, c: 1, d: 1, z: 1 })).to.reject();
-                expect(err.message).to.equal('"value" cannot rename children [c] because multiple renames are disabled and another key was already renamed to "b". "value" cannot rename children [z] because override is disabled and target "z" exists. "d" is not allowed. "b" is not allowed');
+                expect(err.message).to.equal('"value" cannot rename children [c] because multiple renames are disabled and another key was already renamed to "b". "value" cannot rename children [z] because override is disabled and target "z" exists. child "z" fails because ["z" must be a string]. "d" is not allowed. "b" is not allowed');
                 expect(err.details).to.equal([
                     {
                         message: '"value" cannot rename children [c] because multiple renames are disabled and another key was already renamed to "b"',
-                        path: [],
+                        path: [ ],
                         type: 'object.rename.regex.multiple',
-                        context: { from: ['c'], to: 'b', key: undefined, label: 'value' }
+                        context: { from: [ 'c' ], to: 'b', label: 'value', key: undefined }
                     },
                     {
-                        message: '"value" cannot rename children [z] because override is disabled and target "z" exists',
-                        path: [],
+                        message:'"value" cannot rename children [z] because override is disabled and target "z" exists',
+                        path: [ ],
                         type: 'object.rename.regex.override',
-                        context: { from: ['z'], to: 'z', key: undefined, label: 'value' }
+                        context: { from: [ 'z' ], to: 'z', label: 'value', key: undefined }
                     },
                     {
-                        message: '"d" is not allowed',
-                        path: ['d'],
-                        type: 'object.allowUnknown',
-                        context: { child: 'd', key: 'd', label: 'd', value: 1 }
+                        message:'"z" must be a string',
+                        path: [ 'z' ],
+                        type: 'string.base',
+                        context: { value: 1, key: 'z', label: 'z' }
                     },
                     {
-                        message: '"b" is not allowed',
-                        path: ['b'],
+                        message:'"d" is not allowed',
+                        path: [ 'd' ],
                         type: 'object.allowUnknown',
-                        context: { child: 'b', key: 'b', label: 'b', value: 1 }
+                        context: { child: 'd', value: 1, key: 'd', label: 'd'}
+                    },
+                    {
+                        message:'"b" is not allowed',
+                        path: [ 'b' ],
+                        type: 'object.allowUnknown',
+                        context: { child: 'b', value: 1, key: 'b', label: 'b' }
                     }
                 ]);
             });
@@ -3418,6 +3424,37 @@ describe('object', () => {
                 [{ a: 0, b: 0 }, true]
             ]);
         });
+    });
+
+    describe('should normalize keysToLowerCase', () => {
+
+        it('should set keys to lower case', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().required(),
+            });
+            const result = Joi.validate({ A: 1 }, schema, { keysToLowerCase: true });
+            expect(result.value.a).to.equal(1);
+        });
+
+        it('should leave keys as is', () => {
+
+            const schema = Joi.object({
+                A: Joi.number().required(),
+            });
+            const result = Joi.validate({ A: 1 }, schema, { keysToLowerCase: false });
+            expect(result.value.A).to.equal(1);
+        });
+
+        it('should leave keys as is by default keysToLowerCase is false', () => {
+
+            const schema = Joi.object({
+                A: Joi.number().required(),
+            });
+            const result = Joi.validate({ A: 1 }, schema);
+            expect(result.value.A).to.equal(1);
+        });
+
     });
 
     describe('forbiddenKeys()', () => {

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1296,31 +1296,31 @@ describe('object', () => {
                 expect(err.details).to.equal([
                     {
                         message: '"value" cannot rename children [c] because multiple renames are disabled and another key was already renamed to "b"',
-                        path: [ ],
+                        path: [],
                         type: 'object.rename.regex.multiple',
-                        context: { from: [ 'c' ], to: 'b', label: 'value', key: undefined }
+                        context: { from: ['c'], to: 'b', label: 'value', key: undefined }
                     },
                     {
                         message:'"value" cannot rename children [z] because override is disabled and target "z" exists',
-                        path: [ ],
+                        path: [],
                         type: 'object.rename.regex.override',
-                        context: { from: [ 'z' ], to: 'z', label: 'value', key: undefined }
+                        context: { from: ['z'], to: 'z', label: 'value', key: undefined }
                     },
                     {
                         message:'"z" must be a string',
-                        path: [ 'z' ],
+                        path: ['z'],
                         type: 'string.base',
                         context: { value: 1, key: 'z', label: 'z' }
                     },
                     {
                         message:'"d" is not allowed',
-                        path: [ 'd' ],
+                        path: ['d'],
                         type: 'object.allowUnknown',
-                        context: { child: 'd', value: 1, key: 'd', label: 'd'}
+                        context: { child: 'd', value: 1, key: 'd', label: 'd' }
                     },
                     {
                         message:'"b" is not allowed',
-                        path: [ 'b' ],
+                        path: ['b'],
                         type: 'object.allowUnknown',
                         context: { child: 'b', value: 1, key: 'b', label: 'b' }
                     }
@@ -3431,7 +3431,7 @@ describe('object', () => {
         it('should set keys to lower case', () => {
 
             const schema = Joi.object({
-                a: Joi.number().required(),
+                a: Joi.number().required()
             });
             const result = Joi.validate({ A: 1 }, schema, { keysToLowerCase: true });
             expect(result.value.a).to.equal(1);
@@ -3440,7 +3440,7 @@ describe('object', () => {
         it('should leave keys as is', () => {
 
             const schema = Joi.object({
-                A: Joi.number().required(),
+                A: Joi.number().required()
             });
             const result = Joi.validate({ A: 1 }, schema, { keysToLowerCase: false });
             expect(result.value.A).to.equal(1);
@@ -3449,7 +3449,7 @@ describe('object', () => {
         it('should leave keys as is by default keysToLowerCase is false', () => {
 
             const schema = Joi.object({
-                A: Joi.number().required(),
+                A: Joi.number().required()
             });
             const result = Joi.validate({ A: 1 }, schema);
             expect(result.value.A).to.equal(1);


### PR DESCRIPTION
Calling rename with a regex where the key matches the `rename.to` causes the key to get deleted from the object.

Example: I use the folllowing schema to validate an AWS x-api-key header:

```
Joi.object()
    .keys({
        'x-api-key': stringsSchema.awsApiKey.required(),
    })
    .rename(/x-api-key/i, 'x-api-key', {
        // alias: true,
        override: true,
        ignoreUndefined: true,
    })
```

Using rename to force a value such as 'X-ApI-KeY' to be all lower case, and therefore normalizing it to 'x-api-key'. 
The bug is when the header is already all lower case 'x-api-key', the `rename.from` is the same as `rename.to` so it gets deleted if `option.alias = false`, leaving the object with no `x-api-key` at all.

So this:

```
const Joi = require('joi');

const schema = Joi.object()
    .keys({
        'x-api-key': Joi.string().token().min(30).max(128),
    })
    .rename(/x-api-key/i, 'x-api-key', {
        // alias: true,
        override: true,
        ignoreUndefined: true,
    });

const result = Joi.attempt({
      'x-api-key': 'ABCEFGHIJKLMNOPQRSTUVXYWZabcefghijklmnopqrstuvxywz0123456789'
 }, schema);

console.log(result); // prints { }
```





