### PR TITLE
fix(isoDate): pad a bare-hour timeshift with a colon, not just zeros

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -977,8 +977,8 @@ internals.isoDate = function (value) {
         return null;
     }
 
-    if (/.*T.*[+-]\d\d$/.test(value)) {             // Add missing trailing zeros to timeshift
-        value += '00';
+    if (/T.*[+-]\d\d$/.test(value)) {                // Add missing separator and trailing zeros to timeshift
+        value += ':00';
     }
 
     const date = new Date(value);

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -5709,6 +5709,38 @@ describe('string', () => {
             const schema = Joi.string().isoDate().allow('x');
             Helper.validate(schema, [['x', true]]);
         });
+
+        it('pads a bare-hour timeshift with a colon, not just zeros', () => {
+
+            // A bare-hour offset like "+07" is padded to a full offset before being
+            // handed to Date(). Node's own parser tolerates "+0700" (basic format),
+            // but the ISO 8601 extended format used everywhere else in this string
+            // requires "+07:00" - mixing the two breaks stricter parsers (e.g. Safari).
+            // Node can't tell these apart itself, so this spies on what string
+            // actually reaches Date() rather than trusting Date() to reject it.
+
+            const NativeDate = global.Date;
+            const seen = [];
+
+            global.Date = class extends NativeDate {
+
+                constructor(...args) {
+
+                    seen.push(args[0]);
+                    super(...args);
+                }
+            };
+
+            try {
+                Joi.string().isoDate().validate('2013-06-07T14:21:46+07');
+            }
+            finally {
+                global.Date = NativeDate;
+            }
+
+            expect(seen).to.include('2013-06-07T14:21:46+07:00');
+            expect(seen).to.not.include('2013-06-07T14:21:46+0700');
+        });
     });
 
     describe('isoDuration()', () => {


### PR DESCRIPTION
Fixes #2434.

## What

\`internals.isoDate()\` (\`lib/types/string.js\`) pads a bare-hour UTC timeshift like \`+04\` before handing the string to \`Date()\`:

\`\`\`js
if (/.*T.*[+-]\d\d$/.test(value)) {             // Add missing trailing zeros to timeshift
    value += '00';
}
\`\`\`

That produces \`...+0400\` — ISO 8601 basic-format offset — glued onto an otherwise extended-format string (\`YYYY-MM-DDTHH:mm:ss\`). ISO 8601 doesn't allow mixing the two; the correct extended-format offset is \`...+04:00\`.

This was flagged by @kanongil in review on #2421 (the PR that introduced the line): "You need to add the `:` as well to make it a proper extended iso date string. As it is, it breaks in Safari." The PR was merged before the fix landed, and #2434 was opened to track it but never addressed.

Also drops the leading `.*` in the trigger regex, per the same review thread (`.test()` doesn't need start-anchoring, so it was redundant).

## Fix

\`\`\`js
if (/T.*[+-]\d\d$/.test(value)) {                // Add missing separator and trailing zeros to timeshift
    value += ':00';
}
\`\`\`

## Testing

Node's own \`Date\` constructor parses \`+0700\` and \`+07:00\` identically, so a test asserting on Joi's converted output (\`.toISOString()\`) can't distinguish the bug from the fix — I confirmed this empirically before writing the test. Instead, the new test spies on the global \`Date\` constructor to assert the exact string Joi passes to it.

- Negative control: reverted just the source fix, kept the test — it fails, showing the un-colonized string (\`+0700\`) reaching \`Date()\`. Restored.
- Full suite: \`lab\` — 1824/1824 passing.
- \`eslint\` clean on both changed files.