### PR TITLE
Use `this` for SchemaInternals types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -926,7 +926,7 @@ declare namespace Joi {
     /**
      * Adds a rule to current validation schema.
      */
-    $_addRule(rule: string | AddRuleOptions): Schema;
+    $_addRule(rule: string | AddRuleOptions): this;
 
     /**
      * Internally compiles schema.
@@ -962,7 +962,7 @@ declare namespace Joi {
      */
     $_match(value: any, state: State, prefs: ValidationOptions): boolean;
 
-    $_modify(options?: ModifyOptions): Schema;
+    $_modify(options?: ModifyOptions): this;
 
     /**
      * Resets current schema.
@@ -989,7 +989,7 @@ declare namespace Joi {
     /**
      * Set flag to given value.
      */
-    $_setFlag(flag: string, value: any, options?: SetFlagOptions): void;
+    $_setFlag(flag: string, value: any, options?: SetFlagOptions): this;
 
     /**
      * Runs internal validations against given value.


### PR DESCRIPTION
Using `this` instead of `Schema` for methods that clone the input parameter is more precise - for example, calling `$_addRule` on a NumberSchema returns a NumberSchema.

`$_setFlag` was typed as returning void, but it returns an object of the same type. See example code at https://joi.dev/api/18.x.x#extensions.

Note that, as a type in TypeScript, "`this` refers dynamically to the type of the current class", so it can refer to a clone of the method's class as well as the class's own instance.  See
https://www.typescriptlang.org/docs/handbook/2/classes.html#this-types