### PR TITLE
fix: improve JSON Schema conversion for number.port() and number.sign()

### DIFF
--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -269,6 +269,13 @@ module.exports = Any.extend({
                 }
 
                 return helpers.error('number.port');
+            },
+            jsonSchema(rule, res) {
+
+                res.type = 'integer';
+                res.minimum = 0;
+                res.maximum = 65535;
+                return res;
             }
         },
 
@@ -318,7 +325,13 @@ module.exports = Any.extend({
             },
             jsonSchema(rule, res) {
 
-                res['x-constraint'] = { ...res['x-constraint'], sign: rule.args.sign };
+                if (rule.args.sign === 'positive') {
+                    res.exclusiveMinimum = 0;
+                }
+                else {
+                    res.exclusiveMaximum = 0;
+                }
+
                 return res;
             }
         },

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -1070,39 +1070,38 @@ describe('jsonSchema', () => {
 
             Helper.validateJsonSchema(Joi.number().positive(), {
                 type: 'number',
-                'x-constraint': {
-                    sign: 'positive'
-                }
+                exclusiveMinimum: 0
             });
 
             Helper.validateJsonSchema(Joi.number().positive().only(), {
                 type: 'number',
-                'x-constraint': {
-                    sign: 'positive'
-                }
+                exclusiveMinimum: 0
             });
 
             Helper.validateJsonSchema(Joi.number().negative(), {
                 type: 'number',
-                'x-constraint': {
-                    sign: 'negative'
-                }
+                exclusiveMaximum: 0
             });
 
             Helper.validateJsonSchema(Joi.number().positive().multiple(3), {
                 type: 'number',
                 multipleOf: 3,
-                'x-constraint': {
-                    sign: 'positive'
-                }
+                exclusiveMinimum: 0
             });
 
             Helper.validateJsonSchema(Joi.number().multiple(3).positive(), {
                 type: 'number',
                 multipleOf: 3,
-                'x-constraint': {
-                    sign: 'positive'
-                }
+                exclusiveMinimum: 0
+            });
+        });
+
+        it('represents number.port() constraints', () => {
+
+            Helper.validateJsonSchema(Joi.number().port(), {
+                type: 'integer',
+                minimum: 0,
+                maximum: 65535
             });
         });
 


### PR DESCRIPTION
While using Joi schemas with the Standard Schema JSON Schema output for API documentation, I noticed two gaps in the `number` type's JSON Schema conversion:

### 1. `number.port()` — missing JSON Schema output

`Joi.number().port()` validates that a value is an integer between 0 and 65535, but it produced no JSON Schema constraints — just `{"type": "number"}`.

**Before:** `{"type": "number"}`
**After:** `{"type": "integer", "minimum": 0, "maximum": 65535}`

### 2. `number.sign()` — non-standard `x-constraint`

`Joi.number().positive()` / `.negative()` used a non-standard `x-constraint` property instead of the standard JSON Schema keywords.

**Before:** `{"type": "number", "x-constraint": {"sign": "positive"}}`
**After:** `{"type": "number", "exclusiveMinimum": 0}`

**Before:** `{"type": "number", "x-constraint": {"sign": "negative"}}`
**After:** `{"type": "number", "exclusiveMaximum": 0}`

`exclusiveMinimum` and `exclusiveMaximum` are standard JSON Schema Draft 2020-12 keywords that correctly express the same constraint.

### Changes

- `lib/types/number.js`: Added `jsonSchema` handler for `port` rule, updated `sign` rule to use standard keywords
- `test/json-schema.js`: Added test for `port()` conversion, updated sign test expectations

All tests pass: 1797 tests, 100% coverage, lint clean, types clean.