### PR TITLE
fix: preserve 0x prefix when coercing hex string with byteAligned

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -97,7 +97,12 @@ module.exports = Any.extend({
                 hex.args.options.byteAligned &&
                 value.length % 2 !== 0) {
 
-                value = `0${value}`;
+                if (/^0x/i.test(value)) {
+                    value = value.slice(0, 2) + '0' + value.slice(2);
+                }
+                else {
+                    value = `0${value}`;
+                }
             }
 
             if (schema.$_getRule('isoDate')) {

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -4638,6 +4638,24 @@ describe('string', () => {
             ]);
         });
 
+        it('converts an hexadecimal string with byte align and prefix', () => {
+
+            const optionalRule = Joi.string().hex({ byteAligned: true, prefix: 'optional' });
+            Helper.validate(optionalRule, [
+                ['0xABCD', true, '0xABCD'],
+                ['0xABC', true, '0x0ABC'],
+                ['0XABC', true, '0X0ABC'],
+                ['0xABCDE', true, '0x0ABCDE']
+            ]);
+
+            const requiredRule = Joi.string().hex({ byteAligned: true, prefix: true });
+            Helper.validate(requiredRule, [
+                ['0xABCD', true, '0xABCD'],
+                ['0xABC', true, '0x0ABC'],
+                ['0XABC', true, '0X0ABC']
+            ]);
+        });
+
         it('validates an hexadecimal string with prefix explicitly required', () => {
 
             const rule = Joi.string().hex({ prefix: true }).strict();


### PR DESCRIPTION
## Bug

`string.hex({ byteAligned: true })` combined with `prefix: 'optional'` or `prefix: true` incorrectly coerces odd-length hex strings. The coerce phase prepends `'0'` before the entire value — including the `0x`/`0X` prefix — producing an invalid hex string that then fails the `string.hex` regex check:

```js
Joi.string().hex({ byteAligned: true, prefix: 'optional' }).validate('0xABC');
// Before fix → { value: '00xABC', error: '"value" must only contain hexadecimal characters' }
// Expected   → { value: '0x0ABC' }
```

## Fix

When the value starts with a `0x`/`0X` prefix, insert the padding zero *after* the two-character prefix instead of before the whole string. Values without a prefix are unaffected.

**Files changed:** `lib/types/string.js` (1 line → 5 lines), `test/types/string.js` (18 lines added)

## Verification

```
npx lab test/types/string.js --reporter console
# 272 tests complete (271 existing + 1 new)
```

> AI-assisted contribution.