### PR TITLE
fix: transpile optional chaining

### DIFF
--- a/browser/webpack.config.js
+++ b/browser/webpack.config.js
@@ -46,7 +46,9 @@ module.exports = {
                             ]
                         ],
                         plugins: [
-                            '@babel/plugin-proposal-class-properties'
+                            '@babel/plugin-proposal-class-properties',
+                            '@babel/plugin-proposal-optional-chaining',
+                            '@babel/plugin-proposal-nullish-coalescing-operator',
                         ]
                     }
                 }


### PR DESCRIPTION
It seems webpack left `?.` and `??` in the build, I think it may be too early for that.