### PR TITLE
fix: handle bigint in unique rule

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -496,6 +496,7 @@ module.exports = Any.extend({
                     number: Object.create(null),
                     undefined: Object.create(null),
                     boolean: Object.create(null),
+                    bigint: Object.create(null),
                     object: new Map(),
                     function: new Map(),
                     custom: new Map()

--- a/test/types/array.js
+++ b/test/types/array.js
@@ -2061,7 +2061,7 @@ describe('array', () => {
 
     describe('unique()', () => {
 
-        it('errors if duplicate numbers, strings, objects, binaries, functions, dates and booleans', () => {
+        it('errors if duplicate numbers, strings, objects, binaries, functions, dates, booleans, bigint', () => {
 
             const buffer = Buffer.from('hello world');
             const func = function () { };
@@ -2185,7 +2185,21 @@ describe('array', () => {
                         key: 1,
                         value: undefined
                     }
+                }],
+                [[1n, 1n], false, {
+                    message: '"[1]" contains a duplicate value',
+                    path: [1],
+                    type: 'array.unique',
+                    context: {
+                        pos: 1,
+                        dupePos: 0,
+                        dupeValue: 1n,
+                        label: '[1]',
+                        key: 1,
+                        value: 1n
+                    }
                 }]
+
             ]);
         });
 

--- a/test/types/array.js
+++ b/test/types/array.js
@@ -2061,7 +2061,7 @@ describe('array', () => {
 
     describe('unique()', () => {
 
-        it('errors if duplicate numbers, strings, objects, binaries, functions, dates, booleans, bigint', () => {
+        it('errors if duplicate numbers, strings, objects, binaries, functions, dates, booleans and bigints', () => {
 
             const buffer = Buffer.from('hello world');
             const func = function () { };


### PR DESCRIPTION
When trying to validate uniqueness on bigint type arrays, the error `Failed to find unique map container for type bigint` is returned.

this PR adds handling bigint as a native type without having to provide a compare function and treat it as custom