### PR TITLE
fix value type on validation result

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -722,13 +722,9 @@ declare namespace Joi {
     }
 
     type ValidationResult<TSchema = any> = {
-        error: undefined;
+        error?: ValidationError;
         warning?: ValidationError;
         value: TSchema;
-    } | {
-        error: ValidationError;
-        warning?: ValidationError;
-        value: any;
     }
 
     interface CreateErrorOptions {


### PR DESCRIPTION
The **value** property returned from `.validate` is always _any_, which forces casting to the expected type.

The value should always be known (_TSchema_) and the **error** property will be _optional_, check if **error** is falsey to determine if **value** has been properly validated.