### PR TITLE
feat: add 'today' to Date Validation

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1848,8 +1848,9 @@ declare namespace Joi {
          * Notes: 'now' can be passed in lieu of date so as to always compare relatively to the current date,
          * allowing to explicitly ensure a date is either in the past or in the future.
          * It can also be a reference to another field.
+         * 'today' is similar to 'now', but its [h,m,s,ms] is [0,0,0,0]
          */
-        greater(date: 'now' | Date | number | string | Reference): this;
+        greater(date: 'now' | 'today' | Date | number | string | Reference): this;
 
         /**
          * Requires the string value to be in valid ISO 8601 date format.
@@ -1861,24 +1862,27 @@ declare namespace Joi {
          * Notes: 'now' can be passed in lieu of date so as to always compare relatively to the current date,
          * allowing to explicitly ensure a date is either in the past or in the future.
          * It can also be a reference to another field.
+         * 'today' is similar to 'now', but its [h,m,s,ms] is [0,0,0,0]
          */
-        less(date: 'now' | Date | number | string | Reference): this;
+        less(date: 'now' | 'today' | Date | number | string | Reference): this;
 
         /**
          * Specifies the oldest date allowed.
          * Notes: 'now' can be passed in lieu of date so as to always compare relatively to the current date,
          * allowing to explicitly ensure a date is either in the past or in the future.
          * It can also be a reference to another field.
+         * 'today' is similar to 'now', but its [h,m,s,ms] is [0,0,0,0]
          */
-        min(date: 'now' | Date | number | string | Reference): this;
+        min(date: 'now' | 'today'| Date | number | string | Reference): this;
 
         /**
          * Specifies the latest date allowed.
          * Notes: 'now' can be passed in lieu of date so as to always compare relatively to the current date,
          * allowing to explicitly ensure a date is either in the past or in the future.
          * It can also be a reference to another field.
+         * 'today' is similar to 'now', but its [h,m,s,ms] is [0,0,0,0]
          */
-        max(date: 'now' | Date | number | string | Reference): this;
+        max(date: 'now' | 'today'| Date | number | string | Reference): this;
 
         /**
          * Requires the value to be a timestamp interval from Unix Time.

--- a/lib/types/date.js
+++ b/lib/types/date.js
@@ -52,9 +52,13 @@ module.exports = Any.extend({
 
         compare: {
             method: false,
+
             validate(value, helpers, { date }, { name, operator, args }) {
 
-                const to = date === 'now' ? Date.now() : date.getTime();
+                const startOfToday = new Date();
+                startOfToday.setHours(0, 0, 0, 0);
+                const to = date === 'now' ? Date.now() : date === 'today' ? startOfToday.getTime() : date.getTime();
+
                 if (Common.compare(value.getTime(), to, operator)) {
                     return value;
                 }
@@ -67,7 +71,7 @@ module.exports = Any.extend({
                     ref: true,
                     normalize: (date) => {
 
-                        return date === 'now' ? date : internals.parse(date);
+                        return (date === 'now' || date === 'today') ? date : internals.parse(date);
                     },
                     assert: (date) => date !== null,
                     message: 'must have a valid date format'

--- a/test/types/date.js
+++ b/test/types/date.js
@@ -12,7 +12,8 @@ const internals = {};
 
 const { describe, it, before, after } = exports.lab = Lab.script();
 const { expect } = Code;
-
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * 60;
 
 describe('date', () => {
 
@@ -276,6 +277,31 @@ describe('date', () => {
                     path: [],
                     type: 'date.greater',
                     context: { limit: 'now', label: 'value', value: past }
+                }]
+            ]);
+        });
+
+        it('accepts "today" as the greater date', () => {
+
+            const startOfToday = new Date();
+            startOfToday.setHours(0, 0, 0, 0);
+            const future = new Date(startOfToday.getTime() + 1000000);
+
+            expect(Joi.date().greater('today').validate(future)).to.equal({ value: future });
+        });
+
+        it('errors if .greater("today") is used with a past date', () => {
+
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const past = new Date(today.getTime() - 1000000);
+
+            Helper.validate(Joi.date().greater('today'), [
+                [past, false, {
+                    message: '"value" must be greater than "today"',
+                    path: [],
+                    type: 'date.greater',
+                    context: { limit: 'today', label: 'value', value: past }
                 }]
             ]);
         });
@@ -581,6 +607,26 @@ describe('date', () => {
             }]]);
         });
 
+        it('accepts "today" as the less date', () => {
+
+            const past = new Date(Date.now() - ONE_DAY);
+            Helper.validate(Joi.date().less('today'), [[past, true, past]]);
+        });
+
+        it('errors if .less("today") is used with a future date', () => {
+
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const future = new Date(today.getTime() + ONE_HOUR);
+
+            Helper.validate(Joi.date().less('today'), [[future, false, {
+                message: '"value" must be less than "today"',
+                path: [],
+                type: 'date.less',
+                context: { limit: 'today', label: 'value', value: future }
+            }]]);
+        });
+
         it('accepts references as less date', () => {
 
             const ref = Joi.ref('a');
@@ -728,6 +774,26 @@ describe('date', () => {
                 path: [],
                 type: 'date.max',
                 context: { limit: 'now', label: 'value', value: future }
+            }]]);
+        });
+
+        it('accepts "today" as the max date', () => {
+
+            const past = new Date(Date.now() - ONE_DAY);
+            Helper.validate(Joi.date().max('today'), [[past, true, past]]);
+        });
+
+        it('errors if .max("today") is used with a future date', () => {
+
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const future = new Date(today.getTime() + 1);
+
+            Helper.validate(Joi.date().max('today'), [[future, false, {
+                message: '"value" must be less than or equal to "today"',
+                path: [],
+                type: 'date.max',
+                context: { limit: 'today', label: 'value', value: future }
             }]]);
         });
 
@@ -894,6 +960,27 @@ describe('date', () => {
                 path: [],
                 type: 'date.min',
                 context: { limit: 'now', label: 'value', value: past }
+            }]]);
+        });
+
+        it('accepts "today" as the min date', () => {
+
+            const now = new Date();
+            expect(Joi.date().min('today').validate(now)).to.equal({ value: now });
+
+        });
+
+        it('errors if .min("today") is used with a past date', () => {
+
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const past = new Date(today.getTime() - 1);
+
+            Helper.validate(Joi.date().min('today'), [[past, false, {
+                message: '"value" must be greater than or equal to "today"',
+                path: [],
+                type: 'date.min',
+                context: { limit: 'today', label: 'value', value: past }
             }]]);
         });
 


### PR DESCRIPTION
**Issue**
`now` value is `Date.now()`, so it contains `h, m, s, ms` value in `Date` object. Hence, when users select `Date` only (without `h, m, s, ms` values), `now` value always greater than expected value (due to `RTT` from browser to server).

**Feat**
This PR introduce `today` value, which `setHours(0,0,0,0)`.

**Test**
- [x] Add tests for `greater`, `min`, `max`
- [x] Update typing 