### PR TITLE
Update API.md - correct sample - fails because is gone

### DIFF
--- a/API.md
+++ b/API.md
@@ -751,10 +751,10 @@ schema.validate({ foo: -2 });    // returns new Error('"foo" requires a positive
 const schema = Joi.object({
     foo: Joi.number().min(0).error((errors) => {
 
-        return new Error('found errors with ' + errors.map((err) => `${err.type}(${err.local.limit}) with value ${err.local.value}`).join(' and '));
+        return new Error('found errors with ' + errors.map((err) => `${err.local.key}(${err.local.limit}) with value ${err.local.value}`).join(' and '));
     })
 });
-schema.validate({ foo: -2 });    // returns new Error('child "foo" fails because [found errors with number.min(0) with value -2]')
+schema.validate({ foo: -2 });    // returns new Error('found errors with foo(0) with value -2')
 ```
 
 #### `any.example(example, [options])`


### PR DESCRIPTION
@hueniverse removed most of `fails because` in 6182a9b13a74286bd5cfcef1481e1c3555569266, but this documentation item remained, and the output doesn't match the documented expected output.

I'm not absolutely certain about the goal. I picked `err.local.key` because it sort of matched the kinds of things used in the rest of the message. 

Things I considered:
* `code` (`number.min`)
* `flags` (not seriously)
* `messages` (not seriously)
* `path` (`foo`)
* `prefs` (not seriously)
* `state` (not seriously)
* `value` (not seriously)
* `message` (not seriously)
* `template` (not seriously)
* `local`
  * `limit` (already used)
  * `value` (already used)
  * `label` (`foo`)
  * `key` (`foo`)

There were three choices for `foo`, I picked one fairly randomly, using a `local` seemed like a reasonable choice. I'm not at all certain about the distinction between `label` and `key`.