### PR TITLE
feat: reject non-calendar ISO strings

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -834,6 +834,18 @@ internals.isoDate = function (value) {
         return null;
     }
 
+    const day = Number(value.split('T')[0].replace(/^-?/, '').split('-')[2]);
+
+    if (/T24:00$/.test(value)) {
+        const nextDate = new Date(value.replace(/T24:00/, '')).setDate(day + 1);
+        if (date.getTime() !== nextDate) {
+            return null;
+        }
+    }
+    else if (day !== date.getDate()) {
+        return null;
+    }
+
     return date.toISOString();
 };
 

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -5399,7 +5399,7 @@ describe('string', () => {
         });
     });
 
-    describe('isoData()', () => {
+    describe('isoDate()', () => {
 
         it('validates isoDate', () => {
 
@@ -5574,6 +5574,24 @@ describe('string', () => {
                     path: [],
                     type: 'string.isoDate',
                     context: { value: '2013-1841', label: 'value' }
+                }],
+                ['2013-04-31', false, {
+                    message: '"value" must be in iso format',
+                    path: [],
+                    type: 'string.isoDate',
+                    context: { value: '2013-04-31', label: 'value' }
+                }],
+                ['2013-04-31T24:00', false, {
+                    message: '"value" must be in iso format',
+                    path: [],
+                    type: 'string.isoDate',
+                    context: { value: '2013-04-31T24:00', label: 'value' }
+                }],
+                ['2025-02-29T12:21', false, {
+                    message: '"value" must be in iso format',
+                    path: [],
+                    type: 'string.isoDate',
+                    context: { value: '2025-02-29T12:21', label: 'value' }
                 }]
             ]);
         });


### PR DESCRIPTION
Fixes #2733

This adds a stricter validation to string().isoDate(), rejecting dates that do not exist in the calendar. 

It does so by:
- Validating that the day component of the ISO string matches the day derived from the corresponding JavaScript Date.
- Handling edge cases where the difference between days is caused by `T24:00` notation, in order to keep support for valid `T24:00` ISO strings.
- Preventing invalid dates such as April 31st from being accepted, even when combined with `T24:00`.