### PR TITLE
chore: add trend image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@
 - [Versions status](https://joi.dev/resources/status/#joi)
 - [Changelog](https://joi.dev/resources/changelog/)
 - [Project policies](https://joi.dev/policies/)
+
+## Usage Trend
+
+[Usage Trend of joi](https://npm-compare.com/joi#timeRange=THREE_YEARS)
+  
+<a href="https://npm-compare.com/joi#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/joi.png" width="80%" alt="NPM Usage Trend of joi" />
+</a>


### PR DESCRIPTION
I'm a big fan of the`joi` package and its clean validation features. It's been a valuable asset in my development work.

I was thinking about ways to potentially improve the user experience for newcomers to the project. I came across a service which offers a cool visualization of usage trends.

It might be helpful to add an image to the README that showcases joi's growing popularity. This could be a nice way to assure new users of the package's increasing adoption within the web dev community.

Feel free to suggest any modifications! Thank you for your time and for creating such a fantastic package.

Preview of README:

![image](https://github.com/hapijs/joi/assets/3455798/6be72bc4-6dbd-4beb-a1f5-07852ac910c0)
