### PR TITLE
fix(validator): clear externals when failover fires

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -569,6 +569,11 @@ internals.finalize = function (value, errors, helpers) {
             state.mainstay.tracer.value(state, 'failover', value, failover);
             value = failover;
             errors = [];
+
+            // Externals registered against the original value's structure no longer apply
+            // once the value is replaced with a non-traversable fallback (e.g. null).
+
+            state.mainstay.externals.length = 0;
         }
     }
 

--- a/test/base.js
+++ b/test/base.js
@@ -1701,6 +1701,28 @@ describe('any', () => {
                 [{ x: [] }, true, { x: 2 }]
             ]);
         });
+
+        it('does not run external rules after failover replaces value with non-traversable fallback', async () => {
+
+            const schema = Joi.object({
+                someAsync: Joi.any().external(() => Promise.resolve(true)),
+                someNormal: Joi.any().required()
+            }).failover(() => null);
+
+            const value = await schema.validateAsync({ someAsync: 2 });
+            expect(value).to.equal(null);
+        });
+
+        it('runs external rules normally when no failover fires', async () => {
+
+            const schema = Joi.object({
+                someAsync: Joi.any().external(() => Promise.resolve(true))
+            });
+
+            const value = await schema.validateAsync({ someAsync: 2 });
+            expect(value).to.equal({ someAsync: true });
+        });
+
     });
 
     describe('forbidden()', () => {


### PR DESCRIPTION
Closes #3141

### Problem

When a schema's `.failover()` callback replaces the value with a non-traversable fallback (e.g. `null`), any `.external()` rules registered during the synchronous validation pass still try to resolve their original path against the new value.

Reproducer from the issue:

```js
const schema = Joi.object({
  someAsync: Joi.any().external(async () => true),
  someNormal: Joi.any().required()
}).failover(() => null);

await schema.validateAsync({ someAsync: 2 });
// throws: TypeError: Cannot read properties of null (reading 'someAsync')
```

The synchronous pass fails validation (`someNormal` is missing), the failover handler runs and substitutes `null`, and then `entryAsync` proceeds to run the registered external rule at path `['someAsync']`. Path traversal walks the new value (which is `null`) and crashes with a TypeError.

### Fix

In `internals.finalize`, once a failover value has been produced, clear `state.mainstay.externals`. The external rules were registered against the original value's structure; once the value has been replaced, that structure is no longer reachable and the external pass should be skipped.

This is a one-line behavioral change with no effect on schemas that do not combine `.failover()` with `.external()`, and it preserves normal external behavior when no failover fires.

### Tests

- `does not run external rules after failover replaces value with non-traversable fallback` covers the regression.
- `runs external rules normally when no failover fires` guards the happy path so external rules still execute when validation succeeds.

Full suite: 1825 tests, 100% coverage, no lint or type issues.