### PR TITLE
fix: handle objects with broken toJSON in error annotation

### DIFF
--- a/lib/annotate.js
+++ b/lib/annotate.js
@@ -90,7 +90,12 @@ exports.error = function (stripColorCodes) {
 
 internals.safeStringify = function (obj, spaces) {
 
-    return JSON.stringify(obj, internals.serializer(), spaces);
+    try {
+        return JSON.stringify(obj, internals.serializer(), spaces);
+    }
+    catch {
+        return '[object could not be serialized]';
+    }
 };
 
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -1022,6 +1022,27 @@ describe('errors', () => {
             expect(() => err.annotate(true)).to.not.throw();
         });
 
+        it('handles objects with toJSON that throws', () => {
+
+            const schema = Joi.object({
+                type: Joi.string().required()
+            }).unknown(false);
+
+            const badObj = {};
+            Object.defineProperty(badObj, 'toJSON', {
+                value: function () {
+
+                    throw new TypeError('Receiver must be an instance');
+                },
+                enumerable: false
+            });
+
+            const err = schema.validate({ someUrl: badObj }).error;
+            expect(err).to.be.an.error();
+            expect(() => err.annotate()).to.not.throw();
+            expect(err.annotate(true)).to.contain('"type" is required');
+        });
+
         it('annotates joi schema error', () => {
 
             const schema = Joi.object({


### PR DESCRIPTION
When validating objects containing values with a `toJSON` method that throws (e.g. cloned `URL` instances on Node.js 20–22), `Joi.assert()` crashes with a `TypeError` instead of reporting the validation error.

### Root cause

`internals.safeStringify` in `annotate.js` uses `JSON.stringify` with a custom replacer to handle circular references and special values. However, `JSON.stringify` calls `toJSON()` on values *before* the replacer can intervene. When `@hapi/hoek`'s `clone()` produces a plain object that inherits a `toJSON` method requiring a specific receiver (like `URL.prototype.toJSON`), the call throws because `this` is no longer the correct instance.

### Reproduction

```js
const Joi = require('joi');

const schema = Joi.object({
    type: Joi.string().required(),
}).unknown(false);

Joi.assert(
    [{ someUrl: new URL('https://some-url.com') }],
    Joi.array().items(schema)
);
// Node.js 20-22: TypeError: Receiver must be an instance of class URL
// Expected: ValidationError with "[0].type" is required
```

### Fix

Wrap `JSON.stringify` in `safeStringify` with a try-catch, falling back to a placeholder string. The validation error details are still reported in the error message.

### Changes

- `lib/annotate.js`: Added try-catch in `safeStringify` to handle broken `toJSON` methods
- `test/errors.js`: Added test for objects with `toJSON` that throws

All tests pass: 1797 tests, 100% coverage, lint clean, types clean.

Closes #3070