### PR TITLE
Allow `_` in alias, arg, flag, modifier, override, rule, and term names

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -55,7 +55,7 @@ exports.preferences = Joi.object({
 
 // Extensions
 
-internals.nameRx = /^[a-zA-Z0-9]+$/;
+internals.nameRx = /^\w+$/;
 
 
 internals.rule = Joi.object({

--- a/test/extend.js
+++ b/test/extend.js
@@ -319,6 +319,12 @@ describe('extension', () => {
 
                         return helpers.error('special.bar');
                     }
+                },
+                foo_bar: {
+                    validate(value, helpers, args, options) {
+
+                        return null;
+                    }
                 }
             },
             messages: {
@@ -329,10 +335,12 @@ describe('extension', () => {
         const original = Joi.any();
         expect(original.foo).to.not.exist();
         expect(original.bar).to.not.exist();
+        expect(original.foo_bar).to.not.exist();
 
         const schema = custom.special();
         expect(schema.foo().validate({})).to.equal({ value: null });
         expect(schema.bar().validate({}).error).to.be.an.error('"value" oh no bar !');
+        expect(schema.foo_bar().validate({})).to.equal({ value: null });
     });
 
     it('concats custom type', () => {


### PR DESCRIPTION
Closes #2242

I am not sure if this is intended or not but Joi v15 or lower allows `_` in rule names, however, Joi v16 doesn't allow it.

This PR may be a sort of bug fix for backward compatibility.