### PR TITLE
fix(d.ts)!: type details param of ValidationError constructor

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1973,7 +1973,7 @@ declare namespace Joi {
          */
         version: string;
 
-        ValidationError: new (message: string, details: any, original: any) => ValidationError;
+        ValidationError: new (message: string, details: ValidationErrorItem[], original: any) => ValidationError;
 
         /**
          * Generates a schema object that matches any data type.

--- a/test/index.ts
+++ b/test/index.ts
@@ -175,7 +175,7 @@ stringRegexOpts = { invert: bool };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-const validErr = new Joi.ValidationError("message", "details", "original");
+const validErr = new Joi.ValidationError("message", [], "original");
 let validErrItem: Joi.ValidationErrorItem;
 let validErrFunc: Joi.ValidationErrorFunction;
 
@@ -220,7 +220,7 @@ Joi.any().error(validErrFunc);
 
 Joi.isError(validErr);
 
-const maybeValidErr: any = new Joi.ValidationError("message", "details", "original");
+const maybeValidErr: any = new Joi.ValidationError("message", [], "original");
 
 if (Joi.isError(maybeValidErr)) {
     // isError is a type guard that allows accessing these properties:


### PR DESCRIPTION
Since `details` property of `ValidationError` interface is typed as `ValidationErrorItem[]` then I see no reason why `details` param of `ValidationError` constructor should be typed as `any`.