### PR TITLE
fix: domain default tld validation

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -742,7 +742,8 @@ module.exports = Any.extend({
 internals.addressOptions = function (options) {
 
     if (!options) {
-        return options;
+        assert(internals.tlds, 'Built-in TLD list disabled');
+        return Object.assign({}, options, internals.tlds);
     }
 
     // minDomainSegments

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -1323,7 +1323,8 @@ describe('string', () => {
                     type: 'string.domain',
                     context: { value: '"example.com', label: 'value' }
                 }],
-                ['mail@example.com', false, '"value" must contain a valid domain name']
+                ['mail@example.com', false, '"value" must contain a valid domain name'],
+                ['joi.dev.whatevertldiwant', false, '"value" must contain a valid domain name']
             ]);
         });
 
@@ -1496,7 +1497,8 @@ describe('string', () => {
                     type: 'string.email',
                     context: { value: '123456789012345678901234567890123456789012345678901234567890@12345678901234567890123456789012345678901234567890123456789.12345678901234567890123456789012345678901234567890123456789.12345678901234567890123456789012345678901234567890123456789.12345.toolong.com', invalids: ['123456789012345678901234567890123456789012345678901234567890@12345678901234567890123456789012345678901234567890123456789.12345678901234567890123456789012345678901234567890123456789.12345678901234567890123456789012345678901234567890123456789.12345.toolong.com'], label: 'value' }
                 }],
-                ['foo@bar%2ecom', false, '"value" must be a valid email']
+                ['foo@bar%2ecom', false, '"value" must be a valid email'],
+                ['invalid_tlds@email.ccc', false, '"value" must be a valid email']
             ]);
         });
 


### PR DESCRIPTION
Fixes #3007

Methods `Joi.string().domain()` and `Joi.string().email()` are now correctly set to default to `tlds: { allow: true}`, as [documented](https://joi.dev/api/?v=17.9.1#stringdomainoptions).