### PR TITLE
fix(date): treat "now" as dynamic default in default() method

### DIFF
--- a/lib/types/date.js
+++ b/lib/types/date.js
@@ -175,6 +175,19 @@ module.exports = Any.extend({
         }
     },
 
+    overrides: {
+        default(value, options) {
+
+            // Treat 'now' as a dynamic default resolved at validation time,
+            // consistent with min('now'), max('now'), etc.
+            if (value === 'now' && !options?.literal) {
+                return this.$_setFlag('default', () => new Date());
+            }
+
+            return this.$_parent('default', value, options);
+        }
+    },
+
     cast: {
         number: {
             from: internals.isDate,


### PR DESCRIPTION
## Summary

`Joi.date().default("now")` currently returns the literal string `"now"` instead of resolving it to the current date/time. This is inconsistent with the comparison APIs (`min("now")`, `max("now")`, `greater("now")`, `less("now")`) which all treat `"now"` as a dynamic reference to the current timestamp.

## Changes

Added an `overrides` section to the Date type that intercepts the `default()` method. When `value === "now"` (and the `literal` option is not set), it converts the default to a function that returns `new Date()`, matching the documented workaround:

```js
Joi.date().default(() => new Date());
```

## Examples

**Before (broken):**
```js
const schema = Joi.date().default("now");
schema.validate(undefined).value; // "now"
```

**After (fixed):**
```js
const schema = Joi.date().default("now");
schema.validate(undefined).value; // 2026-05-31T12:00:00.000Z (current date)
```

Closes #3112