### PR TITLE
Missing 'allowUnderscore' assertOptions in email

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -282,7 +282,7 @@ module.exports = Any.extend({
         email: {
             method(options = {}) {
 
-                Common.assertOptions(options, ['allowFullyQualified', 'allowUnicode', 'ignoreLength', 'maxDomainSegments', 'minDomainSegments', 'multiple', 'separator', 'tlds']);
+                Common.assertOptions(options, ['allowFullyQualified', 'allowUnderscore', 'allowUnicode', 'ignoreLength', 'maxDomainSegments', 'minDomainSegments', 'multiple', 'separator', 'tlds']);
                 assert(options.multiple === undefined || typeof options.multiple === 'boolean', 'multiple option must be an boolean');
 
                 const address = internals.addressOptions(options);


### PR DESCRIPTION
Close #2972 ,  

Missing "allowUnderscore" in assertOptions.