### PR TITLE
Add extension validation for "cast"

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -89,6 +89,10 @@ exports.extension = Joi.object({
     ])
         .required(),
     args: Joi.function(),
+    cast: Joi.object().pattern(internals.nameRx, Joi.object({
+        from: Joi.function().maxArity(1),
+        to: Joi.function().minArity(1).maxArity(2)
+    })),
     base: Joi.object().schema()
         .when('type', { is: Joi.object().regex(), then: Joi.forbidden() }),
     coerce: [


### PR DESCRIPTION
Extending Joi to implement a custom `cast` was not working with the following error:

````
"cast" is not allowed
````

Internal validation of extensions was not validating the field.

Example:

````js
Joi.extend((joi) => {
  return {
	  type: 'object',
	  base: joi.object(),
	  cast: {
	    string: {
	      from: (value) => value && typeof value === 'object',
		  to: (value) => JSON.stringify(value),
	    },
	  };
  }
});
````