### PR TITLE
fix: do not override existing labels of underlying schemas in alternatives

### DIFF
--- a/lib/types/alternatives.js
+++ b/lib/types/alternatives.js
@@ -211,7 +211,11 @@ module.exports = Any.extend({
         label(name) {
 
             const obj = this.$_parent('label', name);
-            const each = (item, source) => (source.path[0] !== 'is' ? item.label(name) : undefined);
+            const each = (item, source) => {
+
+                return source.path[0] !== 'is' && typeof item._flags.label !== 'string' ? item.label(name) : undefined;
+            };
+
             return obj.$_modify({ each, ref: false });
         }
     },

--- a/test/types/alternatives.js
+++ b/test/types/alternatives.js
@@ -1377,6 +1377,149 @@ describe('alternatives', () => {
                 }
             });
         });
+
+        it('does not override existing labels in nested alternatives', () => {
+
+            const schema = Joi.alternatives().try(
+                Joi.boolean().label('boolean'),
+                Joi.alternatives().try(
+                    Joi.string().label('string'),
+                    Joi.number().label('number')
+                ).label('string or number')
+            );
+
+            expect(schema.describe()).to.equal({
+                type: 'alternatives',
+                matches: [
+                    {
+                        schema: {
+                            type: 'boolean',
+                            flags: {
+                                label: 'boolean'
+                            }
+                        }
+                    },
+                    {
+                        schema: {
+                            type: 'alternatives',
+                            flags: {
+                                label: 'string or number'
+                            },
+                            matches: [
+                                {
+                                    schema: {
+                                        type: 'string',
+                                        flags: {
+                                            label: 'string'
+                                        }
+                                    }
+                                },
+                                {
+                                    schema: {
+                                        type: 'number',
+                                        flags: {
+                                            label: 'number'
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            });
+        });
+
+        it('does not override existing label of then', () => {
+
+            const schema = Joi.object({
+                a: Joi.boolean(),
+                b: Joi.alternatives()
+                    .conditional('a', { is: true, then: Joi.string().label('not x') })
+                    .label('x')
+            });
+
+            expect(schema.describe()).to.equal({
+                type: 'object',
+                keys: {
+                    a: {
+                        type: 'boolean'
+                    },
+                    b: {
+                        type: 'alternatives',
+                        flags: {
+                            label: 'x'
+                        },
+                        matches: [
+                            {
+                                is: {
+                                    type: 'any',
+                                    allow: [{ override: true }, true],
+                                    flags: {
+                                        only: true,
+                                        presence: 'required'
+                                    }
+                                },
+                                ref: {
+                                    path: ['a']
+                                },
+                                then: {
+                                    type: 'string',
+                                    flags: {
+                                        label: 'not x'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            });
+        });
+
+        it('does not override existing label of otherwise', () => {
+
+            const schema = Joi.object({
+                a: Joi.boolean(),
+                b: Joi.alternatives()
+                    .conditional('a', { is: true, otherwise: Joi.string().label('not x') })
+                    .label('x')
+            });
+
+            expect(schema.describe()).to.equal({
+                type: 'object',
+                keys: {
+                    a: {
+                        type: 'boolean'
+                    },
+                    b: {
+                        type: 'alternatives',
+                        flags: {
+                            label: 'x'
+                        },
+                        matches: [
+                            {
+                                is: {
+                                    type: 'any',
+                                    allow: [{ override: true }, true],
+                                    flags: {
+                                        only: true,
+                                        presence: 'required'
+                                    }
+                                },
+                                ref: {
+                                    path: ['a']
+                                },
+                                otherwise: {
+                                    type: 'string',
+                                    flags: {
+                                        label: 'not x'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            });
+        });
     });
 
     describe('match()', () => {


### PR DESCRIPTION
When using labels on underlying schemas of labeled Joi.alternatives, the Joi.alternatives' label overwrites the labels of the underlying schemas. I think this is a bug and therefore propose the changes in this PR.

Based on reading existing tests, I assume passing labels from Joi.alternatives to underlying schemas is wanted, though I do not believe this should be the case when the underlying schemas already have their own labels. The fact that I am not breaking any existing tests with these changes further reinforces my belief that this may be a bug. I only added a few new tests to cover the behavior introduced in my changes.

#### Background:
In my project, I am using joi-to-swagger to convert Joi schemas to OpenAPI-compatible schemas. In case of Joi.alternatives, this leads to `anyof` or `oneOf` (meaning this property can have any/one of the following schemas) , where the schema labels are useful to be able to differentiate the specific alternatives at first glance instead of having a default generic label for each one (object, string, number, ...). When I use nested Joi.alternatives, the nested alternatives all take the parent's label, which results in me being unable to tell the difference at first glance when reading the generated OpenAPI documentation (see screenshots below).

Take the following example:
```typescript
const Joi = require('./lib/index.js');

const valueSchema = Joi.object().keys({
  value: Joi.string().required(),
});

const notFoundErrorSchema = Joi.object().keys({
  code: Joi.string().required(),
  resource: Joi.string().required(),
});

const forbiddenErrorSchema = Joi.object().keys({
  code: Joi.string().required(),
  user: Joi.string().required(),
});

const errorSchema = Joi.alternatives().try(
  notFoundErrorSchema.label('NOT FOUND ERROR'),
  forbiddenErrorSchema.label('FORBIDDEN ERROR'),
);

const responseSchema = Joi.alternatives().try(
  valueSchema.label('VALUE'),
  errorSchema.label('ERROR'),
);

console.log(JSON.stringify(responseSchema.describe(), null, 2));
```

###### Current output
```json
{
  "type": "alternatives",
  "matches": [
    {
      "schema": {
        "type": "object",
        "flags": {
          "label": "VALUE"
        },
        "keys": {
          "value": {
            "type": "string",
            "flags": {
              "presence": "required"
            }
          }
        }
      }
    },
    {
      "schema": {
        "type": "alternatives",
        "flags": {
          "label": "ERROR"
        },
        "matches": [
          {
            "schema": {
              "type": "object",
              "flags": {
                "label": "ERROR"  // <----------------------------------------
              },
              "keys": {
                "code": {
                  "type": "string",
                  "flags": {
                    "presence": "required"
                  }
                },
                "resource": {
                  "type": "string",
                  "flags": {
                    "presence": "required"
                  }
                }
              }
            }
          },
          {
            "schema": {
              "type": "object",
              "flags": {
                "label": "ERROR"  // <----------------------------------------
              },
              "keys": {
                "code": {
                  "type": "string",
                  "flags": {
                    "presence": "required"
                  }
                },
                "user": {
                  "type": "string",
                  "flags": {
                    "presence": "required"
                  }
                }
              }
            }
          }
        ]
      }
    }
  ]
}
```

###### Expected output
```json
{
  "type": "alternatives",
  "matches": [
    {
      "schema": {
        "type": "object",
        "flags": {
          "label": "VALUE"
        },
        "keys": {
          "value": {
            "type": "string",
            "flags": {
              "presence": "required"
            }
          }
        }
      }
    },
    {
      "schema": {
        "type": "alternatives",
        "flags": {
          "label": "ERROR"
        },
        "matches": [
          {
            "schema": {
              "type": "object",
              "flags": {
                "label": "NOT FOUND ERROR"  // <----------------------------------------
              },
              "keys": {
                "code": {
                  "type": "string",
                  "flags": {
                    "presence": "required"
                  }
                },
                "resource": {
                  "type": "string",
                  "flags": {
                    "presence": "required"
                  }
                }
              }
            }
          },
          {
            "schema": {
              "type": "object",
              "flags": {
                "label": "FORBIDDEN ERROR"  // <----------------------------------------
              },
              "keys": {
                "code": {
                  "type": "string",
                  "flags": {
                    "presence": "required"
                  }
                },
                "user": {
                  "type": "string",
                  "flags": {
                    "presence": "required"
                  }
                }
              }
            }
          }
        ]
      }
    }
  ]
}
```

##### Resulting OpenAPI documentation
###### Current behavior
![image](https://github.com/hapijs/joi/assets/27775613/96a2b0dc-05fe-4974-abed-2e7f2a882720)

###### Expected behavior
![image](https://github.com/hapijs/joi/assets/27775613/b6288d51-3005-45a8-98e7-7a9859c47c89)