### PR TITLE
Faster object/array conversion fails

### DIFF
--- a/benchmarks/suite.js
+++ b/benchmarks/suite.js
@@ -38,6 +38,23 @@ module.exports = [
         }
     ],
     [
+        'JSON object',
+        () => [
+            Joi.object({
+                id: Joi.string().required(),
+                level: Joi.string()
+                    .valid(['debug', 'info', 'notice'])
+                    .required()
+            }).unknown(false),
+            '{ "id": "1", "level": "info" }',
+            'invalid'
+        ],
+        (schema, value) => {
+
+            return schema.validate(value, { convert: true });
+        }
+    ],
+    [
         'Schema creation',
         () =>  [],
         () => {

--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -49,7 +49,14 @@ internals.Array = class extends Any {
         if (typeof value === 'string' &&
             options.convert) {
 
-            internals.safeParse(value, result);
+            if (value.length > 1 &&
+                (value[0] === '[' || /^\s*\[/.test(value))) {
+
+                try {
+                    result.value = JSON.parse(value);
+                }
+                catch (e) { }
+            }
         }
 
         let isArray = Array.isArray(result.value);
@@ -689,18 +696,6 @@ internals.Array = class extends Any {
         }
     }
 
-};
-
-
-internals.safeParse = function (value, result) {
-
-    try {
-        const converted = JSON.parse(value);
-        if (Array.isArray(converted)) {
-            result.value = converted;
-        }
-    }
-    catch (e) { }
 };
 
 

--- a/lib/types/binary/index.js
+++ b/lib/types/binary/index.js
@@ -31,8 +31,7 @@ internals.Binary = class extends Any {
             try {
                 result.value = Buffer.from(value, this._flags.encoding);
             }
-            catch (e) {
-            }
+            catch (e) { }
         }
 
         result.errors = Buffer.isBuffer(result.value) ? null : this.createError('binary.base', null, state, options);

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -47,7 +47,14 @@ internals.Object = class extends Any {
         if (typeof value === 'string' &&
             options.convert) {
 
-            value = internals.safeParse(value);
+            if (value.length > 1 &&
+                (value[0] === '{' || /^\s*\{/.test(value))) {
+
+                try {
+                    value = JSON.parse(value);
+                }
+                catch (e) { }
+            }
         }
 
         const type = this._flags.func ? 'function' : 'object';
@@ -724,16 +731,6 @@ internals.Object = class extends Any {
             return this.createError('object.type', { type: typeData.name, value }, state, options);
         });
     }
-};
-
-internals.safeParse = function (value) {
-
-    try {
-        return JSON.parse(value);
-    }
-    catch (parseErr) {}
-
-    return value;
 };
 
 

--- a/test/types/array.js
+++ b/test/types/array.js
@@ -38,6 +38,12 @@ describe('array', () => {
         expect(value.length).to.equal(3);
     });
 
+    it('converts a string with whitespace to an array', async () => {
+
+        const value = await Joi.array().validate(' \n\r\t[ \n\r\t1 \n\r\t, \n\r\t2,3] \n\r\t');
+        expect(value.length).to.equal(3);
+    });
+
     it('errors on non-array string', async () => {
 
         const err = await expect(Joi.array().validate('{ "something": false }')).to.reject('"value" must be an array');

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -31,6 +31,12 @@ describe('object', () => {
         expect(value.hi).to.equal(true);
     });
 
+    it('converts a json string with whitespace to an object', async () => {
+
+        const value = await Joi.object().validate(' \n\r\t{ \n\r\t"hi" \n\r\t: \n\r\ttrue \n\r\t} \n\r\t');
+        expect(value).to.equal({ hi: true });
+    });
+
     it('fails on json string in strict mode', async () => {
 
         await expect(Joi.object().strict().validate('{"hi":true}')).to.reject('"value" must be an object');


### PR DESCRIPTION
This patch speeds up object and array string conversions for the type of invalid inputs that are likely in an `alternatives()` schema. On my machine the included benchmark shows a ~80% increase in throughput.

Note: This slightly changes some of the errors generated from object conversions since it no longer parses non-objects. Eg. `Joi.object().validate('"hello"')` now has `"hello"` in `err.context.value` instead of `hello`. I don't think this is an issue, and I suspect it is actually a bug fix.

**Background**

Throws are very expensive in v8, so it pays to avoid them whenever possible. This is done by screening the strings that are passed to `JSON.parse()` to avoid parsing strings that have no chance to parse into something we need.

The screening is done by a regex. Since this adds a noticeable overhead for valid inputs, a pre-screening is done as well to avoid running it for most valid inputs. Finally, there is a pre-pre-screening, with an ultrafast length check, to skip the whole thing.

I also moved the logic inline, since v8 no longer deoptimizes functions with `try/catch` blocks.