### PR TITLE
Upgrade `@sideway/formula` to `3.0.1` for `CVE-2023-25166`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
## Description 📝

- Upgrades for `@sideway/formula` to `3.0.1` for `CVE-2023-25166`
- This will help users who are getting dependabot alerts about this