### PR TITLE
Strings are longer/shorter

### DIFF
--- a/API.md
+++ b/API.md
@@ -4137,7 +4137,7 @@ The string isn't all lower-cased.
 
 #### `string.max`
 
-The string is larger than expected.
+The string is longer than expected.
 
 Additional local context properties:
 ```ts
@@ -4149,7 +4149,7 @@ Additional local context properties:
 
 #### `string.min`
 
-The string is smaller than expected.
+The string is shorter than expected.
 
 Additional local context properties:
 ```ts


### PR DESCRIPTION
I'm creating this as a PR because it appears that I don't need to create an Issue for a documentation change.

Note: this does relate to an Issue / PR that I intend to make, but the changes here are different.

A string in computer programming is not usually described as being "larger" than another string. What is usually discussed is the *length* of the string, and the comparison operators for lengths are "longer" and "shorter".