### PR TITLE
documentation: fix entry for "attempt"

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,7 +5,8 @@
 <!-- toc -->
 
 - [Joi](#joi)
-  - [`assert(value, schema, [message], [options])` - aliases: `attempt`](#assertvalue-schema-message-options---aliases-attempt)
+  - [`assert(value, schema, [message], [options])`](#assertvalue-schema-message-options)
+  - [`attempt(value, schema, [message], [options])`](#attemptvalue-schema-message-options)
   - [`cache.provision([options])`](#cacheprovisionoptions)
   - [`checkPreferences(prefs)`](#checkpreferencesprefs)
   - [`compile(schema, [options])`](#compileschema-options)
@@ -290,7 +291,7 @@
 
 ## Joi
 
-### `assert(value, schema, [message], [options])` - aliases: `attempt`
+### `assert(value, schema, [message], [options])`
 
 Validates a value against a schema and [throws](#errors) if validation fails where:
 - `value` - the value to validate.
@@ -300,6 +301,19 @@ Validates a value against a schema and [throws](#errors) if validation fails whe
 
 ```js
 Joi.assert('x', Joi.number());
+```
+
+### `attempt(value, schema, [message], [options])`
+
+Validates a value against a schema, returns valid object, and [throws](#errors) if validation fails where:
+- `value` - the value to validate.
+- `schema` - the validation schema. Can be a **joi** type object or a plain object where every key is assigned a **joi** type object using [`Joi.compile`](#compileschema-options) (be careful of the cost of compiling repeatedly the same schemas).
+- `message` - optional message string prefix added in front of the error message. may also be an Error object.
+- `options` - optional options object, passed in to [`any.validate`](#anyvalidatevalue-options)
+
+```js
+Joi.attempt('x', Joi.number()); // throws error
+const result = Joi.attempt('4', Joi.number()); // result -> 4
 ```
 
 ### `cache.provision([options])`


### PR DESCRIPTION
The current documentation for 16.x states that `attempt` is an alias for `assert`, but this is not true, as they have differing returns values. As in, `attempt` has a return value.

This PR fixes the documentation, borrowing some from the older 15.x doc for `attempt`, and some from the 16.x doc for `assert`.

Side note: I use `attempt` frequently and was initially dismayed to read that its core behavior had changed, until I actually tested it and was pleasantly surprised to see it still returned a converted object.