### PR TITLE
Clarify documentation for empty()

### DIFF
--- a/API.md
+++ b/API.md
@@ -723,8 +723,8 @@ const schema = Joi.any().description('this key will match anything you give it')
 
 #### `any.empty(schema)`
 
-Considers anything that matches the schema to be empty (`undefined`).
-- `schema` - any object or **joi** schema to match. An undefined schema unsets that rule.
+Considers anything that matches the schema to be empty (`undefined`). Overrides any previous calls to empty.
+- `schema` - an object, value, or **joi** schema to match or an array of objects, values, and **joi** schemas to match. An undefined schema unsets that rule.
 
 ```js
 let schema = Joi.string().empty('');

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1057,8 +1057,8 @@ declare namespace Joi {
         disallow(...values: any[]): this;
 
         /**
-         * Considers anything that matches the schema to be empty (undefined).
-         * @param schema - any object or joi schema to match. An undefined schema unsets that rule.
+         * Considers anything that matches the schema to be empty (undefined). Overrides any previous calls to empty.
+         * @param schema - an object, value, or joi schema to match or an array of objects, values, and joi schemas to match. An undefined schema unsets that rule.
          */
         empty(schema?: SchemaLike): this;
 


### PR DESCRIPTION
Fixes #3053

This adds additional details to the documentation for `.empty()`.

Specifically, it:
- Notes that calls to `.empty()` override any prior calls.
- Clarifies that `schema` may also be a raw value or an array of matches.