### PR TITLE
fix: catch null preferences

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -145,6 +145,7 @@ exports.preferences = function (target, source) {
     Messages = Messages || require('./messages');
 
     target = target || {};
+    source = source || {};
 
     const merged = Object.assign({}, target, source);
     if (source.errors &&


### PR DESCRIPTION
I noticed that when using a `when` construction the `preferences` are null:
https://github.com/hapijs/joi/blob/master/lib/base.js#L356