### PR TITLE
chore: use latest address module

### DIFF
--- a/API.md
+++ b/API.md
@@ -2727,6 +2727,7 @@ Requires the string value to be a valid domain name.
 - `options` - optional settings:
     - `allowFullyQualified` - if `true`, domains ending with a `.` character are permitted. Defaults to `false`.
     - `allowUnicode` - if `true`, Unicode characters are permitted. Defaults to `true`.
+    - `allowUnderscore` - if `true`, underscores (`_`) are allowed in the domain name. Defaults to `false`.
     - `minDomainSegments` - number of segments required for the domain. Defaults to `2`.
     - `maxDomainSegments` - maximum number of allowed domain segments. Default to no limit.
     - `tlds` - options for TLD (top level domain) validation. By default, the TLD must be a valid
@@ -2754,6 +2755,7 @@ Requires the string value to be a valid email address.
 - `options` - optional settings:
     - `allowFullyQualified` - if `true`, domains ending with a `.` character are permitted. Defaults to `false`.
     - `allowUnicode` - if `true`, Unicode characters are permitted. Defaults to `true`.
+    - `allowUnderscore` - if `true`, underscores (`_`) are allowed in the domain name. Defaults to `false`.
     - `ignoreLength` - if `true`, ignore invalid email length errors. Defaults to `false`.
     - `minDomainSegments` - number of segments required for the domain. The default setting excludes
       single segment domains such as `example@io` which is a valid email but very uncommon. Defaults

--- a/benchmarks/bench.js
+++ b/benchmarks/bench.js
@@ -2,7 +2,7 @@
 
 const Fs = require('fs');
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 const Benchmark = require('benchmark');
 const Bossy = require('@hapi/bossy');
 const Chalk = require('chalk');

--- a/browser/package.json
+++ b/browser/package.json
@@ -7,11 +7,12 @@
         "test": "karma start"
     },
     "devDependencies": {
-        "@babel/core": "^7.4.5",
-        "@babel/plugin-proposal-class-properties": "^7.7.4",
-        "@babel/preset-env": "^7.4.5",
+        "@babel/core": "^7.20.12",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/preset-env": "^7.20.2",
+        "@mixer/webpack-bundle-compare": "^0.1.1",
         "assert": "^2.0.0",
-        "babel-loader": "^8.0.6",
+        "babel-loader": "^9.1.2",
         "karma": "^4.2.0",
         "karma-chrome-launcher": "^3.0.0",
         "karma-mocha": "^1.3.0",
@@ -19,9 +20,9 @@
         "karma-webpack": "^5.0.0",
         "mocha": "^6.2.0",
         "mocha-loader": "^2.0.1",
-        "util": "^0.12.4",
-        "webpack": "^5.40.0",
+        "util": "^0.12.5",
+        "webpack": "^5.75.0",
         "webpack-bundle-analyzer": "^3.4.1",
-        "webpack-cli": "^4.7.2"
+        "webpack-cli": "^4.10.0"
     }
 }

--- a/browser/tests/index.js
+++ b/browser/tests/index.js
@@ -7,7 +7,12 @@ describe('Joi', () => {
 
     it('should be able to create schemas', () => {
 
-        Joi.string().min(5);
+        Joi.boolean().truthy('true');
+        Joi.number().min(5).max(10).multiple(2);
+        Joi.array().items(Joi.number().required());
+        Joi.object({
+            key: Joi.string().required()
+        });
     });
 
     it('should be able to validate data', () => {
@@ -29,5 +34,13 @@ describe('Joi', () => {
         Assert.ok(!schema.validate('test@example.com').error);
         Assert.ok(schema.validate('test@example.com ').error);
         Assert.ok(!schema.validate('伊昭傑@郵件.商務').error);
+    });
+
+    it('validates domain', () => {
+
+        const schema = Joi.string().domain().required();
+        Assert.ok(!schema.validate('example.com').error);
+        Assert.ok(schema.validate('example.com ').error);
+        Assert.ok(!schema.validate('example.商務').error);
     });
 });

--- a/browser/webpack.config.js
+++ b/browser/webpack.config.js
@@ -3,6 +3,7 @@
 const Path = require('path');
 
 const Webpack = require('webpack');
+const { BundleComparisonPlugin } = require('@mixer/webpack-bundle-compare');
 
 
 module.exports = {
@@ -16,6 +17,11 @@ module.exports = {
     plugins: [
         new Webpack.DefinePlugin({
             Buffer: false
+        }),
+        new BundleComparisonPlugin({
+            file: '../stats.msp.gz',
+            format: 'msgpack',
+            gzip: true,
         })
     ],
     module: {
@@ -44,6 +50,10 @@ module.exports = {
                         ]
                     }
                 }
+            },
+            {
+                test: /@(hapi|sideway)\//,
+                sideEffects: false
             }
         ]
     },
