### PR TITLE
docs: fix two 404 links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Useful resources
 
-- [Documentation and API](https://joi.dev/api/18.x.x)
+- [Documentation and API](https://joi.dev/api/)
 - [Versions status](https://joi.dev/resources/status/#joi)
 - [Changelog](https://joi.dev/resources/changelog/)
 - [Project policies](https://joi.dev/policies/coc)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Useful resources
 
-- [Documentation and API](https://joi.dev/api/)
+- [Documentation and API](https://joi.dev/api/18.x.x)
 - [Versions status](https://joi.dev/resources/status/#joi)
 - [Changelog](https://joi.dev/resources/changelog/)
-- [Project policies](https://joi.dev/policies/)
+- [Project policies](https://joi.dev/policies/coc)


### PR DESCRIPTION
Two of the four "Useful resources" links in the README return 404:

| Link | Status | Replacement |
| --- | --- | --- |
| `https://joi.dev/api/` | 404 | [`https://joi.dev/api/18.x.x`](https://joi.dev/api/18.x.x) |
| `https://joi.dev/policies/` | 404 | [`https://joi.dev/policies/coc`](https://joi.dev/policies/coc) |

joi.dev serves no index page at either `/api/` or `/policies/`. The API reference lives under a version segment, and the policies section has no landing page — its first entry is the Code of Conduct, which is also where joi.dev's own homepage navigation points.

The other two resource links (`/resources/status/#joi` and `/resources/changelog/`) resolve fine and are untouched.

Separately, and outside the scope of this PR: joi.dev's own top navigation links to `/api`, which 404s for the same reason — worth fixing on the site side.