### PR TITLE
fix: number.multiple() with decimal ref base wrongly rejects valid values

### DIFF
--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -218,6 +218,14 @@ module.exports = Any.extend({
             },
             validate(value, helpers, { base, baseDecimalPlace, pfactor }, options) {
 
+                // baseDecimalPlace/pfactor are only precomputed when base is a literal number. When base is
+                // a reference, it is resolved to its actual value here, so the decimal place count and factor
+                // must be derived from that resolved value instead of the stale (null) build-time placeholder.
+                if (baseDecimalPlace === null) {
+                    baseDecimalPlace = internals.decimalPlaces(base);
+                    pfactor = Math.pow(10, baseDecimalPlace);
+                }
+
                 const valueDecimalPlace = internals.decimalPlaces(value);
 
                 if (valueDecimalPlace > baseDecimalPlace) {

--- a/test/types/number.js
+++ b/test/types/number.js
@@ -856,6 +856,29 @@ describe('number', () => {
             ]);
         });
 
+        it('handles decimal references correctly', () => {
+
+            const ref = Joi.ref('a');
+            const schema = Joi.object({ a: Joi.number(), b: Joi.number().multiple(ref) });
+            Helper.validate(schema, [
+                [{ a: 0.1, b: 0.3 }, true],
+                [{ a: 0.5, b: 1.5 }, true],
+                [{ a: 3.5, b: 10.5 }, true],
+                [{ a: 0.1, b: 0.35 }, false, {
+                    message: '"b" must be a multiple of ref:a',
+                    path: ['b'],
+                    type: 'number.multiple',
+                    context: { multiple: ref, value: 0.35, label: 'b', key: 'b' }
+                }],
+                [{ a: 3.5, b: 10.499 }, false, {
+                    message: '"b" must be a multiple of ref:a',
+                    path: ['b'],
+                    type: 'number.multiple',
+                    context: { multiple: ref, value: 10.499, label: 'b', key: 'b' }
+                }]
+            ]);
+        });
+
         it('handles references correctly within a when', () => {
 
             const schema = Joi.object({


### PR DESCRIPTION
When the base of `.multiple()` is a ref instead of a literal, `baseDecimalPlace` is precomputed as `null` at schema-build time (only literal numbers get their decimal places counted upfront). At validate time that `null` gets compared against the value's decimal place count with `>`, and JS happily coerces `null` to `0` there, so any value with a fractional part gets rejected outright whenever the resolved ref turns out to be a decimal — even for legit multiples like base 0.5 / value 1.5.

You can see the asymmetry pretty clearly: `Joi.number().multiple(0.5).validate(1.5)` passes, but `Joi.number().multiple(Joi.ref('base')).validate({base: 0.5, value: 1.5})` (wrapped in an object schema) fails with "must be a multiple of ref:base". Fix just recomputes decimal place/factor from the resolved value when the build-time one is null. Added a test alongside the existing ref-based multiple tests, which previously only covered integer bases.
