### PR TITLE
Fix braces escaping when template doesn't contains any variable

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -75,7 +75,7 @@ module.exports = exports = internals.Template = class {
         const processed = [];
         const head = parts.shift();
         if (head) {
-            processed.push(head);
+            processed.push(internals.decode(head));
         }
 
         for (const part of parts) {

--- a/test/template.js
+++ b/test/template.js
@@ -85,6 +85,15 @@ describe('Template', () => {
         expect(template.render({}, {}, { context: { x: 'hello', y: '!' } }, {}, { errors: { escapeHtml: false } })).to.equal('text hello! {{escaped}} xxx abc {{{ignore}} 123 {{x');
     });
 
+    it('parses template with only escaped braces', () => {
+
+        const source = 'text with only \\{escaped\\} braces should be as is';
+        const template = Joi.x(source);
+
+        expect(template.source).to.equal(source);
+        expect(template.render()).to.equal('text with only {escaped} braces should be as is');
+    });
+
     it('parses template with missing elements in binary operation', () => {
 
         const source = 'text {$x || $y}';


### PR DESCRIPTION
# The issue :
When using a message with only escaped braces, it will be returned with special encoded characters

# Example :
Having a message defined as follow
`{ 'my.message': 'I want to display \\{this_escaped_text\\} to my user' }`

Then the final printed message will look like :
`I want to display \u0000this_escaped_text\u0001 to my user`
Or in console decoding unicodes like this without braces :
`I want to display this_escaped_text to my user`

What I finally expect is :
`I want to display {this_escaped_text} to my user`

# Identified root cause
Since there is only escaped braces, the `template.split` function will return the whole text in the unique `head` part
However, this part is pushed in the `processed` array without decoding it and then is returned without more process

# My proposal
- Like all other pushed values in the `processed` array, push the decoded `head` instead of the encoded one
- Add a unit test that represent the issue and is failing with the old code, passing witht the new one