### PR TITLE
fix(shim): compat browser option for those stuck on es5

### DIFF
--- a/browser/build/webpack.config.factory.js
+++ b/browser/build/webpack.config.factory.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const Path = require('path');
+
+const Webpack = require('webpack');
+
+
+module.exports = ({
+    filename,
+    targets,
+}) => ({
+    entry: '../lib/index.js',
+    output: {
+        filename,
+        path: Path.join(__dirname, '../dist'),
+        library: 'joi',
+        libraryTarget: 'umd'
+    },
+    plugins: [
+        new Webpack.DefinePlugin({
+            Buffer: false
+        })
+    ],
+    module: {
+        rules: [
+            {
+                use: './lib/version-loader',
+                include: [
+                    Path.join(__dirname, '../package.json')
+                ]
+            },
+            {
+                use: 'null-loader',
+                include: [
+                    Path.join(__dirname, '../lib/annotate.js'),
+                    Path.join(__dirname, '../lib/manifest.js'),
+                    Path.join(__dirname, '../lib/trace.js'),
+                    Path.join(__dirname, '../lib/types/binary.js'),
+                    Path.join(__dirname, '../node_modules/@hapi/address/lib/tlds.js')
+                ]
+            },
+            {
+                test: /\.js$/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: [
+                            [
+                                '@babel/preset-env',
+                                {
+                                    targets,
+                                }
+                            ]
+                        ],
+                        plugins: [
+                            '@babel/plugin-proposal-class-properties'
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    node: {
+        url: 'empty',
+        util: 'empty'
+    }
+});

--- a/browser/package.json
+++ b/browser/package.json
@@ -1,6 +1,7 @@
 {
     "scripts": {
         "build": "webpack --mode production",
+        "build-compat": "webpack --config webpack.config.compat.js --mode production",
         "build-dev": "webpack --mode development",
         "build-analyze": "webpack --mode production --profile --json > stats.json",
         "postbuild-analyze": "webpack-bundle-analyzer stats.json",

--- a/browser/webpack.config.compat.js
+++ b/browser/webpack.config.compat.js
@@ -3,6 +3,6 @@
 const webpackConfigFactory = require('./build/webpack.config.factory');
 
 module.exports = webpackConfigFactory({
-    filename: 'joi-browser.min.js',
-    targets: '> 1%, not IE 11, not dead',
+    filename: 'joi-browser.compat.min.js',
+    targets: 'defaults',
 });


### PR DESCRIPTION
Hey guys, I love the repo. I just figured I'd kick this out as a possible idea.

Would you guys be interested in having a browser.compat.min.js that uses defaults for the targets for those of us that have to support es5 still?

I made an example implementation here that moves the build to a factory function that takes two inputs: filename and targets. That way two webpack builds can use it, one which makes browser.min.js and one which makes browser.compat.min.js. I know I could just run this package through my own webpack and be done with it, but I wanted to just put this out there and get your guys thoughts.

Thanks for the great repo!