### PR TITLE
feat: Improve object type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -814,15 +814,13 @@ declare namespace Joi {
         ? (StrictSchemaMap<T> | ObjectSchema<T>)
         : never
 
-    type PartialSchemaMap<TSchema = any> = {
-        [key in keyof TSchema]?: SchemaLike | SchemaLike[];
-    }
-
     type StrictSchemaMap<TSchema = any> =  {
         [key in keyof TSchema]-?: ObjectPropertiesSchema<TSchema[key]>
     };
 
-    type SchemaMap<TSchema = any, isStrict = false> = isStrict extends true ? StrictSchemaMap<TSchema> : PartialSchemaMap<TSchema>
+    type SchemaMap<TSchema = any> = {
+        [key in keyof TSchema]: Schema<TSchema[key]> | TSchema[key]
+    }
 
     type Schema<P = any> =
         | AnySchema<P>
@@ -1711,8 +1709,8 @@ declare namespace Joi {
         /**
          * Appends the allowed object keys. If schema is null, undefined, or {}, no changes will be applied.
          */
-        append(schema?: SchemaMap<TSchema>): this;
-        append<TSchemaExtended = any, T = TSchemaExtended>(schema?: SchemaMap<T>): ObjectSchema<T>
+        append<TSchemaExtended extends null | undefined>(schema?: TSchemaExtended): this;
+        append<TSchemaExtended = any>(schema?: SchemaMap<TSchemaExtended>): ObjectSchema<TSchemaExtended & TSchema>
 
         /**
          * Verifies an assertion where.
@@ -1731,7 +1729,8 @@ declare namespace Joi {
         /**
          * Sets or extends the allowed object keys.
          */
-        keys(schema?: SchemaMap<TSchema>): this;
+        keys<TSchemaExtended extends null | undefined>(schema?: TSchemaExtended): this;
+        keys<TSchemaExtended = any>(schema?: SchemaMap<TSchemaExtended>): ObjectSchema<TSchema & TSchemaExtended>;
 
         /**
          * Specifies the exact number of keys in the object.
@@ -1790,7 +1789,7 @@ declare namespace Joi {
         /**
          * Renames a key to another name (deletes the renamed key).
          */
-        rename(from: string | RegExp, to: string, options?: RenameOptions): this;
+        rename<From extends keyof TSchema, To extends string>(from: From | RegExp, to: To, options?: RenameOptions): ObjectSchema<Pick<TSchema, Exclude<keyof TSchema, From>> & {[P in To]: TSchema[From]}>;
 
         /**
          * Requires the object to be a Joi schema instance.
@@ -1805,12 +1804,12 @@ declare namespace Joi {
         /**
          * Requires the presence of other keys whenever the specified key is present.
          */
-        with(key: string, peers: string | string[], options?: DependencyOptions): this;
+        with<Key extends keyof TSchema>(key: Key, peers: Exclude<keyof TSchema, Key> | Exclude<keyof TSchema, Key>[], options?: DependencyOptions): this;
 
         /**
          * Forbids the presence of other keys whenever the specified is present.
          */
-        without(key: string, peers: string | string[], options?: DependencyOptions): this;
+        without<Key extends keyof TSchema>(key: Key, peers: Exclude<keyof TSchema, Key> | Exclude<keyof TSchema, Key>[], options?: DependencyOptions): this;
 
         /**
          * Defines an exclusive relationship between a set of keys. one of them is required but not at the same time.
@@ -2123,8 +2122,7 @@ declare namespace Joi {
         /**
          * Generates a schema object that matches an object data type (as well as JSON strings that have been parsed into objects).
          */
-        // tslint:disable-next-line:no-unnecessary-generics
-        object<TSchema = any, isStrict = false, T = TSchema>(schema?: SchemaMap<T, isStrict>): ObjectSchema<TSchema>;
+        object<TSchema = {}>(schema?: SchemaMap<TSchema>): ObjectSchema<TSchema>;
 
         /**
          * Generates a schema object that matches a string data type. Note that empty strings are not allowed by default and must be enabled with allow('').


### PR DESCRIPTION
This PR improves object's types.

### Before
1. regular object - output schema is `any`
```ts
const testSchema = Joi.object({ FOO: 'bar' });
```
![image](https://github.com/hapijs/joi/assets/9304194/545eaa8c-31de-4647-9568-13f2ca59239c)

2. with `keys` - output schema is `any`
![image](https://github.com/hapijs/joi/assets/9304194/bfc0d124-cc70-4c62-9f88-8bf584347463)

3.  with `append` - output schema not changed
![image](https://github.com/hapijs/joi/assets/9304194/654c45c4-10c4-4c22-92cf-a6f9a51ea8a3)

4. with `rename` - no key completion, output schema not changed
![image](https://github.com/hapijs/joi/assets/9304194/dbc9ed93-549c-4c13-bf65-96b64c3185c9)

5. with `with` - no key's completion
![image](https://github.com/hapijs/joi/assets/9304194/3aee5054-0bf9-4efc-a905-f37307cecdde)

6. with `without` - no key's completion
![image](https://github.com/hapijs/joi/assets/9304194/82629379-df3d-4af9-9779-0ef4fdc37b0c)


### After
1. regular object usage incorporates the object type that was passed
![image](https://github.com/hapijs/joi/assets/9304194/dad54402-9a75-465d-9e96-2a2dcf6ba3ad)
which means that calling to `attempt` returns the object type properly
![image](https://github.com/hapijs/joi/assets/9304194/b7eef7ee-a838-4620-b68a-a326ad4e3478)

2. using `keys`
without provided object
![image](https://github.com/hapijs/joi/assets/9304194/60211921-b26b-4022-ba35-81496b401870)
extending provided object
![image](https://github.com/hapijs/joi/assets/9304194/9d623459-d164-41b6-974a-ff540218017a)

3.  with `append` 
`append` with null or undefined not changing the original obj
![image](https://github.com/hapijs/joi/assets/9304194/313c3b1f-892a-4a3e-85a9-43dd466f861a)
appending new object keys
![image](https://github.com/hapijs/joi/assets/9304194/e2ded3b1-d774-46e9-a83e-f21170141751)

4. with `rename` - key completion, output schema changed
![image](https://github.com/hapijs/joi/assets/9304194/fb57d44d-6869-4c75-96e2-80566daf018f)
![image](https://github.com/hapijs/joi/assets/9304194/9474d282-5bca-4100-8fe9-6ca5f4aa8699)

5. with `with` - key completion
![image](https://github.com/hapijs/joi/assets/9304194/c2a00dee-a8ce-42c6-b915-8034b476eb5f)
completes the rest of the keys (since `.with('foo', 'foo')` doesn't make sense)
![image](https://github.com/hapijs/joi/assets/9304194/fe60999b-cac2-4c84-bbd5-122177ad8120)

6. with `without` - same as `with`
![image](https://github.com/hapijs/joi/assets/9304194/f264e2b3-d1e4-4e6a-a232-960f3f56fbb0)
![image](https://github.com/hapijs/joi/assets/9304194/db046f93-9b9e-4024-93ff-9a43365cec6a)

closes #2978 