### PR TITLE
fix: missing template reference

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -207,7 +207,11 @@ module.exports = exports = internals.Template = class {
 
             const ref = Ref.create(variable, this._settings);
             refs.push(ref);
-            return (context) => ref.resolve(...context);
+            return (context) => {
+
+                const resolved = ref.resolve(...context);
+                return resolved !== undefined ? resolved : null;
+            };
         };
 
         try {

--- a/test/template.js
+++ b/test/template.js
@@ -85,6 +85,17 @@ describe('Template', () => {
         expect(template.render({}, {}, { context: { x: 'hello', y: '!' } }, {}, { errors: { escapeHtml: false } })).to.equal('text hello! {{escaped}} xxx abc {{{ignore}} 123 {{x');
     });
 
+    it('parses template with missing elements in binary operation', () => {
+
+        const source = 'text {$x || $y}';
+        const template = Joi.x(source);
+
+        expect(template.source).to.equal(source);
+        expect(template.render({}, {}, { context: { x: 'hello' } })).to.equal('text hello');
+        expect(template.render({}, {}, { context: { y: 'hello' } })).to.equal('text hello');
+        expect(template.render({}, {}, { context: {} })).to.equal('text null');
+    });
+
     it('parses template with single variable', () => {
 
         const source = '{$x}';


### PR DESCRIPTION
Formula expects a `null` value in case of missing references, since we replace the reference resolver, we must behave like it.

Fixes #2974.