### PR TITLE
fix: allow allowUnderscore on string().email()

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -313,7 +313,7 @@ module.exports = Any.extend({
         email: {
             method(options = {}) {
 
-                Common.assertOptions(options, ['allowFullyQualified', 'allowUnicode', 'ignoreLength', 'maxDomainSegments', 'minDomainSegments', 'multiple', 'separator', 'tlds']);
+                Common.assertOptions(options, ['allowFullyQualified', 'allowUnicode', 'allowUnderscore', 'ignoreLength', 'maxDomainSegments', 'minDomainSegments', 'multiple', 'separator', 'tlds']);
                 assert(options.multiple === undefined || typeof options.multiple === 'boolean', 'multiple option must be an boolean');
 
                 const address = internals.addressOptions(options);

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -1453,6 +1453,34 @@ describe('string', () => {
             expect(() => Joi.string().email({ multiple: false })).to.not.throw();
             expect(() => Joi.string().email({ multiple: {} })).to.throw('multiple option must be an boolean');
             expect(() => Joi.string().email({ multiple: 'abc' })).to.throw('multiple option must be an boolean');
+
+            expect(() => Joi.string().email({ allowUnderscore: true })).to.not.throw();
+            expect(() => Joi.string().email({ allowUnderscore: false })).to.not.throw();
+        });
+
+        it('validates email with underscores in domain', () => {
+
+            const validSchema = Joi.string().email({ allowUnderscore: true });
+            Helper.validate(validSchema, [
+                ['user@_acme-challenge.example.com', true],
+                ['user@_abc.example.com', true]
+            ]);
+
+            const invalidSchema = Joi.string().email();
+            Helper.validate(invalidSchema, [
+                ['user@_acme-challenge.example.com', false, {
+                    message: '"value" must be a valid email',
+                    path: [],
+                    type: 'string.email',
+                    context: { value: 'user@_acme-challenge.example.com', invalids: ['user@_acme-challenge.example.com'], label: 'value' }
+                }],
+                ['user@_abc.example.com', false, {
+                    message: '"value" must be a valid email',
+                    path: [],
+                    type: 'string.email',
+                    context: { value: 'user@_abc.example.com', invalids: ['user@_abc.example.com'], label: 'value' }
+                }]
+            ]);
         });
 
         it('validates email', () => {


### PR DESCRIPTION
## Summary
- `string().email()` documented and typed `allowUnderscore`, and `addressOptions` already forwards it to `@hapi/address`, but `assertOptions` rejected the key (unlike `string().domain()`).
- Accept `allowUnderscore` in the email options allowlist and add regression coverage for underscored domains.

Closes #2972

## Test plan
- [x] `npx lab test/types/string.js -g email`
- [ ] Confirm `Joi.string().email({ allowUnderscore: true })` no longer throws unknown key
- [ ] Confirm emails like `user@_abc.example.com` validate only when the option is set