### PR TITLE
Associate Buffer with BinarySchema

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -808,6 +808,8 @@ declare namespace Joi {
         ? Joi.BooleanSchema
         : T extends NullableType<Date>
         ? Joi.DateSchema
+        : T extends NullableType<Buffer>
+        ? Joi.BinarySchema
         : T extends NullableType<Array<any>>
         ? Joi.ArraySchema
         : T extends NullableType<object>


### PR DESCRIPTION
This fixes the ability do have types like:

```typescript
type Photo = {
  id: number,
  caption: string,
  content: Buffer
};

const schemaProps: SchemaMap<Photo, true> = {
  id: Joi.number(),
  caption: Joi.string(),
  content: Joi.binary()
};
```
