### PR TITLE
feat(d.ts): allow alternatives schema at strict object schema

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -736,8 +736,8 @@ declare namespace Joi {
         [key in keyof TSchema]?: SchemaLike | SchemaLike[];
     } 
 
-    type StrictSchemaMap<TSchema = any> =  {
-        [key in keyof TSchema]-?: ObjectPropertiesSchema<TSchema[key]>
+    type StrictSchemaMap<TSchema = any> = {
+        [key in keyof TSchema]-?: ObjectPropertiesSchema<TSchema[key]> | AlternativesSchema
     };
 
     type SchemaMap<TSchema = any, isStrict = false> = isStrict extends true ? StrictSchemaMap<TSchema> : PartialSchemaMap<TSchema>

--- a/test/index.ts
+++ b/test/index.ts
@@ -1244,6 +1244,16 @@ const userSchema2 = Joi.object<User>().keys({
     family: Joi.string()
 });
 
+interface CommentWithAlternatives {
+    text: string;
+    user: string | User;
+}
+
+const commentWithAlternativesSchemaObject = Joi.object<CommentWithAlternatives, true>({
+    text: Joi.string().required(),
+    user: Joi.alternatives(Joi.string(), userSchemaObject),
+});
+
 
 expect.error(userSchema2.keys({ height: Joi.number() }));
 


### PR DESCRIPTION
Part of #2622

Initially at #2622 topic starter was mentioning `AlternativesSchema` at types. But in implementation it's lost.

While we can have union type inside interfaces, eg: `field: string | number`, the only way to describe them by Joi is to use `AlternativesSchema`. So as I see strict object schema map should allow `AlternativesSchema`  for any field, while we cannot detect in TS, where do we have union type and where not.

Currently we cannot use strict mode for schemas of interfaces which have union types.