### PR TITLE
Added wrapper option to uuid function

### DIFF
--- a/API.md
+++ b/API.md
@@ -2803,7 +2803,7 @@ Requires the string value to be a valid GUID.
 
 -   `options` - optional settings:
     -   `version` - specifies one or more acceptable versions. Can be an Array or String with the following values:
-        `uuidv1`, `uuidv2`, `uuidv3`, `uuidv4`, `uuidv5`. If no `version` is specified then it is assumed to be a generic `guid`
+        `uuidv1`, `uuidv2`, `uuidv3`, `uuidv4`, `uuidv5`, `uuidv6`, `uuidv7` or `uuidv8`. If no `version` is specified then it is assumed to be a generic `guid`
         which will not validate the version or variant of the guid and just check for general structure format.
     -   `separator` - defines the allowed or required GUID separator where:
         -   `true` - a separator is required, can be either `:` or `-`.

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -318,21 +318,12 @@ module.exports = Any.extend({
 
                 Common.assertOptions(options, ['version', 'separator', 'wrapper']);
 
-                if (
-                    options.wrapper !== undefined &&
-                    options.wrapper !== true &&
-                    options.wrapper !== false
-                ) {
-                    const validWrappers = Object.keys(internals.guidBrackets).filter(
-                        (key) => !!key
-                    );
-                    assert(
-                        validWrappers.includes(options.wrapper),
-                        `"wrapper" must be true, false, or one of ${validWrappers.join(
-                            ', '
-                        )}`
-                    );
-                }
+                assert(
+                    options.wrapper === undefined ||
+                    typeof options.wrapper === 'boolean' ||
+                    (typeof options.wrapper === 'string' && typeof internals.guidBrackets[options.wrapper] === 'string'),
+                    `"wrapper" must be true, false, or one of "${Object.keys(internals.guidBrackets).filter(Boolean).join('", "')}"`
+                );
 
                 let versionNumbers = '';
 
@@ -359,8 +350,8 @@ module.exports = Any.extend({
                     options.separator === true ? '[:-]' :
                         options.separator === false ? '[]?' : `\\${options.separator}`;
 
-                let wrapperStart = '';
-                let wrapperEnd = '';
+                let wrapperStart;
+                let wrapperEnd;
 
                 if (options.wrapper === undefined) {
                     wrapperStart = '[\\[{\\(]?';
@@ -402,7 +393,7 @@ module.exports = Any.extend({
                 const open = results[1];
                 const close = results[results.length - 1];
 
-                if (internals.guidBrackets[open || ''] !== (close || '')) {
+                if ((open || close) && internals.guidBrackets[open] !== close) {
                     return helpers.error('string.guid');
                 }
 

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -3248,6 +3248,19 @@ describe('string', () => {
 
         });
 
+        it('errors on invalid wrapper', () => {
+
+            expect(() => {
+
+                Joi.string().guid({ wrapper: 1 });
+            }).to.throw('"wrapper" must be true, false, or one of "{", "[", "("');
+
+            expect(() => {
+
+                Joi.string().guid({ wrapper: '|' });
+            }).to.throw('"wrapper" must be true, false, or one of "{", "[", "("');
+        });
+
         it('validates combination of guid and min', () => {
 
             const rule = Joi.string().guid().min(36);


### PR DESCRIPTION
Adds wrapper options to `.uuid()` function to enable stricter validation rules when validating uuid's.

```
joi.uuid()                  // retains current functionality

joi.uuid({wrapper: true})   // uuid MUST be wrapped by any of the allowed brackets
joi.uuid({wrapper: false})  // uuid MUST NOT be wrapped in any of the allowed brackets
joi.uuid({wrapper: '{'})    // uuid MUST be wrapped by { }
joi.uuid({wrapper: '['})    // uuid MUST be wrapped by [ ]
joi.uuid({wrapper: '('})    // uuid MUST be wrapped by ( )
```

closes #3081
