### PR TITLE
Support function to marshall error label

### DIFF
--- a/API.md
+++ b/API.md
@@ -1122,6 +1122,7 @@ Validates a value using the current schema and options where:
       - `'path'` - the full path to the value being validated. This is the default value.
       - `'key'` - the key of the value being validated.
       - `false` - remove any label prefix from error message, including the `""`.
+      - `function` - function which receives `path` as only argument and must return a string to be used as label
     - `language` - the preferred language code for error messages. The value is matched against keys at the root of the `messages` object, and then the error code as a child key of that. Can be a reference to the value, global context, or local context which is the root value passed to the validation function. Note that references to the value are usually not what you want as they move around the value structure relative to where the error happens. Instead, either use the global context, or the absolute value (e.g. `Joi.ref('/variable')`);
     - `render` - when `false`, skips rendering error templates. Useful when error messages are generated elsewhere to save processing time. Defaults to `true`.
     - `stack` - when `true`, the main error will possess a stack trace, otherwise it will be disabled. Defaults to `false` for performance reasons. Has no effect on platforms other than V8/node.js as it uses the [Stack trace API](https://v8.dev/docs/stack-trace-api).

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -167,6 +167,10 @@ exports.label = function (flags, state, prefs, messages) {
         path = state.path.slice(-1);
     }
 
+    if (typeof prefs.errors.label === 'function') {
+        return prefs.errors.label(path);
+    }
+
     const normalized = exports.path(path);
     if (normalized) {
         return normalized;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -40,7 +40,7 @@ declare namespace Joi {
         /**
          * defines the value used to set the label context variable.
          */
-        label?: 'path' | 'key' | false;
+        label?: 'path' | 'key' | false | ((path: string[]) => string);
         /**
          * The preferred language code for error messages.
          * The value is matched against keys at the root of the messages object, and then the error code as a child key of that.

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -25,7 +25,7 @@ exports.preferences = Joi.object({
     debug: Joi.boolean(),
     errors: {
         escapeHtml: Joi.boolean(),
-        label: Joi.valid('path', 'key', false),
+        label: Joi.valid('path', 'key', false, Joi.function().arity(1)),
         language: [
             Joi.string(),
             Joi.object().ref()

--- a/test/errors.js
+++ b/test/errors.js
@@ -582,6 +582,7 @@ describe('errors', () => {
         expect(schema.validate({ x: { y: { z: 'o' } } }).error).to.be.an.error('"x.y.z" must be [z]');
         expect(schema.validate({ x: { y: { z: 'o' } } }, { errors: { label: false } }).error).to.be.an.error('must be [z]');
         expect(schema.validate({ x: { y: { z: 'o' } } }, { errors: { label: 'key' } }).error).to.be.an.error('"z" must be [z]');
+        expect(schema.validate({ x: { y: { z: 'o' } } }, { errors: { label: (path) => path.slice(-1)[0].toUpperCase() } }).error).to.be.an.error('"Z" must be [z]');
         expect(schema.validate(1, { errors: { label: 'key' } }).error).to.be.an.error('"value" must be of type object');
         expect(schema.validate({ x: { y: { a: [1] } } }, { errors: { label: 'key' } }).error).to.be.an.error('"[0]" must be a string');
     });


### PR DESCRIPTION
Adds support for function used to manipulate the `path` and create a custom label to build the error message when validating.

We needed this change so I made the change for us and now opening a PR, please let me know if this is an unwanted change.

Context: we have a serialized schema which is built and then hydrated at runtime, so we cannot leverage `any.label()`  (the `label` is lost when we `.describe()` the schema) and anyway the label we'd like to use changes based on the current payload.