### PR TITLE
feat: Support encoding uri

### DIFF
--- a/API.md
+++ b/API.md
@@ -3085,6 +3085,7 @@ Requires the string value to be a valid [RFC 3986](http://tools.ietf.org/html/rf
     - `relativeOnly` - Restrict only relative URIs.  Defaults to `false`.
     - `allowQuerySquareBrackets` - Allows unencoded square brackets inside the query string. This is **NOT** RFC 3986 compliant but query strings like `abc[]=123&abc[]=456` are very common these days. Defaults to `false`.
     - `domain` - Validate the domain component using the options specified in [`string.domain()`](#stringdomainoptions).
+    - `encodeUri` - Encodes the uri with non-alphabetical characters. Defaults to `false`.
 
 ```js
 // Accept git or git http/https

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -426,6 +426,12 @@ declare namespace Joi {
          * Validate the domain component using the options specified in `string.domain()`.
          */
         domain?: DomainOptions;
+        /**
+         * Encode URI before validation.
+         * 
+         * @default false
+         */
+        encodeUri?: boolean;
     }
 
     interface DataUriOptions {

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -665,6 +665,10 @@ module.exports = Any.extend({
                     return helpers.error('string.uri');
                 }
 
+                if (helpers.prefs.convert && options.encodeUri) {
+                    value = encodeURI(value);
+                }
+
                 const match = regex.exec(value);
                 if (match) {
                     const matched = match[1] || match[2];
@@ -676,10 +680,6 @@ module.exports = Any.extend({
                     }
 
                     return value;
-                }
-
-                if (helpers.prefs.convert && options.encodeUri) {
-                    return encodeURI(value);
                 }
 
                 if (options.relativeOnly) {

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -690,6 +690,10 @@ module.exports = Any.extend({
                     return helpers.error('string.uriCustomScheme', { scheme, value });
                 }
 
+                if (options.encodeUri) {
+                    return helpers.error('string.uriEncoding');
+                }
+
                 return helpers.error('string.uri');
             }
         }
@@ -740,6 +744,7 @@ module.exports = Any.extend({
         'string.uri': '{{#label}} must be a valid uri',
         'string.uriCustomScheme': '{{#label}} must be a valid uri with a scheme matching the {{#scheme}} pattern',
         'string.uriRelativeOnly': '{{#label}} must be a valid relative uri',
+        'string.uriEncoding': '{{#label}} must contain only valid characters or "convert" must be allowed',
         'string.uppercase': '{{#label}} must only contain uppercase characters'
     }
 });

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -678,6 +678,10 @@ module.exports = Any.extend({
                     return value;
                 }
 
+                if (helpers.prefs.convert && options.encodeUri) {
+                    return encodeURI(value);
+                }
+
                 if (options.relativeOnly) {
                     return helpers.error('string.uriRelativeOnly');
                 }

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -649,7 +649,7 @@ module.exports = Any.extend({
         uri: {
             method(options = {}) {
 
-                Common.assertOptions(options, ['allowRelative', 'allowQuerySquareBrackets', 'domain', 'relativeOnly', 'scheme']);
+                Common.assertOptions(options, ['allowRelative', 'allowQuerySquareBrackets', 'domain', 'relativeOnly', 'scheme', 'encodeUri']);
 
                 if (options.domain) {
                     Common.assertOptions(options.domain, ['allowFullyQualified', 'allowUnicode', 'maxDomainSegments', 'minDomainSegments', 'tlds']);

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -9017,9 +9017,9 @@ describe('string', () => {
             const schema = Joi.string().uri({ encodeUri: true });
 
             Helper.validate(schema, { convert: true }, [
-                ['https://linkedin.com/in/aïssa/', true, 'https://linkedin.com/in/a%C3%AFssa/'],
+                ['https://linkedin.com/in/aïssa/', true, 'https://linkedin.com/in/a%C3%AFssa/']
             ]);
-        })
+        });
 
         it('errors on unknown options', () => {
 

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -9012,6 +9012,15 @@ describe('string', () => {
             ]);
         });
 
+        it('validates uri after encoding', () => {
+
+            const schema = Joi.string().uri({ encodeUri: true });
+
+            Helper.validate(schema, { convert: true }, [
+                ['https://linkedin.com/in/aïssa/', true, 'https://linkedin.com/in/a%C3%AFssa/'],
+            ]);
+        })
+
         it('errors on unknown options', () => {
 
             expect(() => Joi.string().uri({ foo: 'bar', baz: 'qux' })).to.throw('Options contain unknown keys: foo,baz');

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -9012,12 +9012,26 @@ describe('string', () => {
             ]);
         });
 
-        it('validates uri after encoding', () => {
+        it('validates uri with accented characters with encoding', () => {
 
             const schema = Joi.string().uri({ encodeUri: true });
 
             Helper.validate(schema, { convert: true }, [
                 ['https://linkedin.com/in/aïssa/', true, 'https://linkedin.com/in/a%C3%AFssa/']
+            ]);
+        });
+
+        it('validates uri with accented characters without encoding', () => {
+
+            const schema = Joi.string().uri({ encodeUri: true });
+
+            Helper.validate(schema, { convert: false }, [
+                ['https://linkedin.com/in/aïssa/', false, {
+                    message: '"value" must contain only valid characters or "convert" must be allowed',
+                    path: [],
+                    type: 'string.uriEncoding',
+                    context: { value: 'https://linkedin.com/in/aïssa/', label: 'value' }
+                }]
             ]);
         });
 


### PR DESCRIPTION
## Related Issue
- #2889 

## About Changes
- Added optional field `encodeUri` with default `false` in `UriOptions`.
- Added `encodeUri` in string validation method.
  - Returns encoded URI when both `convert` and `encodeUri` flags are `true`.
- Added a test case to reproduce the issue.

## Result
<img width="343" alt="Screenshot 2024-03-30 at 9 26 29 PM" src="https://github.com/hapijs/joi/assets/21357387/cfdde6ff-33ec-4d96-a418-d033b2fd6b24">
