### PR TITLE
feat: Add select-test npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "scripts": {
         "prepublishOnly": "cd browser && npm install && npm run build",
         "test": "lab -t 100 -a @hapi/code -L -Y",
-        "test-cov-html": "lab -r html -o coverage.html -a @hapi/code"
+        "test-cov-html": "lab -r html -o coverage.html -a @hapi/code",
+        "select-test": "lab -t 100 -a @hapi/code -L -Y -g"
     },
     "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
## Related Issue
- #3028 

## About Changes
- As I brought up in the issue, this new command will help contributors to run only specific tests that they want.

## Example Usage
```
npm run select-test "uri after encoding"

> joi@17.12.2 select-test
> lab -t 100 -a @hapi/code -L -Y -g uri after encoding


  
  .

1 tests complete
Test duration: 131 ms
Assertions count: 5 (verbosity: 5.00)
Leaks: No issues
Coverage: 60.11% (3060/7672)
```