### PR TITLE
Fix Joi issue #2746

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -221,7 +221,7 @@ internals.methods = {
 internals.assert = function (value, schema, annotate, args /* [message], [options] */) {
 
     const message = args[0] instanceof Error || typeof args[0] === 'string' ? args[0] : null;
-    const options = message ? args[1] : args[0];
+    const options = message !== null ? args[1] : args[0];
     const result = schema.validate(value, Common.preferences({ errors: { stack: true } }, options || {}));
 
     let error = result.error;

--- a/test/index.js
+++ b/test/index.js
@@ -1027,7 +1027,7 @@ describe('Joi', () => {
 
                 value = Joi.attempt('2022-02-21T21:28:00Z', Joi.string().isoDate(), '', { convert: false });
             }).to.not.throw();
-            expect(value).to.equal('2022-02-21T21:28:00Z')
+            expect(value).to.equal('2022-02-21T21:28:00Z');
         });
 
         it('should convert to iso date', () => {
@@ -1037,7 +1037,7 @@ describe('Joi', () => {
 
                 value = Joi.attempt('2022-02-21T21:28:00Z', Joi.string().isoDate(), '', { convert: true });
             }).to.not.throw();
-            expect(value).to.equal('2022-02-21T21:28:00.000Z')
+            expect(value).to.equal('2022-02-21T21:28:00.000Z');
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1019,6 +1019,26 @@ describe('Joi', () => {
             expect(() => Joi.attempt('x', schema, 'invalid value')).to.throw('invalid value Oh noes !');
             expect(() => Joi.attempt('x', schema, 'invalid value')).to.throw('invalid value Oh noes !');
         });
+
+        it('should not convert to iso date', () => {
+
+            let value;
+            expect(() => {
+
+                value = Joi.attempt('2022-02-21T21:28:00Z', Joi.string().isoDate(), '', { convert: false });
+            }).to.not.throw();
+            expect(value).to.equal('2022-02-21T21:28:00Z')
+        });
+
+        it('should convert to iso date', () => {
+
+            let value;
+            expect(() => {
+
+                value = Joi.attempt('2022-02-21T21:28:00Z', Joi.string().isoDate(), '', { convert: true });
+            }).to.not.throw();
+            expect(value).to.equal('2022-02-21T21:28:00.000Z')
+        });
     });
 
     describe('checkPreferences()', () => {


### PR DESCRIPTION
   - internals.assert was failing in detect empty strings as a message setting this same empty string as options parameter