### PR TITLE
Allow sub-objects for TypeScript strict object schema

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -748,7 +748,7 @@ declare namespace Joi {
         : T extends NullableType<Array<any>>
         ? Joi.ArraySchema
         : T extends NullableType<object>
-        ? ObjectSchema<T>
+        ? (StrictSchemaMap<T> | ObjectSchema<T>)
         : never
 
     type PartialSchemaMap<TSchema = any> = {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1260,7 +1260,7 @@ const commentSchemaObject = Joi.object<Comment, true>({
 
 interface Comment2 {
     text: string;
-    user: {
+    user?: {
         name: string;
     }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1258,6 +1258,20 @@ const commentSchemaObject = Joi.object<Comment, true>({
     user: userSchemaObject
 });
 
+interface Comment2 {
+    text: string;
+    user: {
+        name: string;
+    }
+}
+
+const commentSchemaObject2 = Joi.object<Comment2, true>({
+    text: Joi.string().required(),
+    user: {
+        name: Joi.string().required(),
+    }
+})
+
 expect.error(userSchema2.keys({ height: Joi.number() }));
 
 expect.error(Joi.string('x'));


### PR DESCRIPTION
A strict nested object was previously typed as `ObjectSchema<StrictSchemaMap<T>>`, which meant that Joi expected a Joi schema of a Joi schema of an object (i.e., a schema definition for an object of Joi schema fields) - which doesn't make much sense. Instead, it should require a Joi schema of an object _or_ an object of Joi schema fields.