### PR TITLE
feat: enhance validation to support options in standard function

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1102,9 +1102,9 @@ internals.Base = class {
         return {
             version: 1,
             vendor: 'joi',
-            validate: (value) => {
+            validate: (value, options) => {
 
-                const result = Validator.standard(value, this);
+                const result = Validator.standard(value, this, options);
 
                 if (result instanceof Promise) {
                     return result

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -186,14 +186,15 @@ exports.entryAsync = async function (value, schema, prefs) {
 };
 
 
-exports.standard = function (value, schema) {
+exports.standard = function (value, schema, options) {
 
+    const prefs = options?.libraryOptions;
 
     if (schema.isAsync()) {
-        return exports.entryAsync(value, schema);
+        return exports.entryAsync(value, schema, prefs);
     }
 
-    return exports.entry(value, schema);
+    return exports.entry(value, schema, prefs);
 };
 
 

--- a/test/base.js
+++ b/test/base.js
@@ -4070,6 +4070,19 @@ describe('any', () => {
                     issues: [{ message: '"foo" requires a positive number' }]
                 });
             });
+
+            it('applies libraryOptions when passed to validate()', () => {
+
+                const schema = Joi.object({
+                    foo: Joi.number().min(0).error((errors) => new Error('"foo" requires a positive number'))
+                });
+                expect(schema['~standard'].validate({ foo: 1, bar: 'baz' })).to.equal({
+                    issues: [{ message: '"bar" is not allowed', path: ['bar'] }]
+                });
+                expect(schema['~standard'].validate({ foo: 1, bar: 'baz' }, { libraryOptions: { allowUnknown: true } })).to.equal({
+                    value: { foo: 1, bar: 'baz' }
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Closes #3098

## Summary
Allow passing `options` (e.g. `libraryOptions`) into the standard validator's `validate()` function so that callers can control behavior like `allowUnknown` when using `schema['~standard'].validate(value, options)`.

## Changes
- **lib/base.js**: `~standard.validate` now accepts a second argument `options` and forwards it to `Validator.standard`.
- **lib/validator.js**: `Validator.standard` accepts an optional third argument `options`, uses `options?.libraryOptions` as preferences, and passes them to `entry` / `entryAsync`.
- **test/base.js**: Added test ensuring `libraryOptions: { allowUnknown: true }` is applied (unknown keys no longer produce issues when provided).