### PR TITLE
fix(types): improve Root shorthand method return types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2503,7 +2503,7 @@ declare namespace Joi {
     /**
      * Creates a custom validation schema.
      */
-    custom(fn: CustomValidator, description?: string): Schema;
+    custom(fn: CustomValidator, description?: string): AnySchema;
 
     /**
      * Creates a new Joi instance that will apply defaults onto newly created schemas
@@ -2590,50 +2590,60 @@ declare namespace Joi {
     /**
      * Whitelists a value
      */
-    allow(...values: any[]): Schema;
+    allow(...values: any[]): AnySchema;
 
     /**
      * Adds the provided values into the allowed whitelist and marks them as the only valid values allowed.
      */
-    valid(...values: any[]): Schema;
-    equal(...values: any[]): Schema;
+    valid(...values: any[]): AnySchema;
+    equal(...values: any[]): AnySchema;
 
     /**
      * Blacklists a value
      */
-    invalid(...values: any[]): Schema;
-    disallow(...values: any[]): Schema;
-    not(...values: any[]): Schema;
+    invalid(...values: any[]): AnySchema;
+    disallow(...values: any[]): AnySchema;
+    not(...values: any[]): AnySchema;
 
     /**
      * Marks a key as required which will not allow undefined as value. All keys are optional by default.
      */
-    required(): Schema;
+    required(): AnySchema;
 
     /**
      * Alias of `required`.
      */
-    exist(): Schema;
+    exist(): AnySchema;
 
     /**
      * Marks a key as optional which will allow undefined as values. Used to annotate the schema for readability as all keys are optional by default.
      */
-    optional(): Schema;
+    optional(): AnySchema;
 
     /**
      * Marks a key as forbidden which will not allow any value except undefined. Used to explicitly forbid keys.
      */
-    forbidden(): Schema;
+    forbidden(): AnySchema;
 
     /**
      * Overrides the global validate() options for the current key and any sub-key.
      */
-    preferences(options: ValidationOptions): Schema;
+    preferences(options: ValidationOptions): AnySchema;
 
     /**
      * Overrides the global validate() options for the current key and any sub-key.
      */
-    prefs(options: ValidationOptions): Schema;
+    prefs(options: ValidationOptions): AnySchema;
+
+    /**
+     * Requires the validated value to match of the provided `any.allow()` values.
+     */
+    only(): AnySchema;
+
+    /**
+     * Marks a key to be removed from a resulting object or array after validation. Used to sanitize output.
+     */
+    strip(enabled?: boolean): AnySchema;
 
     /**
      * Converts the type into an alternatives type where the conditions are merged into the type definition where:

--- a/test/index.ts
+++ b/test/index.ts
@@ -1300,6 +1300,24 @@ schema = Joi.forbidden();
 
 schema = Joi.preferences(validOpts);
 
+// Root shorthand methods return AnySchema, enabling method chaining
+
+anySchema = Joi.allow(x).required();
+anySchema = Joi.valid(x).optional();
+anySchema = Joi.equal(x).strip();
+anySchema = Joi.invalid(x).required();
+anySchema = Joi.disallow(x).forbidden();
+anySchema = Joi.not(x).optional();
+anySchema = Joi.required().allow(x);
+anySchema = Joi.exist().valid(x);
+anySchema = Joi.optional().invalid(x);
+anySchema = Joi.forbidden().allow(x);
+anySchema = Joi.preferences(validOpts).required();
+anySchema = Joi.prefs(validOpts).required();
+anySchema = Joi.only().valid(x);
+anySchema = Joi.strip().allow(x);
+anySchema = Joi.custom((value) => value).required();
+
 schema = Joi.when(str, whenOpts);
 schema = Joi.when(ref, whenOpts);
 schema = Joi.when(schema, whenSchemaOpts);


### PR DESCRIPTION
The Root-level shorthand methods (`Joi.allow()`, `Joi.valid()`, `Joi.required()`, etc.) currently declare `Schema` as their return type. Since these methods delegate to `this.any()[method]()` at runtime ([source](https://github.com/hapijs/joi/blob/master/lib/index.js#L63-L67)), they always return an `AnySchema`. Using the broader `Schema` union type loses this specificity and breaks method chaining in TypeScript — e.g. `Joi.allow('x').required()` doesn't resolve to `AnySchema`.

### Changes

- Updated return types for all Root shorthand methods (`allow`, `valid`, `equal`, `invalid`, `disallow`, `not`, `required`, `exist`, `optional`, `forbidden`, `preferences`, `prefs`, `custom`) from `Schema` to `AnySchema`
- Added missing `only()` and `strip()` declarations to the Root interface — these are registered at runtime but were absent from the type definitions
- Added type tests verifying method chaining works correctly with the new return types

### Before

```typescript
const s = Joi.allow('x');  // Schema (union type — no .required() etc.)
const s2 = Joi.required(); // Schema
```

### After

```typescript
const s = Joi.allow('x');            // AnySchema — supports chaining
const s2 = Joi.allow('x').required(); // AnySchema ✓
const s3 = Joi.only().valid('a');     // AnySchema ✓
const s4 = Joi.strip();              // AnySchema ✓
```

All tests pass: `npm test` (1796 tests, 100% coverage, types, lint).