### PR TITLE
Fix Joi issue #2672:

### DIFF
--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -39,7 +39,9 @@ module.exports = Any.extend({
 
             if (!schema._flags.unsafe) {
                 if (value.match(/e/i)) {
-                    const constructed = internals.normalizeExponent(`${result.value / Math.pow(10, matches[1])}e${matches[1]}`);
+                    const rule = schema.$_getRule('precision')?.args.limit;
+                    const constructed = rule ? internals.normalizeExponent(`${(result.value / Math.pow(10, matches[1])).toFixed(rule)}e${matches[1]}`) :
+                        internals.normalizeExponent(`${result.value / Math.pow(10, matches[1])}e${matches[1]}`);
                     if (constructed !== internals.normalizeExponent(value)) {
                         result.errors = error('number.unsafe');
                         return result;

--- a/test/types/number.js
+++ b/test/types/number.js
@@ -1989,5 +1989,13 @@ describe('number', () => {
                 [-9007199254740992, true, -9007199254740992]
             ]);
         });
+
+        it('accepts unsafe numbers with precision specified', () => {
+
+            const t = Joi.number().precision(2);
+            Helper.validate(t, [
+                ['9.4e-1', true, 0.94]
+            ]);
+        });
     });
 });


### PR DESCRIPTION
   - possibility to validate exponential notation strings with double precision problem by specifying a precision number instead of using unsafe specification