### PR TITLE
[types] added "dontChangeOptional" boolean to avoid changing optional props in SchemaMap

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -793,12 +793,22 @@ declare namespace Joi {
     type PartialSchemaMap<TSchema = any> = {
         [key in keyof TSchema]?: SchemaLike | SchemaLike[];
     }
+    
+    type PartialUnchangedSchemaMap<TSchema = any> = {
+        [key in keyof TSchema]: SchemaLike | SchemaLike[];
+    }
 
     type StrictSchemaMap<TSchema = any> =  {
         [key in keyof TSchema]-?: ObjectPropertiesSchema<TSchema[key]>
     };
 
-    type SchemaMap<TSchema = any, isStrict = false> = isStrict extends true ? StrictSchemaMap<TSchema> : PartialSchemaMap<TSchema>
+    type StrictUnchangedSchemaMap<TSchema = any> =  {
+        [key in keyof TSchema]: ObjectPropertiesSchema<TSchema[key]>
+    };
+
+    type SchemaMap<TSchema = any, isStrict = false, dontChangeOptional = false> = isStrict extends true 
+        ? (dontChangeOptional extends true ? StrictUnchangedSchemaMap<TSchema> : StrictSchemaMap<TSchema>)
+        : (dontChangeOptional extends true ? PartialUnchangedSchemaMap<TSchema> : PartialSchemaMap<TSchema>);
 
     type Schema<P = any> =
         | AnySchema<P>
@@ -2100,7 +2110,7 @@ declare namespace Joi {
          * Generates a schema object that matches an object data type (as well as JSON strings that have been parsed into objects).
          */
         // tslint:disable-next-line:no-unnecessary-generics
-        object<TSchema = any, isStrict = false, T = TSchema>(schema?: SchemaMap<T, isStrict>): ObjectSchema<TSchema>;
+        object<TSchema = any, isStrict = false, dontChangeOptional = false, T = TSchema>(schema?: SchemaMap<T, isStrict, dontChangeOptional>): ObjectSchema<TSchema>;
 
         /**
          * Generates a schema object that matches a string data type. Note that empty strings are not allowed by default and must be enabled with allow('').


### PR DESCRIPTION
I have a type which has some parameters that come from GET (and requires validation), others are filled later using request headers and protocol and other stuff (which don't require validation). 

When trying to use the type when defining the schema, the fact that either all the properties are made optional (PartialSchemaMap), or are mandatory (StrictSchemaMap), makes defining schema types impossible when some parameters doesn't need validation.

Example:

```js
type GetParams = {
    destination: string
    destination_latitude: number
    destination_longitude: number
    destination_country: string
    destination_id: string
    secure?: boolean
    host?: boolean
}

//This alerts that "secure" and "host" are missing
const schema = Joi.object<GetParams, true>({
    destination: Joi.string(),
    destination_latitude: Joi.number(),
    destination_longitude: Joi.number(),
    destination_country: Joi.string(),
    destination_id: Joi.string(),
})

const validatedParams = schema.validate(req.query);
validatedParams.secure = req.secure;
validatedParams.host = req.headers.host;
```

This pull request would allow this:

```
type GetParams = {
    destination: string
    destination_latitude: number
    destination_longitude: number
    destination_country: string
    destination_id: string
    secure?: boolean
    host?: boolean
}

//This doesn't throw error
const schema = Joi.object<GetParams, true, true>({
    destination: Joi.string(),
    destination_latitude: Joi.number(),
    destination_longitude: Joi.number(),
    destination_country: Joi.string(),
    destination_id: Joi.string(),
})

const validatedParams = schema.validate(req.query);
validatedParams.secure = req.secure;
validatedParams.host = req.headers.host;
```