### PR TITLE
fix: ignore internal references when ordering object keys

### DIFF
--- a/lib/types/keys.js
+++ b/lib/types/keys.js
@@ -602,7 +602,11 @@ module.exports = Any.extend({
         if (schema.$_terms.keys) {
             const topo = new Topo.Sorter();
             for (const child of schema.$_terms.keys) {
-                Common.tryWithPath(() => topo.add(child, { after: child.schema.$_rootReferences(), group: child.key }), child.key);
+                const keys = child.schema.$_terms.keys;
+                const after = child.schema.$_rootReferences()
+                    .filter((ref) => !keys || !keys.some((local) => local.key === ref));     // Ignore references resolved internally by the child (e.g. a nested reference to a duplicated sibling key name)
+
+                Common.tryWithPath(() => topo.add(child, { after, group: child.key }), child.key);
             }
 
             schema.$_terms.keys = new internals.Keys(...topo.nodes);

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1638,6 +1638,28 @@ describe('object', () => {
                 [{ type: 'a', set: true, flag: true }, false, '"flag" must be [false]']
             ]);
         });
+
+        it('builds keys referencing a duplicated sibling key name of a nested object', () => {
+
+            const schema = Joi.object({
+                id: Joi.number().required(),
+                command: Joi.object({
+                    command: Joi.string().valid('run', 'jump').required(),
+                    params: Joi.alternatives().conditional('command', {
+                        switch: [
+                            { is: 'run', then: Joi.object({ howFast: Joi.number().required() }) },
+                            { is: 'jump', then: Joi.object({ howHigh: Joi.number().required() }) }
+                        ]
+                    })
+                })
+            });
+
+            Helper.validate(schema, [
+                [{ id: 1, command: { command: 'run', params: { howFast: 1 } } }, true],
+                [{ id: 1, command: { command: 'jump', params: { howHigh: 2 } } }, true],
+                [{ id: 1, command: { command: 'run', params: {} } }, false, '"command.params.howFast" is required']
+            ]);
+        });
     });
 
     describe('length()', () => {


### PR DESCRIPTION
## Problem

When an object key holds a nested object whose value references a sibling key that shares a name with an ancestor key, the reference propagated up as a root reference of the outer key. This made that key depend on itself and threw `"Item cannot come after itself"` during key ordering.

For example, an outer `command` key containing a nested `command` key (referenced by a sibling `params` via `.conditional('command', ...)`) would fail to build.

## Fix

When computing the topological ordering of object keys, skip references that a child object resolves internally (i.e. references that match one of the child's own keys). Genuine cross-object circular dependencies are still surfaced.

## Testing

Added a test in `test/types/object.js` covering an object whose nested key references a duplicated sibling key name, verifying the schema builds and validates correctly (including the `conditional`/`switch` branches).

Closes #2877
