### PR TITLE
Improve object keys performance

### DIFF
--- a/lib/types/keys.js
+++ b/lib/types/keys.js
@@ -602,7 +602,23 @@ module.exports = Any.extend({
         if (schema.$_terms.keys) {
             const topo = new Topo.Sorter();
             for (const child of schema.$_terms.keys) {
-                Common.tryWithPath(() => topo.add(child, { after: child.schema.$_rootReferences(), group: child.key }), child.key);
+                Common.tryWithPath(() => topo.add(child, { after: child.schema.$_rootReferences(), group: child.key, manual: true }), child.key);
+            }
+
+            try {
+                topo.sort();
+            }
+            catch (err) {
+                // Sorting failed (e.g. circular references). Replay the adds one at a
+                // time, sorting after each, to identify the offending key in the error.
+                const detailed = new Topo.Sorter();
+                for (const child of schema.$_terms.keys) {
+                    Common.tryWithPath(() => detailed.add(child, { after: child.schema.$_rootReferences(), group: child.key }), child.key);
+                }
+
+                // The replay above always throws first - this is an unreachable safety net
+
+                throw err;      // $lab:coverage:ignore$
             }
 
             schema.$_terms.keys = new internals.Keys(...topo.nodes);

--- a/test/types/object.js
+++ b/test/types/object.js
@@ -1638,6 +1638,31 @@ describe('object', () => {
                 [{ type: 'a', set: true, flag: true }, false, '"flag" must be [false]']
             ]);
         });
+
+        it('errors on circular references between sibling keys', () => {
+
+            const err = expect(() => {
+
+                Joi.object({
+                    a: Joi.ref('b'),
+                    b: Joi.ref('a')
+                });
+            }).to.throw('item added into group b created a dependencies error');
+
+            expect(err.path).to.equal('b');
+        });
+
+        it('errors on circular references introduced by rebuild', () => {
+
+            const schema = Joi.object({
+                a: Joi.any(),
+                b: Joi.any()
+            })
+                .fork('a', (s) => s.default(Joi.ref('b')));
+
+            const err = expect(() => schema.fork('b', (s) => s.default(Joi.ref('a')))).to.throw('item added into group a created a dependencies error');
+            expect(err.path).to.equal('a');
+        });
     });
 
     describe('length()', () => {


### PR DESCRIPTION
I noticed that constructing Joi.object schemas of complex object types was causing significant slowdown in my Node.js application startup. Profiling revealed that a major source of slowdown was the topographical sorting within object keys' `rebuild`: `sort` was called for each added property, resulting in N * N topographical sorts.

To address this, this PR uses @hapi/topo's `manual` option to sort once, at the end. If that sort fails, it redoes the rebuild operation, sorting per key as the current behavior, so that `tryWithPath` can throw the more detailed error message.

The updated code constructs my application's schemas roughly 3.6x faster.

The preexisting test suite did not cover `rebuild` / @hapi/topo's error handling, so I added tests to cover the affected behavior.