### PR TITLE
Don't delete object key when it equals the rename.to in a rename with regex

### DIFF
--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -142,7 +142,9 @@ internals.Object = class extends Any {
 
                 if (!rename.options.alias) {
                     for (let j = 0; j < matchedTargetKeys.length; ++j) {
-                        delete target[matchedTargetKeys[j]];
+                        if (rename.to !== matchedTargetKeys[j]) {
+                            delete target[matchedTargetKeys[j]];
+                        }
                     }
                 }
             }

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1289,31 +1289,37 @@ describe('object', () => {
 
                 const schema = Joi.object().keys({ z: Joi.string() }).rename(/a/i, 'b').rename(/c/i, 'b').rename(/z/i, 'z').options({ abortEarly: false });
                 const err = await expect(schema.validate({ a: 1, c: 1, d: 1, z: 1 })).to.reject();
-                expect(err.message).to.equal('"value" cannot rename children [c] because multiple renames are disabled and another key was already renamed to "b". "value" cannot rename children [z] because override is disabled and target "z" exists. "d" is not allowed. "b" is not allowed');
+                expect(err.message).to.equal('"value" cannot rename children [c] because multiple renames are disabled and another key was already renamed to "b". "value" cannot rename children [z] because override is disabled and target "z" exists. child "z" fails because ["z" must be a string]. "d" is not allowed. "b" is not allowed');
                 expect(err.details).to.equal([
                     {
                         message: '"value" cannot rename children [c] because multiple renames are disabled and another key was already renamed to "b"',
                         path: [],
                         type: 'object.rename.regex.multiple',
-                        context: { from: ['c'], to: 'b', key: undefined, label: 'value' }
+                        context: { from: ['c'], to: 'b', label: 'value', key: undefined }
                     },
                     {
-                        message: '"value" cannot rename children [z] because override is disabled and target "z" exists',
+                        message:'"value" cannot rename children [z] because override is disabled and target "z" exists',
                         path: [],
                         type: 'object.rename.regex.override',
-                        context: { from: ['z'], to: 'z', key: undefined, label: 'value' }
+                        context: { from: ['z'], to: 'z', label: 'value', key: undefined }
                     },
                     {
-                        message: '"d" is not allowed',
+                        message:'"z" must be a string',
+                        path: ['z'],
+                        type: 'string.base',
+                        context: { value: 1, key: 'z', label: 'z' }
+                    },
+                    {
+                        message:'"d" is not allowed',
                         path: ['d'],
                         type: 'object.allowUnknown',
-                        context: { child: 'd', key: 'd', label: 'd', value: 1 }
+                        context: { child: 'd', value: 1, key: 'd', label: 'd' }
                     },
                     {
-                        message: '"b" is not allowed',
+                        message:'"b" is not allowed',
                         path: ['b'],
                         type: 'object.allowUnknown',
-                        context: { child: 'b', key: 'b', label: 'b', value: 1 }
+                        context: { child: 'b', value: 1, key: 'b', label: 'b' }
                     }
                 ]);
             });


### PR DESCRIPTION
Separating out the rename fix from the`keysToLowerCase` 

Description copied from original pull request #1763, for easier reference.

Calling rename with a regex where the key matches the `rename.to` causes the key to get deleted from the object.

Example: I use the folllowing schema to validate an AWS x-api-key header:

```
Joi.object()
    .keys({
        'x-api-key': stringsSchema.awsApiKey.required(),
    })
    .rename(/x-api-key/i, 'x-api-key', {
        // alias: true,
        override: true,
        ignoreUndefined: true,
    })
```

Using rename to force a value such as 'X-ApI-KeY' to be all lower case, and therefore normalizing it to 'x-api-key'. 
The bug is when the header is already all lower case 'x-api-key', the `rename.from` is the same as `rename.to` so it gets deleted if `option.alias = false`, leaving the object with no `x-api-key` at all.

So this:

```
const Joi = require('joi');

const schema = Joi.object()
    .keys({
        'x-api-key': Joi.string().token().min(30).max(128),
    })
    .rename(/x-api-key/i, 'x-api-key', {
        // alias: true,
        override: true,
        ignoreUndefined: true,
    });

const result = Joi.attempt({
      'x-api-key': 'ABCEFGHIJKLMNOPQRSTUVXYWZabcefghijklmnopqrstuvxywz0123456789'
 }, schema);

console.log(result); // prints { }
```
