### PR TITLE
fix: include warnings in rejected async validation error

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -59,6 +59,10 @@ exports.entryAsync = async function (value, schema, prefs) {
             result.error.debug = mainstay.debug;
         }
 
+        if (mainstay.warnings.length) {
+            result.error.warning = Errors.details(mainstay.warnings);
+        }
+
         throw result.error;
     }
 

--- a/test/validator.js
+++ b/test/validator.js
@@ -687,6 +687,30 @@ describe('Validator', () => {
             });
         });
 
+        it('should include warnings in rejected error for async validation', async () => {
+
+            const schema = Joi.object({
+                a: Joi.number().max(10).warning('number.max', { limit: 10 }),
+                b: Joi.number().max(1)
+            });
+
+            const error = await expect(schema.validateAsync({ a: 5, b: 10 }, { warnings: true })).to.reject('"b" must be less than or equal to 1');
+            expect(error.warning).to.equal({
+                message: '"a" must be less than or equal to 10',
+                details: [{
+                    context: {
+                        key: 'a',
+                        label: 'a',
+                        limit: 10,
+                        value: 5
+                    },
+                    message: '"a" must be less than or equal to 10',
+                    path: ['a'],
+                    type: 'number.max'
+                }]
+            });
+        });
+
         it('should add errors when error helper is used on a link', async () => {
 
             const schema = Joi.object({


### PR DESCRIPTION
Fixes #3100

When async validation fails with `validateAsync(value, { warnings: true })`, the rejected error now includes the `warning` property, matching the behavior of synchronous validation.

Previously, warnings were only returned when validation succeeded. Now they are included in the rejected error object as well.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*