### PR TITLE
fix(typings): incompatible type issue for nested strict object schemas

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -729,14 +729,14 @@ declare namespace Joi {
         : T extends NullableType<Array<any>>
         ? Joi.ArraySchema
         : T extends NullableType<object>
-        ? ObjectSchema<StrictSchemaMap<T>>
+        ? ObjectSchema<T>
         : never    
     
     type PartialSchemaMap<TSchema = any> = {
         [key in keyof TSchema]?: SchemaLike | SchemaLike[];
     } 
 
-    type StrictSchemaMap<TSchema = any> =  {
+    type StrictSchemaMap<TSchema> =  {
         [key in keyof TSchema]-?: ObjectPropertiesSchema<TSchema[key]>
     };
 
@@ -2024,7 +2024,7 @@ declare namespace Joi {
          * Generates a schema object that matches an object data type (as well as JSON strings that have been parsed into objects).
          */
         // tslint:disable-next-line:no-unnecessary-generics
-        object<TSchema = any, isStrict = false, T = TSchema>(schema?: SchemaMap<T, isStrict>): ObjectSchema<TSchema>;
+        object<TSchema = any, isStrict extends boolean = false, T = TSchema>(schema?: SchemaMap<T, isStrict>): ObjectSchema<TSchema>;
 
         /**
          * Generates a schema object that matches a string data type. Note that empty strings are not allowed by default and must be enabled with allow('').


### PR DESCRIPTION
The type issue that prevented strict object schemas from being nested has been resolved. The following is no longer incorrectly flagged as an error.

````ts
interface ObjType {
  firstName: string;
  lastName: string;
  nestedObject: {
    middleName: string;
  }
}

// no errors
Joi.object<ObjType, true>({
  firstName: Joi.string(),
  lastName: Joi.string(),
  nestedObject: Joi.object<ObjType['nestedObject'], true>({
    middleName: Joi.string()
  })
})
````

This PR fixes #2764.