### PR TITLE
fix: commit states to avoid memory leak

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -68,6 +68,16 @@ module.exports = internals.State = class {
 
         this.mainstay.restore();
     }
+
+    commit() {
+
+        if (this.mainstay.shadow) {
+            this.mainstay.shadow.override(this.path, this._snapshot);
+            this._snapshot = undefined;
+        }
+
+        this.mainstay.commit();
+    }
 };
 
 

--- a/lib/types/alternatives.js
+++ b/lib/types/alternatives.js
@@ -56,6 +56,7 @@ module.exports = Any.extend({
                 const result = item.schema.$_validate(value, localState, prefs);
                 if (!result.errors) {
                     matched.push(result.value);
+                    localState.commit();
                 }
                 else {
                     failed.push(result.errors);
@@ -113,6 +114,7 @@ module.exports = Any.extend({
 
                 const result = item.schema.$_validate(value, localState, prefs);
                 if (!result.errors) {
+                    localState.commit();
                     return result;
                 }
 

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -227,6 +227,7 @@ module.exports = Any.extend({
                         requiredChecks[j] = res;
 
                         if (!res.errors) {
+                            localState.commit();
                             value[i] = res.value;
                             isValid = true;
                             internals.fastSplice(requireds, j);
@@ -272,6 +273,7 @@ module.exports = Any.extend({
 
                             res = inclusion.$_validate(item, localState, prefs);
                             if (!res.errors) {
+                                localState.commit();
                                 if (inclusion._flags.result === 'strip') {
                                     internals.fastSplice(value, i);
                                     --i;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -218,6 +218,11 @@ internals.Mainstay = class {
         this.externals = snapshot.externals;
         this.warnings = snapshot.warnings;
     }
+
+    commit() {
+
+        this._snapshots.pop();
+    }
 };
 
 


### PR DESCRIPTION
Snapshots were being constantly added without ever being removed, creating a leak.