### PR TITLE
Preserve warnings on async validation errors

### DIFF
--- a/API.md
+++ b/API.md
@@ -1181,7 +1181,7 @@ Validates a value asynchronously using the current schema and options where:
     - `artifacts` - when `true`, artifacts are returned alongside the value (i.e. `{ value, artifacts }`). Defaults to `false`.
     - `warnings` - when `true`, warnings are returned alongside the value (i.e. `{ value, warning }`). Defaults to `false`.
 
-Returns a Promise that resolves into the validated value when the value is valid. If the value is valid and the `warnings` or `debug` options are set to `true`, returns an object `{ value, warning, debug }`. If validation fails, the promise rejects with the validation error.
+Returns a Promise that resolves into the validated value when the value is valid. If the value is valid and the `warnings` or `debug` options are set to `true`, returns an object `{ value, warning, debug }`. If validation fails, the promise rejects with the validation error. When `warnings` is `true`, warnings generated before the failure are available as `error.warning`.
 
 ```js
 const schema = Joi.object({
@@ -3518,6 +3518,7 @@ Performs validation against the current schema without the extra overhead of mer
 **joi** throws or returns `ValidationError` objects containing :
 - `name` - `'ValidationError'`.
 - `isJoi` - `true`.
+- `warning` - when the `warnings` option is `true`, the warning object generated before an asynchronous validation failure, if any.
 - `details` - an array of errors :
     - `message` - string with a description of the error.
     - `path` - ordered array where each element is the accessor to the value where the error happened.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -718,6 +718,11 @@ declare namespace Joi {
     details: ValidationErrorItem[];
 
     /**
+     * warnings generated before an asynchronous validation failure.
+     */
+    warning?: ValidationWarning;
+
+    /**
      * function that returns a string with an annotated version of the object pointing at the places where errors occurred.
      *
      * NOTE: This method does not exist in browser builds of Joi

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -55,11 +55,7 @@ exports.entryAsync = async function (value, schema, prefs) {
     const result = internals.entry(value, schema, settings);
     const mainstay = result.mainstay;
     if (result.error) {
-        if (mainstay.debug) {
-            result.error.debug = mainstay.debug;
-        }
-
-        throw result.error;
+        throw internals.finalizeError(result, settings);
     }
 
     if (mainstay.externals.length) {
@@ -153,12 +149,7 @@ exports.entryAsync = async function (value, schema, prefs) {
 
         if (errors.length) {
             result.error = Errors.process(errors, value, settings);
-
-            if (mainstay.debug) {
-                result.error.debug = mainstay.debug;
-            }
-
-            throw result.error;
+            throw internals.finalizeError(result, settings);
         }
     }
 
@@ -183,6 +174,23 @@ exports.entryAsync = async function (value, schema, prefs) {
     }
 
     return outcome;
+};
+
+
+internals.finalizeError = function (result, settings) {
+
+    const { error, mainstay } = result;
+    if (settings.warnings &&
+        mainstay.warnings.length) {
+
+        error.warning = Errors.details(mainstay.warnings);
+    }
+
+    if (mainstay.debug) {
+        error.debug = mainstay.debug;
+    }
+
+    return error;
 };
 
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -181,6 +181,7 @@ stringRegexOpts = { invert: bool };
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 const validErr = new Joi.ValidationError('message', [], 'original');
+expect.type<Joi.ValidationWarning | undefined>(validErr.warning);
 let validErrItem: Joi.ValidationErrorItem;
 let validErrFunc: Joi.ValidationErrorFunction;
 

--- a/test/validator.js
+++ b/test/validator.js
@@ -893,6 +893,32 @@ describe('Validator', () => {
             });
         });
 
+        it('reports warnings with errors (async)', async () => {
+
+            const schema = Joi.object({
+                a: Joi.any().warning('custom.x', { w: 'world' }).message({ 'custom.x': 'hello {#w}!' }),
+                b: Joi.number().max(1)
+            });
+
+            const error = await expect(schema.validateAsync({ a: 'anything', b: 2 }, { warnings: true })).to.reject('"b" must be less than or equal to 1');
+            expect(error.warning).to.equal({
+                message: 'hello world!',
+                details: [
+                    {
+                        message: 'hello world!',
+                        path: ['a'],
+                        type: 'custom.x',
+                        context: {
+                            w: 'world',
+                            label: 'a',
+                            value: 'anything',
+                            key: 'a'
+                        }
+                    }
+                ]
+            });
+        });
+
         it('reports warnings with externals', async () => {
 
             const append = (value) => value + '!';
@@ -916,6 +942,32 @@ describe('Validator', () => {
                         }
                     ]
                 }
+            });
+        });
+
+        it('reports warnings with external errors', async () => {
+
+            const schema = Joi.number().external((value, { error, warn }) => {
+
+                warn('number.max', { limit: 1, value });
+                return error('number.min', { limit: 10, value });
+            });
+
+            const error = await expect(schema.validateAsync(5, { warnings: true })).to.reject('"value" must be greater than or equal to 10');
+            expect(error.warning).to.equal({
+                message: '"value" must be less than or equal to 1',
+                details: [
+                    {
+                        message: '"value" must be less than or equal to 1',
+                        path: [],
+                        type: 'number.max',
+                        context: {
+                            limit: 1,
+                            value: 5,
+                            label: 'value'
+                        }
+                    }
+                ]
             });
         });
 


### PR DESCRIPTION
Fixes #3100

## Summary
- attach warnings generated before rejected async validation to the `ValidationError` when warnings are enabled
- apply the same behavior to ordinary and external validation errors while preserving debug output
- document and type the optional `error.warning` result

## Testing
- `npm test` (1,820 tests, 48,077 assertions, 100% coverage, lint and types clean)