### PR TITLE
fix: copy object including Symbols

### DIFF
--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -78,7 +78,7 @@ internals.Object = class extends Any {
 
         if (target === value) {
             if (type === 'object') {
-                target = Object.create(Object.getPrototypeOf(value));
+                target = Object.assign({}, value);
             }
             else {
                 target = function (...args) {

--- a/lib/types/object/index.js
+++ b/lib/types/object/index.js
@@ -87,11 +87,11 @@ internals.Object = class extends Any {
                 };
 
                 target.prototype = Hoek.clone(value.prototype);
-            }
 
-            const valueKeys = Object.keys(value);
-            for (let i = 0; i < valueKeys.length; ++i) {
-                target[valueKeys[i]] = value[valueKeys[i]];
+                const valueKeys = Object.keys(value);
+                for (let i = 0; i < valueKeys.length; ++i) {
+                    target[valueKeys[i]] = value[valueKeys[i]];
+                }
             }
         }
         else {

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -742,6 +742,16 @@ describe('object', () => {
         }]);
     });
 
+    it('should keep symbols', async () => {
+
+        const schema = Joi.object().keys({
+            a: Joi.number()
+        });
+        const symbol = Symbol();
+        const value = await schema.validate({ [symbol]: 5, a: 5 });
+        expect(value[symbol]).to.equal(5);
+    });
+
     describe('keys()', () => {
 
         it('allows any key', async () => {


### PR DESCRIPTION
Currently, symbols are lost as soon as they are passed into validation:
https://repl.it/repls/MediumorchidRadiantActionscript

This fix copies the object including its symbols.