### PR TITLE
fix: allow a single rename to a target named after an Object.prototype member

### DIFF
--- a/lib/types/keys.js
+++ b/lib/types/keys.js
@@ -919,7 +919,7 @@ internals.isPresent = function (options) {
 
 internals.rename = function (schema, value, state, prefs, errors) {
 
-    const renamed = {};
+    const renamed = Object.create(null);
     for (const rename of schema.$_terms.renames) {
         const matches = [];
         const pattern = typeof rename.from !== 'string';

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -2790,6 +2790,12 @@ describe('object', () => {
             expect(Joi.compile(schema).validate({ test1: 'a', test2: 'b' }).error).to.not.exist();
         });
 
+        it('allows a single rename to a target named after an Object prototype member', () => {
+
+            const schema = Joi.object().rename('a', 'toString');
+            Helper.validate(schema, [[{ a: 1 }, true, { toString: 1 }]]);
+        });
+
         it('errors renaming multiple times with multiple disabled', () => {
 
             const schema = Joi.object({


### PR DESCRIPTION
`internals.rename` (lib/types/keys.js) tracks used rename targets in a plain `{}`, so the guard `renamed[to]` inherits from `Object.prototype`. When the target name collides with a prototype member (`toString`, `constructor`, `__proto__`, `hasOwnProperty`, `valueOf`, ...), `renamed['toString']` is already truthy on the **first** rename, so even a single legitimate rename to such a name falsely raises `object.rename.multiple`.

This is self-inconsistent:

```js
Joi.object().rename('a', 'toString', { multiple: true }).validate({ a: 1 });  // ok
Joi.object().rename('a', 'b').validate({ a: 1 });                             // ok
Joi.object().rename('a', 'toString').validate({ a: 1 });                      // throws object.rename.multiple
```

`multiple` defaults to `false`, so a single rename must succeed regardless of the target's name. The failure depends only on a name collision with a built-in prototype member.

### Fix

Build the tracking map with `Object.create(null)` so membership reflects only actual renames, not inherited prototype keys.

### Tests

Added a test for a single rename to a prototype-named target. It fails before the fix (`object.rename.multiple`) and passes after. Full suite is green with no leaks. Genuine duplicate-rename detection (two renames to the same target, including `toString`) and override detection are unchanged.