@@ -54,7 +64,8 @@ module.exports = {
           [Path.join(__dirname, '../lib/manifest.js')]: false,
           [Path.join(__dirname, '../lib/trace.js')]: false,
           [Path.join(__dirname, '../lib/types/binary.js')]: false,
-          [Path.join(__dirname, '../node_modules/@sideway/address/lib/tlds.js')]: false,
+          [Path.join(__dirname, '../node_modules/@hapi/tlds/esm/index.js')]: false,
+          [Path.join(__dirname, '../node_modules/@hapi/address/esm/decode.js')]: false,
       },
       fallback: {
         url: false,

--- a/lib/annotate.js
+++ b/lib/annotate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Clone = require('@hapi/hoek/lib/clone');
+const Clone = require('@hapi/hoek/clone');
 
 const Common = require('./common');
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
-const DeepEqual = require('@hapi/hoek/lib/deepEqual');
-const Merge = require('@hapi/hoek/lib/merge');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
+const DeepEqual = require('@hapi/hoek/deepEqual');
+const Merge = require('@hapi/hoek/merge');
 
 const Cache = require('./cache');
 const Common = require('./common');

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
 
 const Common = require('./common');
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const AssertError = require('@hapi/hoek/lib/error');
+const Assert = require('@hapi/hoek/assert');
+const AssertError = require('@hapi/hoek/assertError');
 
 const Pkg = require('../package.json');
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Common = require('./common');
 const Ref = require('./ref');

--- a/lib/extend.js
+++ b/lib/extend.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
 
 const Common = require('./common');
 const Messages = require('./messages');

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -291,6 +291,12 @@ declare namespace Joi {
          */
         allowUnicode?: boolean;
         /**
+         * If `true`, underscores (`_`) are allowed in the domain name
+         *
+         * @default false
+         */
+        allowUnderscore?: boolean;
+        /**
          * if `true`, ignore invalid email length errors.
          *
          * @default false
@@ -341,7 +347,12 @@ declare namespace Joi {
          * @default true
          */
         allowUnicode?: boolean;
-
+        /**
+         * If `true`, underscores (`_`) are allowed in the domain name
+         *
+         * @default false
+         */
+        allowUnderscore?: boolean;
         /**
          * Options for TLD (top level domain) validation. By default, the TLD must be a valid name listed on the [IANA registry](http://data.iana.org/TLD/tlds-alpha-by-domain.txt)
          *

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
 
 const Cache = require('./cache');
 const Common = require('./common');

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
 
 const Common = require('./common');
 const Messages = require('./messages');

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
 
 const Template = require('./template');
 

--- a/lib/modify.js
+++ b/lib/modify.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Common = require('./common');
 const Ref = require('./ref');

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
-const Reach = require('@hapi/hoek/lib/reach');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
+const Reach = require('@hapi/hoek/reach');
 
 const Common = require('./common');
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Clone = require('@hapi/hoek/lib/clone');
-const Reach = require('@hapi/hoek/lib/reach');
+const Clone = require('@hapi/hoek/clone');
+const Reach = require('@hapi/hoek/reach');
 
 const Common = require('./common');
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
-const EscapeHtml = require('@hapi/hoek/lib/escapeHtml');
-const Formula = require('@sideway/formula');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
+const EscapeHtml = require('@hapi/hoek/escapeHtml');
+const Formula = require('@hapi/formula');
 
 const Common = require('./common');
 const Errors = require('./errors');

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const DeepEqual = require('@hapi/hoek/lib/deepEqual');
-const Pinpoint = require('@sideway/pinpoint');
+const DeepEqual = require('@hapi/hoek/deepEqual');
+const Pinpoint = require('@hapi/pinpoint');
 
 const Errors = require('./errors');
 

--- a/lib/types/alternatives.js
+++ b/lib/types/alternatives.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Merge = require('@hapi/hoek/lib/merge');
+const Assert = require('@hapi/hoek/assert');
+const Merge = require('@hapi/hoek/merge');
 
 const Any = require('./any');
 const Common = require('../common');

--- a/lib/types/any.js
+++ b/lib/types/any.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Base = require('../base');
 const Common = require('../common');

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const DeepEqual = require('@hapi/hoek/lib/deepEqual');
-const Reach = require('@hapi/hoek/lib/reach');
+const Assert = require('@hapi/hoek/assert');
+const DeepEqual = require('@hapi/hoek/deepEqual');
+const Reach = require('@hapi/hoek/reach');
 
 const Any = require('./any');
 const Common = require('../common');

--- a/lib/types/binary.js
+++ b/lib/types/binary.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Any = require('./any');
 const Common = require('../common');

--- a/lib/types/boolean.js
+++ b/lib/types/boolean.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Any = require('./any');
 const Common = require('../common');

--- a/lib/types/date.js
+++ b/lib/types/date.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Any = require('./any');
 const Common = require('../common');

--- a/lib/types/function.js
+++ b/lib/types/function.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Keys = require('./keys');
 

--- a/lib/types/keys.js
+++ b/lib/types/keys.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const ApplyToDefaults = require('@hapi/hoek/lib/applyToDefaults');
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
+const ApplyToDefaults = require('@hapi/hoek/applyToDefaults');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
 const Topo = require('@hapi/topo');
 
 const Any = require('./any');

--- a/lib/types/link.js
+++ b/lib/types/link.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Any = require('./any');
 const Common = require('../common');

--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Any = require('./any');
 const Common = require('../common');

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -1,19 +1,16 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Domain = require('@sideway/address/lib/domain');
-const Email = require('@sideway/address/lib/email');
-const Ip = require('@sideway/address/lib/ip');
-const EscapeRegex = require('@hapi/hoek/lib/escapeRegex');
-const Tlds = require('@sideway/address/lib/tlds');
-const Uri = require('@sideway/address/lib/uri');
+const Assert = require('@hapi/hoek/assert');
+const { isDomainValid, isEmailValid, ipRegex, uriRegex } = require('@hapi/address');
+const EscapeRegex = require('@hapi/hoek/escapeRegex');
+const Tlds = require('@hapi/tlds');
 
 const Any = require('./any');
 const Common = require('../common');
 
 
 const internals = {
-    tlds: Tlds instanceof Set ? { tlds: { allow: Tlds, deny: null } } : false,              // $lab:coverage:ignore$
+    tlds: Tlds.tlds instanceof Set ? { tlds: { allow: Tlds.tlds, deny: null } } : false,              // $lab:coverage:ignore$
     base64Regex: {
         // paddingRequired
         true: {
@@ -28,7 +25,7 @@ const internals = {
     },
     dataUriRegex: /^data:[\w+.-]+\/[\w+.-]+;((charset=[\w-]+|base64),)?(.*)$/,
     hexRegex: /^[a-f0-9]+$/i,
-    ipRegex: Ip.regex({ cidr: 'forbidden' }).regex,
+    ipRegex: ipRegex({ cidr: 'forbidden' }).regex,
     isoDurationRegex: /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$/,
 
     guidBrackets: {
@@ -264,7 +261,7 @@ module.exports = Any.extend({
             method(options) {
 
                 if (options) {
-                    Common.assertOptions(options, ['allowFullyQualified', 'allowUnicode', 'maxDomainSegments', 'minDomainSegments', 'tlds']);
+                    Common.assertOptions(options, ['allowFullyQualified', 'allowUnicode', 'allowUnderscore', 'maxDomainSegments', 'minDomainSegments', 'tlds']);
                 }
 
                 const address = internals.addressOptions(options);
@@ -272,7 +269,7 @@ module.exports = Any.extend({
             },
             validate(value, helpers, args, { address }) {
 
-                if (Domain.isValid(value, address)) {
+                if (isDomainValid(value, address)) {
                     return value;
                 }
 
@@ -296,7 +293,7 @@ module.exports = Any.extend({
                 const emails = options.multiple ? value.split(regex) : [value];
                 const invalids = [];
                 for (const email of emails) {
-                    if (!Email.isValid(email, address)) {
+                    if (!isEmailValid(email, address)) {
                         invalids.push(email);
                     }
                 }
@@ -395,7 +392,7 @@ module.exports = Any.extend({
             },
             validate(value, helpers) {
 
-                if (Domain.isValid(value, { minDomainSegments: 1 }) ||
+                if (isDomainValid(value, { minDomainSegments: 1 }) ||
                     internals.ipRegex.test(value)) {
 
                     return value;
@@ -417,7 +414,7 @@ module.exports = Any.extend({
 
                 Common.assertOptions(options, ['cidr', 'version']);
 
-                const { cidr, versions, regex } = Ip.regex(options);
+                const { cidr, versions, regex } = ipRegex(options);
                 const version = options.version ? versions : undefined;
                 return this.$_addRule({ name: 'ip', args: { options: { cidr, version } }, regex });
             },
@@ -642,7 +639,7 @@ module.exports = Any.extend({
                     Common.assertOptions(options.domain, ['allowFullyQualified', 'allowUnicode', 'maxDomainSegments', 'minDomainSegments', 'tlds']);
                 }
 
-                const { regex, scheme } = Uri.regex(options);
+                const { regex, scheme } = uriRegex(options);
                 const domain = options.domain ? internals.addressOptions(options.domain) : null;
                 return this.$_addRule({ name: 'uri', args: { options }, regex, domain, scheme });
             },
@@ -657,7 +654,7 @@ module.exports = Any.extend({
                     const matched = match[1] || match[2];
                     if (domain &&
                         (!options.allowRelative || matched) &&
-                        !Domain.isValid(matched, domain)) {
+                        !isDomainValid(matched, domain)) {
 
                         return helpers.error('string.domain', { value: matched });
                     }
@@ -796,7 +793,7 @@ internals.addressOptions = function (options) {
 internals.validateTlds = function (set, source) {
 
     for (const tld of set) {
-        Assert(Domain.isValid(tld, { minDomainSegments: 1, maxDomainSegments: 1 }), `${source} must contain valid top level domain names`);
+        Assert(isDomainValid(tld, { minDomainSegments: 1, maxDomainSegments: 1 }), `${source} must contain valid top level domain names`);
     }
 };
 

--- a/lib/types/symbol.js
+++ b/lib/types/symbol.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
+const Assert = require('@hapi/hoek/assert');
 
 const Any = require('./any');
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const Clone = require('@hapi/hoek/lib/clone');
-const Ignore = require('@hapi/hoek/lib/ignore');
-const Reach = require('@hapi/hoek/lib/reach');
+const Assert = require('@hapi/hoek/assert');
+const Clone = require('@hapi/hoek/clone');
+const Ignore = require('@hapi/hoek/ignore');
+const Reach = require('@hapi/hoek/reach');
 
 const Common = require('./common');
 const Errors = require('./errors');

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Assert = require('@hapi/hoek/lib/assert');
-const DeepEqual = require('@hapi/hoek/lib/deepEqual');
+const Assert = require('@hapi/hoek/assert');
+const DeepEqual = require('@hapi/hoek/deepEqual');
 
 const Common = require('./common');
 

--- a/package.json
+++ b/package.json
@@ -15,17 +15,18 @@
         "validation"
     ],
     "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/tlds": "^1.0.1",
+        "@hapi/topo": "^6.0.1",
+        "@hapi/address": "^5.1.0",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/formula": "^3.0.2"
     },
     "devDependencies": {
-        "@hapi/bourne": "2.x.x",
-        "@hapi/code": "8.x.x",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/code": "^9.0.3",
         "@hapi/joi-legacy-test": "npm:@hapi/joi@15.x.x",
-        "@hapi/lab": "^25.0.1",
+        "@hapi/lab": "^25.1.2",
         "@types/node": "^14.18.24",
         "typescript": "4.3.x"
     },

--- a/test/trace.js
+++ b/test/trace.js
@@ -3,7 +3,7 @@
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 const Joi = require('..');
-const Pinpoint = require('@sideway/pinpoint');
+const Pinpoint = require('@hapi/pinpoint');
 
 
 const internals = {};

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -1334,6 +1334,37 @@ describe('string', () => {
                 context: { value: 'something', label: 'item', key: 'item' }
             }]]);
         });
+
+        it('validates domain with underscores', () => {
+
+            const validSchema = Joi.string().domain({ allowUnderscore: true });
+            Helper.validate(validSchema, [
+                ['_acme-challenge.example.com', true],
+                ['_abc.example.com', true]
+            ]);
+
+            const invalidSchema = Joi.string().domain();
+            Helper.validate(invalidSchema, [
+                ['_acme-challenge.example.com', false, {
+                    context: {
+                        label: 'value',
+                        value: '_acme-challenge.example.com'
+                    },
+                    message: '"value" must contain a valid domain name',
+                    path: [],
+                    type: 'string.domain'
+                }],
+                ['_abc.example.com', false, {
+                    context: {
+                        label: 'value',
+                        value: '_abc.example.com'
+                    },
+                    message: '"value" must contain a valid domain name',
+                    path: [],
+                    type: 'string.domain'
+                }]
+            ]);
+        });
     });
 
     describe('email()', () => {
@@ -4589,7 +4620,7 @@ describe('string', () => {
 
         it('throws when options.cidr is not a string', () => {
 
-            expect(() => Joi.string().ip({ cidr: 42 })).to.throw('options.cidr must be a string');
+            expect(() => Joi.string().ip({ cidr: 42 })).to.throw('options.cidr must be one of required, optional, forbidden');
         });
 
         it('throws when options.cidr is not a valid value', () => {


### PR DESCRIPTION
Address was rewritten in TypeScript and now includes [support for underscores](https://github.com/hapijs/address/pull/43) in domains and emails.

Browser bundling had to change a bit because of that.