### PR TITLE
fix: allow NaN in schema describe() output validation

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -210,7 +210,7 @@ internals.desc.values = Joi.array()
         null,
         Joi.boolean(),
         Joi.function(),
-        Joi.number().allow(Infinity, -Infinity),
+        Joi.number().allow(Infinity, -Infinity, NaN),
         Joi.string().allow(''),
         Joi.symbol(),
         internals.desc.buffer,

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -254,6 +254,15 @@ describe('Manifest', () => {
             expect(Joi.invalid(1).allow(1).describe()).to.equal({ type: 'any', allow: [1] });
         });
 
+        it('handles NaN in allow list', () => {
+
+            const schema = Joi.number().allow(NaN);
+            const desc = schema.describe();
+            expect(desc.type).to.equal('number');
+            expect(desc.allow).to.have.length(1);
+            expect(Number.isNaN(desc.allow[0])).to.equal(true);
+        });
+
         it('describes ruleset changes', () => {
 
             const schema = Joi.string().min(1).keep();


### PR DESCRIPTION
Calling `.describe()` on a schema that includes `.allow(NaN)` throws a ValidationError.

```js
const schema = Joi.number().allow(null, NaN);
schema.describe(); // throws
```

The issue is in `internals.desc.values` in `lib/schemas.js` — `Infinity` and `-Infinity` are listed as allowed number values, but `NaN` is not, so the describe output fails its own internal validation.

Adding `NaN` to the list fixes it. All existing tests still pass.

Fixes #3094