### PR TITLE
API.md - clarify casting behavior of Joi.alternatives

### DIFF
--- a/API.md
+++ b/API.md
@@ -1377,6 +1377,8 @@ const alt = Joi.alternatives().try(Joi.number(), Joi.string());
 // Same as [Joi.number(), Joi.string()]
 ```
 
+Note that numeric strings would be casted to numbers in the example above (see [any.strict()](#anystrictisstrict)).
+
 Possible validation errors: [`alternatives.any`](#alternativesany), [`alternatives.all`](#alternativesall), [`alternatives.one`](#alternativesone), [`alternatives.types`](#alternativestypes), [`alternatives.match`](#alternativesmatch)
 
 #### `alternatives.conditional(condition, options)`


### PR DESCRIPTION
I think that it's worth noting docs that `[Joi.number(), Joi.string()]` would for example cast `'1'` to `1`.

It is a bit counterintuitive (but perfectly valid) that `Joi.alternatives()` uses the first sub-schema, even though the second sub-schema could match without casting

I had at least 2 bugs with it in my project, I wish I had noticed this behavior earlier.