### PR TITLE
fix: do not trigger warnings and externals on arrays and alternatives mismatches

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -55,6 +55,8 @@ module.exports = internals.State = class {
         if (this.mainstay.shadow) {
             this._snapshot = Clone(this.mainstay.shadow.node(this.path));
         }
+
+        this.mainstay.snapshot();
     }
 
     restore() {
@@ -63,6 +65,8 @@ module.exports = internals.State = class {
             this.mainstay.shadow.override(this.path, this._snapshot);
             this._snapshot = undefined;
         }
+
+        this.mainstay.restore();
     }
 };
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -189,6 +189,38 @@ exports.entryAsync = async function (value, schema, prefs) {
 };
 
 
+internals.Mainstay = class {
+
+    constructor(tracer, debug, links) {
+
+        this.externals = [];
+        this.warnings = [];
+        this.tracer = tracer;
+        this.debug = debug;
+        this.links = links;
+        this.shadow = null;
+        this.artifacts = null;
+
+        this._snapshots = [];
+    }
+
+    snapshot() {
+
+        this._snapshots.push({
+            externals: this.externals.slice(),
+            warnings: this.warnings.slice()
+        });
+    }
+
+    restore() {
+
+        const snapshot = this._snapshots.pop();
+        this.externals = snapshot.externals;
+        this.warnings = snapshot.warnings;
+    }
+};
+
+
 internals.entry = function (value, schema, prefs) {
 
     // Prepare state
@@ -196,7 +228,7 @@ internals.entry = function (value, schema, prefs) {
     const { tracer, cleanup } = internals.tracer(schema, prefs);
     const debug = prefs.debug ? [] : null;
     const links = schema._ids._schemaChain ? new Map() : null;
-    const mainstay = { externals: [], warnings: [], tracer, debug, links };
+    const mainstay = new internals.Mainstay(tracer, debug, links);
     const schemas = schema._ids._schemaChain ? [{ schema }] : null;
     const state = new State([], [], { mainstay, schemas });
 

--- a/test/base.js
+++ b/test/base.js
@@ -1657,6 +1657,36 @@ describe('any', () => {
                 ]
             });
         });
+
+        it('does not run on invalid array items', async () => {
+
+            const schema = Joi.array().items(
+                Joi.string().min(5).external((value) => value + value),
+                Joi.string().external((value) => value + '-')
+            );
+
+            expect(await schema.validateAsync(['x'])).to.equal(['x-']);
+        });
+
+        it('does not run on invalid alternatives', async () => {
+
+            const schema = Joi.alternatives(
+                Joi.string().min(5).external((value) => value + value),
+                Joi.string().external((value) => value + '-')
+            );
+
+            expect(await schema.validateAsync('x')).to.equal('x-');
+        });
+
+        it('does not run on invalid alternatives with match mode "one"', async () => {
+
+            const schema = Joi.alternatives().try(
+                Joi.string().min(5).external((value) => value + value),
+                Joi.string().external((value) => value + '-')
+            ).match('one');
+
+            expect(await schema.validateAsync('x')).to.equal('x-');
+        });
     });
 
     describe('failover()', () => {

--- a/test/validator.js
+++ b/test/validator.js
@@ -887,6 +887,78 @@ describe('Validator', () => {
                 }
             });
         });
+
+        it('does not report warnings on mismatched array items', async () => {
+
+            const schema = Joi.array().items(
+                Joi.string().min(5).warning('custom.x'),
+                Joi.string()
+            );
+
+            expect(await schema.validateAsync(['x', 'y'], { warnings: true, abortEarly: false })).to.equal({ value: ['x', 'y'] });
+        });
+
+        it('does not report warnings on mismatched alternatives', async () => {
+
+            const schema = Joi.alternatives().try(
+                Joi.string().min(5).warning('custom.x'),
+                Joi.string()
+            );
+
+            expect(await schema.validateAsync('x', { warnings: true, abortEarly: false })).to.equal({ value: 'x' });
+        });
+
+        it('does not report warnings on mismatched alternatives with match mode "one"', async () => {
+
+            const schema = Joi.alternatives().try(
+                Joi.string().min(5).warning('custom.x'),
+                Joi.string()
+            ).match('one');
+
+            expect(await schema.validateAsync('x', { warnings: true, abortEarly: false })).to.equal({ value: 'x' });
+        });
+
+        it('does not report custom warnings on mismatched array items', async () => {
+
+            const schema = Joi.array().items(
+                Joi.string().min(5).custom((value, { warn }) => {
+
+                    warn('custom.x');
+                    return value;
+                }),
+                Joi.string()
+            );
+
+            expect(await schema.validateAsync(['x', 'y'], { warnings: true, abortEarly: false })).to.equal({ value: ['x', 'y'] });
+        });
+
+        it('does not report custom warnings on mismatched alternatives', async () => {
+
+            const schema = Joi.alternatives().try(
+                Joi.string().min(5).custom((value, { warn }) => {
+
+                    warn('custom.x');
+                    return value;
+                }),
+                Joi.string()
+            );
+
+            expect(await schema.validateAsync('x', { warnings: true, abortEarly: false })).to.equal({ value: 'x' });
+        });
+
+        it('does not report custom warnings on mismatched alternatives with match mode "one"', async () => {
+
+            const schema = Joi.alternatives().try(
+                Joi.string().min(5).custom((value, { warn }) => {
+
+                    warn('custom.x');
+                    return value;
+                }),
+                Joi.string()
+            ).match('one');
+
+            expect(await schema.validateAsync('x', { warnings: true, abortEarly: false })).to.equal({ value: 'x' });
+        });
     });
 
     describe('Shadow', () => {


### PR DESCRIPTION
Warnings and externals should not appear in results nor run if this is the result of the validation of a mismatch in an array or an alternative.