### PR TITLE
Update API.md - valid() no longer takes arrays

### DIFF
--- a/API.md
+++ b/API.md
@@ -691,7 +691,7 @@ Returns an object that represents the internal configuration of the schema. Usef
 and exposing a schema's configuration to other systems, like valid values in a user interface.
 
 ```js
-const schema = Joi.any().valid([ 'foo', 'bar' ]);
+const schema = Joi.any().valid('foo', 'bar');
 console.log(schema.describe());
 ```
 


### PR DESCRIPTION
Ensure documentation example reflects that method valid() no longer takes arrays as a parameter.

![Screen Shot 2020-02-27 at 2 02 53 PM](https://user-images.githubusercontent.com/3312895/75484082-b3bc7080-596d-11ea-8715-4f1bb644cd8c.png)