### PR TITLE
fix: LanguageMessages type now supports languages in TypeScript

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -26,7 +26,7 @@ declare namespace Joi {
 
     type BasicType = boolean | number | string | any[] | object | null;
 
-    type LanguageMessages = Record<string, string>;
+    type LanguageMessages = Record<string, string | Record<string, string>>;
 
     type PresenceMode = 'optional' | 'required' | 'forbidden';
 


### PR DESCRIPTION
Closes:
- https://github.com/hapijs/joi/issues/2720
- https://github.com/hapijs/joi/issues/2941

This feature has always really been supported, but the type was correct all the time, resulting in build errors.
Only fixable with ugly `ts-expect-error` patterns or `ts-patch` files.
It was really annoying to see this feature actually [documented](https://joi.dev/api/?v=17.9.1#anyvalidatevalue-options), but the type not being correct.

Multiple tests are already present, but this is one example:
https://github.com/hapijs/joi/blob/master/test/errors.js#L176-L196

Code that backs this up as being an existing and supported feature:
https://github.com/hapijs/joi/blob/master/lib/errors.js#L133-L143

Would love to hear back!