### PR TITLE
Fix hapitoc 'API Reference' link generation in README.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@hapi/joi",
   "description": "Object schema validation",
   "version": "14.4.1",
+  "homepage": "https://github.com/hapijs/joi",
   "repository": "git://github.com/hapijs/joi",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
Restores the `homepage` property to `package.json`. This property is required for the correct operation of hapitoc's documentation generation as per #1773.

**Changes**
- `package.json`- Restore the `homepage` property

_No test changes required_