### PR TITLE
fix: clone static error() overrides so mutations do not leak

### DIFF
--- a/API.md
+++ b/API.md
@@ -740,9 +740,9 @@ Overrides the default **joi** error with a custom error if the rule fails where:
   - an instance of `Error` - the override error.
   - a function with the signature `function(errors)`, where `errors` is an array of validation reports and it returns either a single `Error` or an array of validation reports.
 
-Do not use this method if you are simply trying to override the error message - use `any.message()` or `any.messages()` instead. This method is designed to override the **joi** validation error and return the exact override provided. It is useful when you want to return the result of validation directly (e.g. when using with a **hapi** server) and want to return a different HTTP error code than 400.
+Do not use this method if you are simply trying to override the error message - use `any.message()` or `any.messages()` instead. This method is designed to override the **joi** validation error and return that override. It is useful when you want to return the result of validation directly (e.g. when using with a **hapi** server) and want to return a different HTTP error code than 400.
 
-Note that if you provide an `Error`, it will be returned as-is, unmodified and undecorated with any of the normal error properties. If validation fails and another error is found before the error override, that error will be returned and the override will be ignored (unless the `abortEarly` option has been set to `false`). If you set multiple errors on a single schema, only the last error is used.
+Note that if you provide an `Error`, a clone of it is returned, unmodified and undecorated with any of the normal error properties. Cloning avoids leaking later mutations (for example a request-specific `data` field) into later validations. If validation fails and another error is found before the error override, that error will be returned and the override will be ignored (unless the `abortEarly` option has been set to `false`). If you set multiple errors on a single schema, only the last error is used.
 
 ```js
 const schema = Joi.string().error(new Error('Was REALLY expecting a string'));

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -588,7 +588,7 @@ internals.finalize = function (value, errors, helpers) {
             }
         }
         else {
-            errors = [schema._flags.error];
+            errors = [clone(schema._flags.error)];
         }
     }
 

--- a/test/base.js
+++ b/test/base.js
@@ -1359,6 +1359,26 @@ describe('any', () => {
             expect(err.details).to.not.exist();
         });
 
+        it('returns a clone of a static Error override', () => {
+
+            const override = new Error('shared');
+            override.data = { owner: 'original' };
+
+            const schema = Joi.any().invalid('x').error(override);
+            const first = schema.validate('x').error;
+            first.data.request = 'first';
+
+            const second = schema.validate('x').error;
+
+            expect(first).to.not.shallow.equal(override);
+            expect(second).to.not.shallow.equal(first);
+            expect(first).to.be.an.error('shared');
+            expect(second).to.be.an.error('shared');
+            expect(second.data.request).to.not.exist();
+            expect(override.data.request).to.not.exist();
+            expect(second.data.owner).to.equal('original');
+        });
+
         it('returns first custom error with multiple errors', () => {
 
             const schema = Joi.object({


### PR DESCRIPTION
Thanks for writing this up. A static Error passed to error() is currently returned by reference, so later mutations leak into the schema and into later validations.

This returns a clone of that override, using the same hoek clone already used elsewhere, so each failed validation gets its own Error. Custom enumerable fields are copied. Function overrides are unchanged.

Fixes #3140