### PR TITLE
Minor correction for boolean() documentation

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2118,12 +2118,12 @@ declare namespace Joi {
         array<TSchema = any[]>(): ArraySchema<TSchema>;
 
         /**
-         * Generates a schema object that matches a boolean data type (as well as the strings 'true', 'false', 'yes', and 'no'). Can also be called via boolean().
+         * Generates a schema object that matches a boolean data type (as well as the strings 'true' and 'false'). Can also be called via boolean().
          */
         bool<TSchema = boolean>(): BooleanSchema<TSchema>;
 
         /**
-         * Generates a schema object that matches a boolean data type (as well as the strings 'true', 'false', 'yes', and 'no'). Can also be called via bool().
+         * Generates a schema object that matches a boolean data type (as well as the strings 'true' and 'false'). Can also be called via bool().
          */
         boolean<TSchema = boolean>(): BooleanSchema<TSchema>;
 


### PR DESCRIPTION

Currently the [comments describing boolean()](https://github.com/hapijs/joi/blob/3cb73d6cded39fa49a46069b64d638a0ba0f7d14/lib/index.d.ts#L2094) advise that 'true', false', 'yes', or 'no' will be automatically handled if not in strict() mode, however for some time the actual default behaviour has been only to convert 'true' and 'false' (since around [v10](https://github.com/hapijs/joi/commit/b14693f92fc1c3a761befbd19462c0c843194589) I think).

Just a very small PR to fix them up