### PR TITLE
remove strip from defaults now that it has been removed

### DIFF
--- a/lib/types/any/index.js
+++ b/lib/types/any/index.js
@@ -26,7 +26,6 @@ internals.defaults = {
     stripUnknown: false,
     language: {},
     presence: 'optional',
-    strip: false,
     noDefaults: false,
     escapeHtml: false
 


### PR DESCRIPTION
This commit seems to have broken something: https://github.com/hapijs/joi/issues/1714

Well. once 15.0.1 went out.

```
"strip" is not allowed

at internals.Alternatives.checkOptions (/mnt/project/node_modules/@hapi/joi/lib/types/any/index.js:105:19)
at internals.Alternatives._validateWithOptions (/mnt/project/node_modules/@hapi/joi/lib/types/any/index.js:758:18)
at internals.Alternatives.validate (/mnt/project/node_modules/@hapi/joi/lib/types/any/index.js:797:21)
at type.validate (/mnt/project/lib/by-document/lookup.js:82:123)
at type.validate (/mnt/project/node_modules/@hapi/joi/lib/index.js:394:54)
at type._validate (/mnt/project/node_modules/@hapi/joi/lib/types/any/index.js:676:35)
at internals.Array._checkItems (/mnt/project/node_modules/@hapi/joi/lib/types/array/index.js:245:37)
at internals.Array._base (/mnt/project/node_modules/@hapi/joi/lib/types/array/index.js:81:34)
at internals.Array._validate (/mnt/project/node_modules/@hapi/joi/lib/types/any/index.js:636:31)
at internals.Array._validateWithOptions (/mnt/project/node_modules/@hapi/joi/lib/types/any/index.js:762:29)
at internals.Array.validate (/mnt/project/node_modules/@hapi/joi/lib/types/any/index.js:797:21)
... our code goes here ...
```

This seems to fix it.