### PR TITLE
feat: support bindary buffer that has been JSON.parse(JSON.strinified())

### DIFF
--- a/lib/types/binary.js
+++ b/lib/types/binary.js
@@ -13,10 +13,16 @@ module.exports = Any.extend({
 
     type: 'binary',
 
-    coerce: {
-        from: 'string',
-        method(value, { schema }) {
+    coerce(value, { schema }) {
 
+        if (typeof value === 'string') {
+            try {
+                return { value: Buffer.from(value, schema._flags.encoding) };
+            }
+            catch (ignoreErr) { }
+        }
+
+        if (typeof value === 'object' && value !== null && value.type === 'Buffer') {
             try {
                 return { value: Buffer.from(value, schema._flags.encoding) };
             }

--- a/test/types/binary.js
+++ b/test/types/binary.js
@@ -29,6 +29,18 @@ describe('binary', () => {
         expect(value.toString('utf8')).to.equal('test');
     });
 
+    it('converts a JSON encoded and decoded buffer to a buffer', () => {
+
+        const testPngMagicNumber = Buffer.from('89504E470D0A', 'hex');
+        const jsonEncodedBuffer = JSON.stringify(testPngMagicNumber);
+        const jsonDecodedBuffer = JSON.parse(jsonEncodedBuffer);
+
+        const value = Joi.binary().validate(jsonDecodedBuffer).value;
+        expect(value instanceof Buffer).to.equal(true);
+        expect(value.length).to.equal(testPngMagicNumber.length);
+        expect(value).to.equal(testPngMagicNumber);
+    });
+
     it('validates allowed buffer content', () => {
 
         const hello = Buffer.from('hello');
@@ -116,6 +128,23 @@ describe('binary', () => {
                     path: [],
                     type: 'binary.base',
                     context: { label: 'value', value: 5 }
+                }]
+            ]);
+        });
+
+        it('returns an error when a JSON encoded & decoded buffer object is used in strict mode', () => {
+
+            // Generate Buffer and stringify it as JSON.
+            const testPngMagicNumber = Buffer.from('89504E470D0A', 'hex');
+            const jsonEncodedBuffer = JSON.stringify(testPngMagicNumber);
+            const jsonDecodedBuffer = JSON.parse(jsonEncodedBuffer);
+
+            Helper.validate(Joi.binary().strict(), [
+                [jsonDecodedBuffer, false, {
+                    message: '"value" must be a buffer or a string',
+                    path: [],
+                    type: 'binary.base',
+                    context: { label: 'value', value: jsonDecodedBuffer }
                 }]
             ]);
         });


### PR DESCRIPTION
What?
This adds to binary type handler the ability to utilize node.JS's built in Buffer JSON encoding and appropriate tests for the functionality.

What issues does this address?
https://github.com/hapijs/joi/issues/2954

What can be improved?
- [ ] Validate the numeric data array to ensure numbers in the data array were between 0 and 255. I don't think Joi can be called within Joi, and so unsure of validating this without quite a bit of code. Hoping maintainers have a better idea of how this can be done without adding significant cognitive load to this change.

Why?
As a part of a larger request, it is helpful to be able to pass a binary value over a larger JSON model. I ran into this recently when passing request handlers over an HTTP call initiating a browser session that then had an array of request replacements. It worked great for JS and CSS, but small images would fail to decode properly.

Available workarounds?
This can also be achieved via doing the following in with the schema:
```JavaScript
Joi.alternatives(
   Joi.binary(),
   Joi.object({
      type: 'Buffer',
      data: Joi.array().items(Joi.number().min(0).max(255))
   }).and('type','data').custom(Buffer.from)
)
```

Why should this be apart of the core framework?
I believe that the inclusion of allowing this to be coerced via Buffer.from() indicates that node.js meant for this data type to be both encoded and decoded. I feel like this change follows the "least surprise" API: If a buffer snuck into a data structure that was passed to a JSON encoder (like when posting an HTTP call), then parsed by a HTTP reciever's middleware, then the least surprising outcome would be to have it be a Buffer in the end. I believe that if projects were to add the workaround to their projects, it would add to the cognitive load of their projects.

Arguments against this being apart of Joi?
Argument: @Marsup brought up the inefficiency of encoding binary in JSON.
Response: While I agree it is inefficient overall, but I pose the purpose of JSON was never extreme efficiency. It's strength is in clarity and easy of reading. I agree that there are other formats that are better for binary transfer, but I think preventing this based on efficiency argument forces premature optimization of software.

Conclusion:
I appreciate your consideration of this PR. If you don't want to commit to adding this to the project, please indicate such and decline this PR, so that downstream projects can act upon that information. Thank you for the awesome tool!