### PR TITLE
feat(d.ts): Improve value typing for assert function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2066,8 +2066,8 @@ declare namespace Joi {
          * @param schema - the schema object.
          * @param message - optional message string prefix added in front of the error message. may also be an Error object.
          */
-        assert(value: any, schema: Schema, options?: ValidationOptions): void;
-        assert(value: any, schema: Schema, message: string | Error, options?: ValidationOptions): void;
+        assert<T = any>(value: any, schema: Schema<T>, options?: ValidationOptions): asserts value is T;
+        assert<T = any>(value: any, schema: Schema<T>, message: string | Error, options?: ValidationOptions): asserts value is T;
 
         /**
          * Validates a value against a schema, returns valid object, and throws if validation fails.


### PR DESCRIPTION
Referencing #2797, I made a similar change that help `Joi.assert()` to assert value type accordingly.

It uses a mixture of asserts condition and user defined type guard.

- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
- https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards