### PR TITLE
fix: allow any.error() return type to be ErrorReport[]

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -693,7 +693,7 @@ declare namespace Joi {
         context?: Context;
     }
 
-    type ValidationErrorFunction = (errors: ErrorReport[]) => string | ValidationErrorItem | Error;
+    type ValidationErrorFunction = (errors: ErrorReport[]) => string | ValidationErrorItem | Error | ErrorReport[];
 
     interface ValidationWarning {
         message: string;


### PR DESCRIPTION
This function already accepts to return its input, let's fix the type.