### PR TITLE
fix: allow Unicode domains in URI validation

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -809,17 +809,42 @@ module.exports = Any.extend({
                 }
 
                 let match = regex.exec(value);
+                let matched = match && (match[1] || match[2]);
+                const allowUnicodeDomain = domain && domain.allowUnicode !== false;
+
+                if (!match && allowUnicodeDomain) {
+
+                    const encoded = internals.encodeUriUnicode(value);
+                    if (encoded) {
+                        const unicodeMatch = regex.exec(encoded);
+                        const encodedDomain = unicodeMatch && (unicodeMatch[1] || unicodeMatch[2]);
+                        if (encodedDomain) {
+                            let unicodeDomain = encodedDomain;
+                            for (const [characters] of value.matchAll(/[^\x00-\x7f]+/g)) {
+                                unicodeDomain = unicodeDomain.replace(encodeURI(characters), characters);
+                            }
+
+                            if (value.replace(unicodeDomain, encodedDomain) === encoded) {
+                                match = unicodeMatch;
+                                matched = unicodeDomain;
+                            }
+                        }
+                    }
+                }
 
                 if (!match && helpers.prefs.convert && options.encodeUri) {
                     const encoded = encodeURI(value);
                     match = regex.exec(encoded);
                     if (match) {
                         value = encoded;
+                        matched = match[1] || match[2];
+                        if (allowUnicodeDomain && matched) {
+                            matched = decodeURI(matched);
+                        }
                     }
                 }
 
                 if (match) {
-                    const matched = match[1] || match[2];
                     if (domain &&
                         (!options.allowRelative || matched) &&
                         !isDomainValid(matched, domain)) {
@@ -899,6 +924,17 @@ module.exports = Any.extend({
 
 
 // Helpers
+
+internals.encodeUriUnicode = function (value) {
+
+    try {
+        return value.replace(/[^\x00-\x7f]+/g, encodeURI);
+    }
+    catch {
+        return null;
+    }
+};
+
 
 internals.addressOptions = function (options) {
 

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -8082,6 +8082,42 @@ describe('string', () => {
             ]);
         });
 
+        it('validates uri with Unicode domain', () => {
+
+            const schema = Joi.string().uri({ domain: { allowUnicode: true, tlds: false } });
+
+            Helper.validate(schema, [
+                ['https://ëxample.com', true],
+                ['https://ëxample.com/path', true],
+                ['https://ëxample.com/a%20b', true],
+                ['https://example.com/ë', false, '"value" must be a valid uri'],
+                ['urn:ë', false, '"value" must be a valid uri'],
+                ['https:///ë', false, '"value" must be a valid uri'],
+                ['https://\uD800.com', false, '"value" must be a valid uri']
+            ]);
+
+            Helper.validate(schema, { convert: false }, [
+                ['https://ëxample.com', true],
+                ['https://example.com/ë', false, '"value" must be a valid uri']
+            ]);
+
+            const asciiSchema = Joi.string().uri({ domain: { allowUnicode: false, tlds: false } });
+            Helper.validate(asciiSchema, [
+                ['https://ëxample.com', false, '"value" must be a valid uri']
+            ]);
+
+            const relativeSchema = Joi.string().uri({ allowRelative: true, domain: { allowUnicode: true, tlds: false } });
+            Helper.validate(relativeSchema, [
+                ['//ëxample.com/path', true]
+            ]);
+
+            const encodedSchema = Joi.string().uri({ domain: { allowUnicode: true, tlds: false }, encodeUri: true });
+            Helper.validate(encodedSchema, [
+                ['https://ëxample.com/ë', true, 'https://%C3%ABxample.com/%C3%AB'],
+                ['urn:ë', false, '"value" must contain a valid domain name']
+            ]);
+        });
+
         it('validates relative uri', () => {
 
             const schema = Joi.string().uri({ allowRelative: true });


### PR DESCRIPTION
Fixes #3068

The URI regex rejected non-ASCII hosts before the Unicode-aware domain validation ran. This adds a validation-only fallback that percent-encodes non-ASCII characters for structural matching only when all encoding changes are confined to the captured host. The original Unicode domain is then checked with the configured domain rules, and the input stays unchanged unless `encodeUri` conversion was requested.

Tests cover raw Unicode hosts, relative URIs, percent-encoded paths, `allowUnicode: false`, `convert: false`, existing `encodeUri` behavior, Unicode outside the host, and malformed surrogate input.

Validation:
- `npm test` on Node 25.8.2: 1,819 tests, 100% coverage, lint, types, and leak checks clean
- The same complete command via Node 20.20.2: same result

AI assistance: used for investigation, implementation, and test review; every submitted change and validation result was reviewed.