### PR TITLE
fix: precision issue on number().multiple()

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v17
   pull_request:
   workflow_dispatch:
 

--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -12,7 +12,17 @@ const internals = {
     exponentialPartRegex: /[eE][+-]?\d+$/,
     leadingSignAndZerosRegex: /^[+-]?(0*)?/,
     dotRegex: /\./,
-    trailingZerosRegex: /0+$/
+    trailingZerosRegex: /0+$/,
+    decimalPlaces(value) {
+
+        const str = value.toString();
+        const dindex = str.indexOf('.');
+        const eindex = str.indexOf('e');
+        return (
+            (dindex < 0 ? 0 : (eindex < 0 ? str.length : eindex) - dindex - 1) +
+            (eindex < 0 ? 0 : Math.max(0, -parseInt(str.slice(eindex + 1))))
+        );
+    }
 };
 
 
@@ -168,15 +178,30 @@ module.exports = Any.extend({
         multiple: {
             method(base) {
 
-                return this.$_addRule({ name: 'multiple', args: { base } });
-            },
-            validate(value, helpers, { base }, options) {
+                const baseDecimalPlace = typeof base === 'number' ? internals.decimalPlaces(base) : null;
+                const pfactor = Math.pow(10, baseDecimalPlace);
 
-                if (value * (1 / base) % 1 === 0) {
-                    return value;
+                return this.$_addRule({
+                    name: 'multiple',
+                    args: {
+                        base,
+                        baseDecimalPlace,
+                        pfactor
+                    }
+                });
+            },
+            validate(value, helpers, { base, baseDecimalPlace, pfactor }, options) {
+
+                const valueDecimalPlace = internals.decimalPlaces(value);
+
+                if (valueDecimalPlace > baseDecimalPlace) {
+                    // Value with higher precision than base can never be a multiple
+                    return helpers.error('number.multiple', { multiple: options.args.base, value });
                 }
 
-                return helpers.error('number.multiple', { multiple: options.args.base, value });
+                return Math.round(pfactor * value) % Math.round(pfactor * base) === 0 ?
+                    value :
+                    helpers.error('number.multiple', { multiple: options.args.base, value });
             },
             args: [
                 {
@@ -184,7 +209,9 @@ module.exports = Any.extend({
                     ref: true,
                     assert: (value) => typeof value === 'number' && isFinite(value) && value > 0,
                     message: 'must be a positive number'
-                }
+                },
+                'baseDecimalPlace',
+                'pfactor'
             ],
             multi: true
         },

--- a/test/errors.js
+++ b/test/errors.js
@@ -38,7 +38,8 @@ describe('errors', () => {
         const err = Joi.valid('foo').validate('bar', { errors: { stack: true } }).error;
         expect(err).to.be.an.error();
         expect(err.isJoi).to.be.true();
-        expect(err.stack).to.contain('at Object.exports.process');
+        expect(err.stack).to.contain('    at ');
+        expect(err.stack).to.contain('exports.process');
     });
 
     it('supports custom errors when validating types', () => {

--- a/test/types/number.js
+++ b/test/types/number.js
@@ -747,6 +747,48 @@ describe('number', () => {
             ]);
         });
 
+        it('handles precision errors correctly', () => {
+
+            const cases = [
+                [3600000, [
+                    [14400000, true]
+                ]],
+                [0.01, [
+                    [2.03, true],
+                    [2.029999999999, false, {
+                        message: '"value" must be a multiple of 0.01',
+                        path: [],
+                        type: 'number.multiple',
+                        context: { multiple: 0.01, value: 2.029999999999, label: 'value' }
+                    }],
+                    [2.030000000001, false, {
+                        message: '"value" must be a multiple of 0.01',
+                        path: [],
+                        type: 'number.multiple',
+                        context: { multiple: 0.01, value: 2.030000000001, label: 'value' }
+                    }],
+                    [0.03, true]
+                ]],
+                [0.0000000001, [
+                    [0.2, true]
+                ]],
+                [0.000000101, [
+                    [0.101, true],
+                    [0.10101, false, {
+                        message: '"value" must be a multiple of 1.01e-7',
+                        path: [],
+                        type: 'number.multiple',
+                        context: { multiple: 0.000000101, value: 0.10101, label: 'value' }
+                    }]
+                ]]
+            ];
+
+            for (const [multiple, tests] of cases) {
+                const schema = Joi.number().multiple(multiple);
+                Helper.validate(schema, tests);
+            }
+        });
+
         it('handles floats multiples correctly', () => {
 
             const schema = Joi.number().multiple(3.5);


### PR DESCRIPTION
Fixes #2962.

Comparison method borrowed and adapted from https://stackoverflow.com/questions/7037926/javascript-how-to-tell-if-one-number-is-a-multiple-of-another