### PR TITLE
LowerCase all Object keys in validate

### DIFF
--- a/API.md
+++ b/API.md
@@ -292,6 +292,7 @@ Validates a value using the given schema and options where:
     `validate()` and not using `any.options()`.
   - `noDefaults` - when `true`, do not apply default values. Defaults to `false`.
   - `escapeHtml` - when `true`, error message templates will escape special characters to HTML entities, for security purposes. Defaults to `false`.
+  - `keysToLowerCase` - when `true` all of the value's object keys will be lower cased. Defaults to `false`.
 - `callback` - the optional synchronous callback method using the signature `function(err, value)` where:
   - `err` - if validation failed, the [error](#errors) reason, otherwise `null`.
   - `value` - the validated value with any type conversions and other modifiers applied (the input is left unchanged). `value` can be
@@ -1619,7 +1620,7 @@ const schema = Joi.func().ref();
 
 ### `number` - inherits from `Any`
 
-Generates a schema object that matches a number data type (as well as strings that can be converted to numbers). 
+Generates a schema object that matches a number data type (as well as strings that can be converted to numbers).
 
 By default, it only allows safe numbers, see [`number.unsafe()`](#numberunsafeenabled).
 
@@ -2387,7 +2388,7 @@ Requires the string value to be a valid email address.
     - `errorLevel` - Numerical threshold at which an email address is considered invalid.
     - `tldWhitelist` - Specifies a list of acceptable TLDs.
     - `minDomainAtoms` - Number of atoms required for the domain. Be careful since some domains, such as `io`, directly allow email.
-    
+
 Have a look at [`isemail`’s documentation](https://github.com/hapijs/isemail) for a detailed description of the options.
 
 ```js
@@ -2589,7 +2590,7 @@ const schema = Joi.string().isoDate();
 
 Generates a schema object that matches a `Symbol` data type.
 
-If the validation `convert` option is on (enabled by default), the mappings declared in `map()` will be tried for an eventual match. 
+If the validation `convert` option is on (enabled by default), the mappings declared in `map()` will be tried for an eventual match.
 
 Supports the same methods of the [`any()`](#any) type.
 
@@ -2606,7 +2607,7 @@ Allows values to be transformed into `Symbol`s, where:
 - `map` - mapping declaration that can be:
   - an object, where keys are strings, and values are `Symbol`s
   - an array of arrays of length 2, where for each sub-array, the 1st element must be anything but an object, a function or a `Symbol`, and the 2nd element must be a Symbol
-  - a `Map`, following the same principles as the array above 
+  - a `Map`, following the same principles as the array above
 
 ```js
 const schema = Joi.symbol().map([
@@ -3591,7 +3592,7 @@ The number didn't look like a port number.
 {
     key: string, // Last element of the path accessing the value, `undefined` if at the root
     label: string, // Label if defined, otherwise it's the key
-    value: number // The number itself 
+    value: number // The number itself
 }
 ```
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -18,5 +18,6 @@ exports.options = Joi.object({
     context: Joi.object(),
     strip: Joi.boolean(),
     noDefaults: Joi.boolean(),
-    escapeHtml: Joi.boolean()
+    escapeHtml: Joi.boolean(),
+    keysToLowerCase: Joi.boolean()
 }).strict();

--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -28,7 +28,8 @@ internals.defaults = {
     presence: 'optional',
     strip: false,
     noDefaults: false,
-    escapeHtml: false
+    escapeHtml: false,
+    keysToLowerCase: false
 
     // context: null
 };
@@ -753,6 +754,20 @@ module.exports = internals.Any = class {
 
         if (options) {
             this.checkOptions(options);
+        }
+
+        // Normalize Keys
+        if (options && options.keysToLowerCase) {
+            const keys = Object.keys(value);
+            for (let i = 0; i < keys.length; ++i) {
+                const key =  keys[i];
+                const k = key.toLowerCase();
+
+                if (k !== key) {
+                    value[k] = value[key];
+                    delete value[key];
+                }
+            }
         }
 
         const settings = Settings.concat(internals.defaults, options);

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -3417,6 +3417,48 @@ describe('object', () => {
         });
     });
 
+    describe('should normalize keysToLowerCase', () => {
+
+        it('should set keys to lower case', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().required()
+            });
+            const result = Joi.validate({ A: 1 }, schema, { keysToLowerCase: true });
+            expect(result.value.a).to.equal(1);
+        });
+
+        it('should leave keys as is', () => {
+
+            const schema = Joi.object({
+                A: Joi.number().required()
+            });
+            const result = Joi.validate({ A: 1 }, schema, { keysToLowerCase: false });
+            expect(result.value.A).to.equal(1);
+        });
+
+        it('should leave keys as is by default keysToLowerCase is false', () => {
+
+            const schema = Joi.object({
+                A: Joi.number().required()
+            });
+            const result = Joi.validate({ A: 1 }, schema);
+            expect(result.value.A).to.equal(1);
+        });
+
+        it('should not delete lower case keys', () => {
+
+            const schema = Joi.object({
+                a: Joi.number().required(),
+                b: Joi.number().required()
+            });
+            const result = Joi.validate({ a: 1, B: 2 }, schema, { keysToLowerCase: true });
+            expect(result.value.a).to.equal(1);
+            expect(result.value.b).to.equal(2);
+        });
+
+    });
+
     describe('forbiddenKeys()', () => {
 
         it('should set keys as forbidden', () => {


### PR DESCRIPTION
It's hard to write schemas that validate object keys that are case insensitive. For example AWS API Gateway send headers to a Lambda function as is from the client. So the function could receive  `X-API-KEY`, or `X-API-Key` in the `event` object.

Here's a log output from CloudWatch:

```
{
    "headers": {
        "Accept": "*/*",
        "accept-encoding": "gzip, deflate",
        "cache-control": "no-cache",
        "Host": "api.1login.io",
        "Postman-Token": "a3fa85e6-4b73-35ce-df2b-8a6199553397",
        "User-Agent": "PostmanRuntime/7.6.1",
        "X-Amzn-Trace-Id": "Root=1-5c9beda7-836cfbda4352e8520c0ff20a",
        "X-Api-KeY": "*****************************************",
        "X-Forwarded-For": "X.X.X.X",
        "X-Forwarded-Port": "443",
        "X-Forwarded-Proto": "https"
    }
}
```

As can be seen in the log output the AWS API Gateway, unlike node, does not lower case the headers. This makes it really hard to create Joi schemas that validate header values.
Tried with .pattern and .rename but it becomes really cumbersome.

Implemented a possible solution that normalized the keys to lower case adding `{ keysToLowerCase: true }` option to the `validate` call.

Discussed in issue #1085
