### PR TITLE
Update documentation regarding conditional vs when

### DIFF
--- a/API.md
+++ b/API.md
@@ -1446,7 +1446,7 @@ To accomplish the desired result above use:
 
 ```js
 const schema = {
-    a: Joi.conditional('b', { is: true, then: Joi.required() }),
+    a: Joi.when('b', { is: true, then: Joi.required() }),
     b: Joi.boolean()
 };
 ```


### PR DESCRIPTION
The example might be from an older version. I think there is no top-level `.conditional` available anymore and the example should use `.when` instead.

Feel free to merge or just close the PR.

Thank you so much for creating and maintaining joi! It is a .. pleasure to work with 😃 