### PR TITLE
Correct example in date.less documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -1839,7 +1839,7 @@ const schema = Joi.date().less('12-31-2020');
 Notes: `'now'` can be passed in lieu of `date` so as to always compare relatively to the current date, allowing to explicitly ensure a date is either in the past or in the future.
 
 ```js
-const schema = Joi.date().max('now');
+const schema = Joi.date().less('now');
 ```
 
 ```js


### PR DESCRIPTION
Corrects an example in the date.less() documentation which uses max in place of less. 